### PR TITLE
Add from_features constructor for GeoDataFrame.

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,8 +1,4 @@
-from collections import defaultdict
-
-from shapely.geometry import shape
-
-from geopandas import GeoSeries, GeoDataFrame
+from geopandas import GeoDataFrame
 
 def read_file(filename, **kwargs):
     """
@@ -11,14 +7,8 @@ def read_file(filename, **kwargs):
     *filename* is either the absolute or relative path to the file to be
     opened and *kwargs* are keyword args to be passed to the method when
     opening the file.
-
-    Note: This method does not attempt to align rows.
-    Properties that are not present in all features of the source
-    file will not be properly aligned.  This should be fixed.
     """
     import fiona
-    geoms = []
-    columns = defaultdict(lambda: [])
     bbox = kwargs.pop('bbox', None)
     with fiona.open(filename, **kwargs) as f:
         crs = f.crs
@@ -27,12 +17,6 @@ def read_file(filename, **kwargs):
             f_filt = f.filter(bbox=bbox)
         else:
             f_filt = f
-        for rec in f_filt:
-            geoms.append(shape(rec['geometry']))
-            for key, value in rec['properties'].iteritems():
-                columns[key].append(value)
-    geom = GeoSeries(geoms)
-    df = GeoDataFrame(columns)
-    df['geometry'] = geom
-    df.crs = crs
-    return df
+        gdf = GeoDataFrame.from_features(f)
+
+    return gdf


### PR DESCRIPTION
Allows passing a list of features or objects that implement
**geo_interface** for easier GeoDataFrame construction.

This makes it easy to create a GeoDataFrame if you have features or feature dicts already in memory.
