### PR TITLE
Update links to new repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ In particular, when submitting a pull request:
 
 - All existing tests should pass.  Please make sure that the test
   suite passes, both locally and on
-  [Travis CI](https://travis-ci.org/kjordahl/geopandas).  Status on
+  [Travis CI](https://travis-ci.org/geopandas/geopandas).  Status on
   Travis will be visible on a pull request.  If you want to enable
   Travis CI on your own fork, please read the pandas guidelines link
   above or the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-GeoPandas [![build status](https://secure.travis-ci.org/kjordahl/geopandas.png?branch=master)](https://travis-ci.org/kjordahl/geopandas) [![Coverage Status](https://coveralls.io/repos/kjordahl/geopandas/badge.png)](https://coveralls.io/r/kjordahl/geopandas)
+GeoPandas [![build status](https://secure.travis-ci.org/geopandas/geopandas.png?branch=master)](https://travis-ci.org/geopandas/geopandas) [![Coverage Status](https://coveralls.io/repos/geopandas/geopandas/badge.png)](https://coveralls.io/r/geopandas/geopandas)
 =========
 
 Python tools for geographic data

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -7,7 +7,7 @@ version, use ``pip install geopandas``.
 You may install the latest development version by cloning the
 `GitHub`_ repository and using the setup script::
 
-    git clone https://github.com/kjordahl/geopandas.git
+    git clone https://github.com/geopandas/geopandas.git
     cd geopandas
     python setup.py install
 
@@ -16,7 +16,7 @@ available on PyPI with `pip` by adding the ``--pre`` flag for pip 1.4
 and later, or to use `pip` to install directly from the GitHub
 repository with::
 
-    pip install git+git://github.com/kjordahl/geopandas.git
+    pip install git+git://github.com/geopandas/geopandas.git
 
 
 Dependencies
@@ -51,7 +51,7 @@ Tests are automatically run on all commits on the GitHub repository,
 including pull requests, on `Travis CI`_.
 
 .. _PyPI: https://pypi.python.org/pypi/geopandas
-.. _GitHub: https://github.com/kjordahl/geopandas
+.. _GitHub: https://github.com/geopandas/geopandas
 .. _numpy: http://www.numpy.org
 .. _pandas: http://pandas.pydata.org
 .. _shapely: http://toblerity.github.io/shapely
@@ -62,7 +62,7 @@ including pull requests, on `Travis CI`_.
 .. _six: https://pythonhosted.org/six
 .. _psycopg2: https://pypi.python.org/pypi/psycopg2
 .. _pysal: http://pysal.org
-.. _Travis CI: https://travis-ci.org/kjordahl/geopandas
+.. _Travis CI: https://travis-ci.org/geopandas/geopandas
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The GitHub repo is now [geopandas/geopandas](https://github.com/geopandas/geopandas).
