### PR TITLE
Remove the shift = translate alias

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -313,9 +313,6 @@ class GeoPandasBase(object):
                              for s in self.geometry], 
             index=self.index, crs=self.crs)
 
-    # Shift is simply an alias for translate
-    shift = translate
-
     def rotate(self, angle, origin='center', use_radians=False):
         """
         Rotate the coordinates of the GeoSeries.


### PR DESCRIPTION
Over-riding shift on GeoSeries and GeoDataFrame clobbered shift
in Pandas. Get rid of it and just use translate

Although this breaks the public API for `GeoSeries` and `GeoDataFrame`, the Pandas `shift` function is pretty important to have. It plays a role in many common patterns.
