### PR TITLE
More robust to_file test

### DIFF
--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -17,6 +17,8 @@ class TestDataFrame(unittest.TestCase):
         self.df = GeoDataFrame.from_file(
             '/nybb_13a/nybb.shp', vfs='zip://examples/nybb_13a.zip')
         self.tempdir = tempfile.mkdtemp()
+        self.boros = np.array(['Staten Island', 'Queens', 'Brooklyn',
+                               'Manhattan', 'Bronx'])
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -24,15 +26,14 @@ class TestDataFrame(unittest.TestCase):
     def test_from_file_(self):
         self.assertTrue('geometry' in self.df)
         self.assertTrue(len(self.df) == 5)
-        self.assertTrue(np.alltrue(self.df['BoroName'].values == np.array(['Staten Island',
-                                   'Queens', 'Brooklyn', 'Manhattan', 'Bronx'])))
-    
+        self.assertTrue(np.alltrue(self.df['BoroName'].values == self.boros))
+
     def test_to_json(self):
         text = self.df.to_json()
         data = json.loads(text)
         self.assertTrue(data['type'] == 'FeatureCollection')
         self.assertTrue(len(data['features']) == 5)
-        
+
     def test_to_file(self):
         tempfilename = os.path.join(self.tempdir, 'boros.shp')
         self.df.to_file(tempfilename)
@@ -40,5 +41,4 @@ class TestDataFrame(unittest.TestCase):
         df = GeoDataFrame.from_file(tempfilename)
         self.assertTrue('geometry' in df)
         self.assertTrue(len(df) == 5)
-        self.assertTrue(np.alltrue(df['BoroName'].values == np.array(['Staten Island',
-                                   'Queens', 'Brooklyn', 'Manhattan', 'Bronx'])))
+        self.assertTrue(np.alltrue(df['BoroName'].values == self.boros))


### PR DESCRIPTION
tempfile.NamedTemporaryFile was failing for me, so reimplemented the to_file test in a temp directory.  Requires a tearDown function to clean up.
