### PR TITLE
BUG: Require geopy 0.96 in test requirements

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,4 @@
 psycopg2>=2.5.1
-geopy>=0.95.1
+geopy==0.96.3
 matplotlib>=1.2.1
 descartes>=1.0


### PR DESCRIPTION
Changes in 0.97 break GeoPandas error detection. Until this is properly
handled, this fixes the Travis build.

The newest version of geopy, 0.97, removes the `GeocoderResultError` which we're using. This just requires the latest 0.96 in `requirements.test.txt` to get the Travis build passing.
