### PR TITLE
Geopandas requires a dev version of Shapely

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -8,7 +8,12 @@ import pyproj
 from shapely.geometry import shape, Polygon, Point
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry.base import BaseGeometry
-from shapely.ops import cascaded_union, unary_union, transform
+from shapely.ops import cascaded_union, unary_union
+try:
+    from shapely.ops import transform
+except ImportError:
+    print("Geopandas currently requires a development version of Shapely: https://github.com/sgillies/shapely")
+    raise
 import fiona
 from fiona.crs import from_epsg
 


### PR DESCRIPTION
As per #16, the current release of Shapely (2.1.17) doesn't include the
ops.transform method, requiring GeoPandas users to install
a bleeding-edge version from Github.
