### PR TITLE
DOC: Add --pre to pip install

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -6,8 +6,9 @@ from `GitHub`_ and use the setup script::
 
     python setup.py install
 
-GeoPandas is also available on `PyPI`_, so ``pip install --pre geopandas``
-should work as well.
+GeoPandas is also available on `PyPI`_, so ``pip install geopandas``
+should work as well. You will have to add the ``--pre`` flag
+for pip 1.4 and later.
 
 Dependencies
 ------------


### PR DESCRIPTION
--pre is required to install with pip when using pre-release version numbers

See http://www.pip-installer.org/en/1.4.1/logic.html#pre-release-versions
