### PR TITLE
Provide access to all PySAL map classification methods

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -281,9 +281,9 @@ def __pysal_choro(values, scheme, k=5):
             k = 5
         binning = imported_module(values, k)
         values = binning.yb
-        return values
     except ImportError: 
         print('PySAL not installed. Setting map to default')
+    return values
 
 def norm_cmap(values, cmap, normalize, cm):
 


### PR DESCRIPTION
This PR uses the `imp` library to dynamically load the requested PySAL map classification scheme, which no longer restricts users to the three hard-coded classification methods previously provided. It'll default to 'Quantiles' as before if the requested method isn't found.

Caveat:

`imp` is pending deprecation (though included) as of Python 3.5, and the use of `importlib` is recommended instead, but Python 2.6 doesn't include `importlib`, though it's available to be installed from PyPI, and _could_ be provided as a conditional requirement based on the python version.

More generally: should this functionality be moved to `geopandas.tools` (if only to discourage the proliferation of choropleth maps?)
