### PR TITLE
Add pandas release 0.13 to Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 env:
   - PANDAS_VERSION=v0.12.0
+  - PANDAS_VERSION=v0.13.0
   - PANDAS_VERSION=master
 
 before_install:


### PR DESCRIPTION
Pandas 0.13 [has now been released](http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#v0-13-0-january-1-2014), so added the pandas 0.13 tag to the matrix of tests on Travis CI.  Now running 3 different pandas versions, 0.12, 0.13 and master.
