### PR TITLE
ENH: Add geometry property to GeoDataFrame

### DIFF
--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -35,6 +35,43 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue(type(self.df2) is GeoDataFrame)
         self.assertTrue(self.df2.crs == self.crs)
 
+    def test_set_geometry(self):
+        geom = [Point(x,y) for x,y in zip(range(5), range(5))]
+        df2 = self.df.set_geometry(geom)
+        self.assert_(self.df is not df2)
+        for x, y in zip(df2.geometry.values, geom):
+            self.assertEqual(x, y)
+
+    def test_set_geometry_col(self):
+        g = self.df.geometry
+        g_simplified = g.simplify(100)
+        self.df['simplified_geometry'] = g_simplified
+        df2 = self.df.set_geometry('simplified_geometry')
+
+        # Drop is true by default
+        self.assert_('simplified_geometry' not in df2)
+
+        for x, y in zip(df2.geometry.values, g_simplified):
+            self.assertEqual(x, y)
+
+    def test_set_geometry_col_no_drop(self):
+        g = self.df.geometry
+        g_simplified = g.simplify(100)
+        self.df['simplified_geometry'] = g_simplified
+        df2 = self.df.set_geometry('simplified_geometry', drop=False)
+
+        self.assert_('simplified_geometry' in df2)
+
+        for x, y in zip(df2.geometry.values, g_simplified):
+            self.assertEqual(x, y)
+
+    def test_set_geometry_inplace(self):
+        geom = [Point(x,y) for x,y in zip(range(5), range(5))]
+        ret = self.df.set_geometry(geom, inplace=True)
+        self.assert_(ret is None)
+        for x, y in zip(self.df['geometry'].values, geom):
+            self.assertEqual(x, y)
+
     def test_to_json(self):
         text = self.df.to_json()
         data = json.loads(text)


### PR DESCRIPTION
Adds a geometry property and set_geometry() method to GeoDataFrame. This was
suggested in Issue #45. The implementation mimics that of DataFrame's
set_index in that it returns a copy of the GeoDataFrame by default with the
new geometry. You can specify a column or give a list/ndarray of geometries.

This addresses the discussion in Issue #45. The new `set_geometry()` method in `GeoDataFrame` more explicitly sets the geometry instead of just operating on the geometry column. The interface is modeled on `DataFrame.set_index()` including the `drop` and `inplace` options, as well the ability to use an existing column. (Most of its code comes from `set_index` as well). The geometry should be accessed using the `geometry` property instead of as a column.

Soon, we might also want to remove the geometry column altogether soon and just access it through the property and `set_geometry` method. I didn't want to go that far before getting feedback.

The Travis build on this fails on Pandas master due to the new implementation of head and tail. Pull request #46 takes care of that.
