### PR TITLE
Geocoding improvements

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 psycopg2>=2.5.1
 SQLAlchemy>=0.8.3
-geopy>=0.99
+geopy>=1.1.0
 matplotlib>=1.2.1
 descartes>=1.0
 pytest-cov

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -24,45 +24,73 @@ def _skip_if_no_geopy():
                             "Skipping tests.")
 
 class TestGeocode(unittest.TestCase):
-    def setUp(self):
+
+    @classmethod
+    def setUpClass(cls):
         _skip_if_no_geopy()
-        self.locations = ['260 Broadway, New York, NY',
+        cls.locations = ['260 Broadway, New York, NY',
                           '77 Massachusetts Ave, Cambridge, MA']
-        self.points = [Point(-71.0597732, 42.3584308),
+        cls.points = [Point(-71.0597732, 42.3584308),
                        Point(-77.0365305, 38.8977332)]
 
     def test_prepare_result(self):
-        # Calls _prepare_result with sample results from the geocoder call
-        # loop
-        p0 = Point(12.3, -45.6) # Treat these as lat/lon
-        p1 = Point(-23.4, 56.7)
-        d = {'a': ('address0', p0.coords[0]),
-             'b': ('address1', p1.coords[0])}
+        """
+        _prepare_geocode_result with data for every item
+        """
+        from geopy.location import Location
+
+        # lon, lat, alt
+        p0_coords = (-45.6, 12.3, 0.1)
+        p1_coords = (56.7, -23.4, 0.2)
+
+        d = {
+            'a': Location(
+                'address0',
+                (p0_coords[1], p0_coords[0], p0_coords[2])
+            ),
+            'b': Location(
+                'address1',
+                (p1_coords[1], p1_coords[0], p1_coords[2])
+            ),
+        }
 
         df = _prepare_geocode_result(d)
-        assert type(df) is gpd.GeoDataFrame
+        self.assertTrue(type(df) is gpd.GeoDataFrame)
         self.assertEqual(from_epsg(4326), df.crs)
         self.assertEqual(len(df), 2)
         self.assert_('address' in df)
 
         coords = df.loc['a']['geometry'].coords[0]
-        test = p0.coords[0]
+
+        test = p0_coords
         # Output from the df should be lon/lat
-        self.assertAlmostEqual(coords[0], test[1])
-        self.assertAlmostEqual(coords[1], test[0])
+        self.assertAlmostEqual(coords[0], test[0])
+        self.assertAlmostEqual(coords[1], test[1])
 
         coords = df.loc['b']['geometry'].coords[0]
-        test = p1.coords[0]
-        self.assertAlmostEqual(coords[0], test[1])
-        self.assertAlmostEqual(coords[1], test[0])
+        test = p1_coords
+        self.assertAlmostEqual(coords[0], test[0])
+        self.assertAlmostEqual(coords[1], test[1])
 
     def test_prepare_result_none(self):
-        p0 = Point(12.3, -45.6) # Treat these as lat/lon
-        d = {'a': ('address0', p0.coords[0]),
-             'b': (None, None)}
+        """
+        _prepare_geocode_result when some items are null
+        """
+        from geopy.location import Location
+
+        # lon, lat, alt
+        p0_coords = (-45.6, 12.3, 0.1)
+
+        d = {
+            'a': Location(
+                'address0',
+                (p0_coords[1], p0_coords[0], p0_coords[2])
+            ),
+            'b': None
+        }
 
         df = _prepare_geocode_result(d)
-        assert type(df) is gpd.GeoDataFrame
+        self.assertTrue(type(df) is gpd.GeoDataFrame)
         self.assertEqual(from_epsg(4326), df.crs)
         self.assertEqual(len(df), 2)
         self.assert_('address' in df)
@@ -70,7 +98,7 @@ class TestGeocode(unittest.TestCase):
         row = df.loc['b']
         self.assertEqual(len(row['geometry'].coords), 0)
         self.assert_(pd.np.isnan(row['address']))
-    
+
     def test_bad_provider_forward(self):
         with self.assertRaises(ValueError):
             geocode(['cambridge, ma'], 'badprovider')


### PR DESCRIPTION
```
tools.geocoding delegates finding a geocoder to geopy.

Geocoding results are handled as geopy.location.Location objects,
and altitude is added to shapely.geometry.Point objects.

None results from geocoding results are handled better.

geopy is upgraded to >=1.1.0.
```

I saw this is being used, and thought I'd provide a better interface. Let me know if I've misunderstood something about the use or you have other feedback.