### PR TITLE
ENH: Allow setting geometry property via XY coords (two columns)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 doc/_build
 geopandas.egg-info
 geopandas/version.py
+*.py~


### PR DESCRIPTION
This PR allows the user to specify two columns (X and Y) to the `set_geometry` method. This will allow a DataFrame with Lat, Lon, fields to be easily converted to a GeoDataFrame.

``` python
df = GeoDataFrame({"A": [1,2,3,4,5,6],
                               "B": [6,5,4,3,2,1],
                               "X": [1,2,3,4,5,6],
                               "Y": [1,2,3,4,5,6]})
df.set_geometry(["X", "Y"], inplace=True, drop=False)
```
