### PR TITLE
PERF: Use faster version of list comprehension

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -101,8 +101,9 @@ class GeoSeries(Series):
             if self.crs != other.crs:
                 warn('GeoSeries crs mismatch: {0} and {1}'.format(self.crs, other.crs))
             this, other = self.align(other)
-            return GeoSeries([getattr(s[0], op)(s[1]) for s in zip(this, other)],
-                          index=this.index, crs=self.crs)
+            return GeoSeries([getattr(this_elem, op)(other_elem)
+                              for this_elem, other_elem in zip(this, other)],
+                             index=this.index, crs=self.crs)
         else:
             return GeoSeries([getattr(s, op)(other) for s in self],
                           index=self.index, crs=self.crs)
@@ -112,7 +113,8 @@ class GeoSeries(Series):
         """Geometric operation that returns a pandas Series"""
         if isinstance(other, GeoSeries):
             this, other = self.align(other)
-            return Series([getattr(s[0], op)(s[1], **kwargs) for s in zip(this, other)],
+            return Series([getattr(this_elem, op)(other_elem, **kwargs) for
+                           this_elem, other_elem in zip(this, other)],
                           index=this.index)
         else:
             return Series([getattr(s, op)(other, **kwargs) for s in self],


### PR DESCRIPTION
Using index lookups is ~20% slower (and less pythonic) than unpacking with
comprehension (there's a bit of variability). Plus it makes it more
readable too.

Snippet:

``` python
In [1]: def index_unpack(): return [(s[0], s[1]) for s in lst]

In [2]: def pythonic_unpack(): return [(a, b) for a, b in lst]

In [3]: lst = zip(range(100000), range(100000))

In [10]: %timeit -n 100 index_unpack()
100 loops, best of 3: 26.2 ms per loop

In [12]: %timeit -n 100 pythonic_unpack()
100 loops, best of 3: 22 ms per loop
```
