### PR TITLE
BUG: Check 'method' in GeoDataFrame __finalize__

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -354,8 +354,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __finalize__(self, other, method=None, **kwargs):
         """ propagate metadata from other to self """
         # NOTE: backported from pandas master (upcoming v0.13)
+        obj = other
+        if method is not None and method == 'merge':
+            obj = other.left
         for name in self._metadata:
-            object.__setattr__(self, name, getattr(other, name, None))
+            object.__setattr__(self, name, getattr(obj, name, None))
         return self
 
     def copy(self, deep=True):

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -425,3 +425,11 @@ class TestDataFrame(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             df.set_geometry('location', inplace=True)
+
+    @unittest.skip("Awaiting PR#7737 on pandas to be merged")
+    def test_merge(self):
+        df2 = pd.DataFrame({'BoroCode': self.df.BoroCode,
+                            'BoroName': self.df.BoroName.str.upper()})
+        result = self.df.merge(df2)
+        self.assertIsInstance(result, GeoDataFrame)
+        self.assertTrue(result.crs == self.df.crs)


### PR DESCRIPTION
This will pull metadata from the correct place when the finalize
operation is from a merge.

This partly addresses Issue #118, but it's a bug in Pandas that hardcodes `DataFrame` as the result of a merge.

The new test is skipped here until Pandas [PR#7737](https://github.com/pydata/pandas/pull/7737) is merged.
Not yet ready to merge.
