### PR TITLE
Update Travis CI pandas test version to 0.13.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 env:
   - PANDAS_VERSION=v0.12.0
-  - PANDAS_VERSION=v0.13.0
+  - PANDAS_VERSION=v0.13.1
   - PANDAS_VERSION=master
 
 before_install:


### PR DESCRIPTION
Pandas [0.13.1](http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#v0-13-1-february-3-2014) has been released.  Using that for testing, along with 0.12 and master.
