### PR TITLE
TST/CLN: Guard geopy import and add skip tests if no geopy.

### DIFF
--- a/geopandas/geocode.py
+++ b/geopandas/geocode.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 
 import fiona
-import geopy
-from geopy.geocoders.base import GeocoderResultError
 import numpy as np
 import pandas as pd
 from shapely.geometry import Point
@@ -40,6 +38,9 @@ def geocode(strings, provider='googlev3', **kwargs):
     1  1600 Pennsylvania Avenue Northwest, President'...  POINT (-77.0365122999999983 38.8978377999999978)
 
     """
+    import geopy
+    from geopy.geocoders.base import GeocoderResultError
+
     if not isinstance(strings, pd.Series):
         strings = pd.Series(strings)
 

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -4,10 +4,20 @@ import fiona
 import pandas as pd
 from shapely.geometry import Point
 import geopandas as gpd
+import nose
 
 from geopandas.geocode import geocode, _prepare_geocode_result
 
+def _skip_if_no_geopy():
+    try:
+        import geopy
+    except ImportError:
+        raise nose.SkipTest("Geopy not installed. Skipping")
+
 class TestGeocode(unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_geopy()
+
     def test_prepare_result(self):
         # Calls _prepare_result with sample results from the geocoder call
         # loop


### PR DESCRIPTION
Might make sense to add a test suite example with no geopy? Passes on my
test environment (which doesn't have geopy) and now you can import the
geocode module without a problem.
