### PR TITLE
Add omitna option to GeoDataFrame.to_json

### DIFF
--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -89,13 +89,13 @@ class TestDataFrame(unittest.TestCase):
             props = f['properties']
             self.assertEqual(len(props), 4)
             if props['BoroName'] == 'Queens':
-                self.assertTrue(np.isnan(props['Shape_Area']))
+                self.assertTrue(props['Shape_Area'] is None)
 
-    def test_to_json_omitna(self):
+    def test_to_json_dropna(self):
         self.df['Shape_Area'][self.df['BoroName']=='Queens'] = np.nan
         self.df['Shape_Leng'][self.df['BoroName']=='Bronx'] = np.nan
 
-        text = self.df.to_json(omitna=True)
+        text = self.df.to_json(na='drop')
         data = json.loads(text)
         self.assertEqual(len(data['features']), 5)
         for f in data['features']:
@@ -112,6 +112,25 @@ class TestDataFrame(unittest.TestCase):
                 self.assertTrue('Shape_Area' in props)
             else:
                 self.assertEqual(len(props), 4)
+
+    def test_to_json_keepna(self):
+        self.df['Shape_Area'][self.df['BoroName']=='Queens'] = np.nan
+        self.df['Shape_Leng'][self.df['BoroName']=='Bronx'] = np.nan
+
+        text = self.df.to_json(na='keep')
+        data = json.loads(text)
+        self.assertEqual(len(data['features']), 5)
+        for f in data['features']:
+            props = f['properties']
+            self.assertEqual(len(props), 4)
+            if props['BoroName'] == 'Queens':
+                self.assertTrue(np.isnan(props['Shape_Area']))
+                # Just make sure setting it to nan in a different row
+                # doesn't affect this one
+                self.assertTrue('Shape_Leng' in props)
+            elif props['BoroName'] == 'Bronx':
+                self.assertTrue(np.isnan(props['Shape_Leng']))
+                self.assertTrue('Shape_Area' in props)
 
     def test_copy(self):
         df2 = self.df.copy()


### PR DESCRIPTION
When omitna is true, any properties that are NaN will not be written out.
This means that different features can have different numbers of properties,
which is okay for GeoJSON. Writing out NaN values is not valid JSON and causes
problems for some parsers.

This introduces a new flag, `omitna`, to `GeoDataFrame.to_json()`. Each feature's properties are evaluated independently and null values are removed before serializing to JSON. I originally wanted to call this `dropna` but thought that could be confusing as `dropna` typically removes whole rows or columns, whereas `omitna` effectively removes single elements from the output.
