### PR TITLE
Add reverse() method to geocode module

### DIFF
--- a/geopandas/geocode.py
+++ b/geopandas/geocode.py
@@ -62,7 +62,7 @@ def geocode(strings, provider='googlev3', **kwargs):
     return _query(strings, True, provider, **kwargs)
 
 
-def reverse(points, provider='googlev3', **kwargs):
+def reverse_geocode(points, provider='googlev3', **kwargs):
     """
     Reverse geocode a set of points and get a GeoDataFrame of the resulting
     addresses.
@@ -93,8 +93,8 @@ def reverse(points, provider='googlev3', **kwargs):
 
     Example
     -------
-    >>> df = reverse([Point(-71.0594869, 42.3584697),
-                      Point(-77.0365305, 38.8977332)])
+    >>> df = reverse_geocode([Point(-71.0594869, 42.3584697),
+                              Point(-77.0365305, 38.8977332)])
 
                                              address  \
     0             29 Court Square, Boston, MA 02108, USA

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -8,7 +8,7 @@ from shapely.geometry import Point
 import geopandas as gpd
 import nose
 
-from geopandas.geocode import geocode, reverse, _prepare_geocode_result
+from geopandas.geocode import geocode, reverse_geocode, _prepare_geocode_result
 from .util import unittest
 
 
@@ -78,7 +78,7 @@ class TestGeocode(unittest.TestCase):
 
     def test_bad_provider_reverse(self):
         with self.assertRaises(ValueError):
-            reverse(['cambridge, ma'], 'badprovider')
+            reverse_geocode(['cambridge, ma'], 'badprovider')
 
     def test_googlev3_forward(self):
         from geopandas.geocode import geocode
@@ -87,7 +87,7 @@ class TestGeocode(unittest.TestCase):
 
     def test_googlev3_reverse(self):
         from geopandas.geocode import geocode
-        g = reverse(self.points, provider='googlev3', timeout=2)
+        g = reverse_geocode(self.points, provider='googlev3', timeout=2)
         self.assertIsInstance(g, gpd.GeoDataFrame)
 
     def test_openmapquest_forward(self):


### PR DESCRIPTION
Take a bunch of points and turn them into addresses.

Addresses #111.

This turned out to be pretty easy as the the forward and reverse geocode functions return the same thing.
Possible future enhancement would be to allow coordinate tuples instead of Shapely `Point` objects.

It would be nice if the reverse geocoding split out administrative levels, but it doesn't look like most of them do it now.
