### PR TITLE
CLN: Use absolute imports in __init__ + add to namespace for interactive work

### DIFF
--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -2,8 +2,15 @@ try:
     from geopandas.version import version as __version__
 except ImportError:
     __version__ = '0.1.0.dev-unknown'
-from geoseries import GeoSeries
-from geodataframe import GeoDataFrame
+
+from geopandas.geoseries import GeoSeries
+from geopandas.geodataframe import GeoDataFrame
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis
+
+# make the interactive namespace easier to use
+# for `from geopandas import *` demos.
+import geopandas as gpd
+import pandas as pd
+import numpy as np


### PR DESCRIPTION
Minor fixup to use absolute imports (necessary for Python 3). Added pd,
np, and gpd to namespace because I've found having np (and now pd) makes
it much easier to quickly test something out, rather than always having
to type out the import.
