### PR TITLE
DOC: Use default theme on Read the Docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -93,7 +93,10 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+if os.environ.get('READTHEDOCS', None) == 'True':
+    html_theme = 'default'
+else:
+    html_theme = 'nature'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Use the new default theme on [Read the Docs](https://readthedocs.org/), but `nature` theme for docs built elsewhere.
