### PR TITLE
Include support for null geometries

### DIFF
--- a/examples/null_geom.geojson
+++ b/examples/null_geom.geojson
@@ -1,0 +1,9 @@
+{
+"type": "FeatureCollection",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+                                                                                
+"features": [
+{ "type": "Feature", "properties": { "Name": "Null Geometry" }, "geometry": null },
+{ "type": "Feature", "properties": { "Name": "SF to NY" }, "geometry": { "type": "LineString", "coordinates": [ [ -122.4051293283311, 37.786780113640894 ], [ -73.859832357849271, 40.487594916296196 ] ] } }
+]
+}

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -58,9 +58,9 @@ def _geo_unary_op(this, op):
     return gpd.GeoSeries([getattr(geom, op) for geom in this.geometry],
                      index=this.index, crs=this.crs)
 
-def _series_unary_op(this, op):
+def _series_unary_op(this, op, null_value=False):
     """Unary operation that returns a Series"""
-    return Series([getattr(geom, op, np.nan) for geom in this.geometry],
+    return Series([getattr(geom, op, null_value) for geom in this.geometry],
                      index=this.index)
 
 
@@ -85,12 +85,12 @@ class GeoPandasBase(object):
     @property
     def area(self):
         """Return the area of each geometry in the GeoSeries"""
-        return _series_unary_op(self, 'area')
+        return _series_unary_op(self, 'area', np.nan)
 
     @property
     def geom_type(self):
         """Return the geometry type of each geometry in the GeoSeries"""
-        return _series_unary_op(self, 'geom_type')
+        return _series_unary_op(self, 'geom_type', None)
 
     @property
     def type(self):
@@ -100,7 +100,7 @@ class GeoPandasBase(object):
     @property
     def length(self):
         """Return the length of each geometry in the GeoSeries"""
-        return _series_unary_op(self, 'length')
+        return _series_unary_op(self, 'length', np.nan)
 
     @property
     def is_valid(self):
@@ -115,7 +115,7 @@ class GeoPandasBase(object):
     @property
     def is_simple(self):
         """Return True for each simple geometry, else False"""
-        return _series_unary_op(self, 'is_simple')
+        return _series_unary_op(self, 'is_simple', False)
 
     @property
     def is_ring(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -40,14 +40,17 @@ def _geo_op(this, other, op):
 # TODO: think about merging with _geo_op
 def _series_op(this, other, op, **kwargs):
     """Geometric operation that returns a pandas Series"""
+    null_val = False if op != 'distance' else np.nan
+
     if isinstance(other, GeoPandasBase):
         this = this.geometry
         this, other = this.align(other.geometry)
-        return Series([getattr(this_elem, op)(other_elem, **kwargs)
-                      for this_elem, other_elem in zip(this, other)],
-                      index=this.index)
+        return Series([getattr(this_elem, op)(other_elem, **kwargs) 
+                    if not this_elem.is_empty | other_elem.is_empty else null_val
+                    for this_elem, other_elem in zip(this, other)],
+                    index=this.index)
     else:
-        return Series([getattr(s, op)(other, **kwargs)
+        return Series([getattr(s, op)(other, **kwargs) if s else null_val
                       for s in this.geometry], index=this.index)
 
 def _geo_unary_op(this, op):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -57,7 +57,7 @@ def _geo_unary_op(this, op):
 
 def _series_unary_op(this, op):
     """Unary operation that returns a Series"""
-    return Series([getattr(geom, op) for geom in this.geometry],
+    return Series([getattr(geom, op, np.nan) for geom in this.geometry],
                      index=this.index)
 
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -4,6 +4,7 @@ except ImportError:
     # Python 2.6
     from ordereddict import OrderedDict
 from collections import defaultdict
+from types import NoneType
 import json
 import os
 import sys
@@ -139,7 +140,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             level.crs = crs
 
         # Check that we are using a listlike of geometries
-        if not all(isinstance(item, BaseGeometry) for item in level):
+        if not all(isinstance(item, (BaseGeometry, NoneType)) for item in level):
             raise TypeError("Input geometry column must contain valid geometry objects.")
         frame[geo_column_name] = level
         frame._geometry_column_name = geo_column_name

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -68,7 +68,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if not isinstance(col, (list, np.ndarray, Series)):
             raise ValueError("Must use a list-like to set the geometry"
                              " property")
-
         self.set_geometry(col, inplace=True)
 
     geometry = property(fget=_get_geometry, fset=_set_geometry,
@@ -177,7 +176,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             else:
                 f = f
 
-            d = {'geometry': shape(f['geometry'])}
+            d = {'geometry': shape(f['geometry']) if f['geometry'] else None}
             d.update(f['properties'])
             rows.append(d)
         df = GeoDataFrame.from_dict(rows)
@@ -326,8 +325,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 'type': 'Feature',
                 'properties':
                     dict((k, v) for k, v in iteritems(row) if k != 'geometry'),
-                'geometry': mapping(row['geometry'])}
-
+                'geometry': mapping(row['geometry']) if row['geometry']
+                    else None}
         properties = OrderedDict([(col, convert_type(_type)) for col, _type
             in zip(self.columns, self.dtypes) if col != 'geometry'])
         # Need to check geom_types before we write to file...
@@ -335,7 +334,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # Point, LineString, or Polygon
         geom_types = self['geometry'].geom_type.unique()
         from os.path import commonprefix # To find longest common prefix
-        geom_type = commonprefix([g[::-1] for g in geom_types])[::-1]  # Reverse
+        geom_type = commonprefix([g[::-1] for g in geom_types if g])[::-1]
         if geom_type == '': # No common suffix = mixed geometry types
             raise ValueError("Geometry column cannot contains mutiple "
                              "geometry types when writing to file.")

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     # Python 2.6
     from ordereddict import OrderedDict
-from collections import defaultdict
 from types import NoneType
 import json
 import os
@@ -153,7 +152,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def from_file(cls, filename, **kwargs):
         """
         Alternate constructor to create a GeoDataFrame from a file.
-        
+
         Example:
             df = geopandas.GeoDataFrame.from_file('nybb.shp')
 
@@ -200,9 +199,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Wraps geopandas.read_postgis(). For additional help, see read_postgis()
 
         """
-        return geopandas.io.sql.read_postgis(sql, con, geom_col, crs, index_col, 
+        return geopandas.io.sql.read_postgis(sql, con, geom_col, crs, index_col,
                      coerce_float, params)
-
 
     def to_json(self, na='null', show_bbox=False, **kwargs):
         """Returns a GeoJSON string representation of the GeoDataFrame.
@@ -218,7 +216,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             * keep: output the missing entries as NaN
 
         show_bbox : include bbox (bounds) in the geojson
-        
+
         The remaining *kwargs* are passed to json.dumps().
         """
         return json.dumps(self._to_geo(na, show_bbox), **kwargs)
@@ -279,7 +277,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 'type': 'Feature',
                 'properties':
                     dict((k, v) for k, v in iteritems(row) if k != self._geometry_column_name),
-                'geometry': mapping(row[self._geometry_column_name]) }
+                'geometry': mapping(row[self._geometry_column_name])}
 
             if show_bbox:
                 feat['bbox'] = bbox
@@ -293,26 +291,27 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             geo['bbox'] = self.total_bounds
 
         return geo
-            
+
     def to_file(self, filename, driver="ESRI Shapefile", **kwargs):
         """
         Write this GeoDataFrame to an OGR data source
-        
+
         A dictionary of supported OGR providers is available via:
         >>> import fiona
         >>> fiona.supported_drivers
 
         Parameters
         ----------
-        filename : string 
+        filename : string
             File path or file handle to write to.
         driver : string, default 'ESRI Shapefile'
             The OGR format driver used to write the vector file.
 
-        The *kwargs* are passed to fiona.open and can be used to write 
+        The *kwargs* are passed to fiona.open and can be used to write
         to multi-layer data, store data within archives (zip files), etc.
         """
         import fiona
+
         def convert_type(in_type):
             if in_type == object:
                 return 'str'
@@ -320,19 +319,19 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             if out_type == 'long':
                 out_type = 'int'
             return out_type
-            
+
         def feature(i, row):
             return {
                 'id': str(i),
                 'type': 'Feature',
                 'properties':
                     dict((k, v) for k, v in iteritems(row) if k != 'geometry'),
-                'geometry': mapping(row['geometry']) }
-        
-        properties = OrderedDict([(col, convert_type(_type)) for col, _type 
-            in zip(self.columns, self.dtypes) if col!='geometry'])
-        # Need to check geom_types before we write to file... 
-        # Some (most?) providers expect a single geometry type: 
+                'geometry': mapping(row['geometry'])}
+
+        properties = OrderedDict([(col, convert_type(_type)) for col, _type
+            in zip(self.columns, self.dtypes) if col != 'geometry'])
+        # Need to check geom_types before we write to file...
+        # Some (most?) providers expect a single geometry type:
         # Point, LineString, or Polygon
         geom_types = self['geometry'].geom_type.unique()
         from os.path import commonprefix # To find longest common prefix
@@ -342,7 +341,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                              "geometry types when writing to file.")
         schema = {'geometry': geom_type, 'properties': properties}
         filename = os.path.abspath(os.path.expanduser(filename))
-        with fiona.open(filename, 'w', driver=driver, crs=self.crs, 
+        with fiona.open(filename, 'w', driver=driver, crs=self.crs,
                         schema=schema, **kwargs) as c:
             for i, row in self.iterrows():
                 c.write(feature(i, row))
@@ -436,6 +435,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def plot(self, *args, **kwargs):
         return plot_dataframe(self, *args, **kwargs)
+
 
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     if inplace:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     # Python 2.6
     from ordereddict import OrderedDict
-from types import NoneType
 import json
 import os
 import sys
@@ -138,7 +137,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             level.crs = crs
 
         # Check that we are using a listlike of geometries
-        if not all(isinstance(item, (BaseGeometry, NoneType)) for item in level):
+        if not all(isinstance(item, BaseGeometry) or not item for item in level):
             raise TypeError("Input geometry column must contain valid geometry objects.")
         frame[geo_column_name] = level
         frame._geometry_column_name = geo_column_name

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -28,7 +28,7 @@ class TestDataFrame(unittest.TestCase):
         self.boros = self.df['BoroName']
         self.crs = {'init': 'epsg:4326'}
         self.df2 = GeoDataFrame([
-            {'geometry' : Point(x, y), 'value1': x + y, 'value2': x * y}
+            {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
             for x, y in zip(range(N), range(N))], crs=self.crs)
 
     def tearDown(self):
@@ -86,7 +86,7 @@ class TestDataFrame(unittest.TestCase):
                                   check_dtype=True, check_index_type=True)
 
         df = self.df.copy()
-        new_geom = [Point(x,y) for x, y in zip(range(len(self.df)),
+        new_geom = [Point(x, y) for x, y in zip(range(len(self.df)),
                                                range(len(self.df)))]
         df.geometry = new_geom
 
@@ -131,7 +131,7 @@ class TestDataFrame(unittest.TestCase):
             df.geometry = df
 
     def test_set_geometry(self):
-        geom = GeoSeries([Point(x,y) for x,y in zip(range(5), range(5))])
+        geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
         original_geom = self.df.geometry
 
         df2 = self.df.set_geometry(geom)
@@ -178,7 +178,7 @@ class TestDataFrame(unittest.TestCase):
         assert_geoseries_equal(df3.geometry, g_simplified)
 
     def test_set_geometry_inplace(self):
-        geom = [Point(x,y) for x,y in zip(range(5), range(5))]
+        geom = [Point(x, y) for x, y in zip(range(5), range(5))]
         ret = self.df.set_geometry(geom, inplace=True)
         self.assert_(ret is None)
         geom = GeoSeries(geom, index=self.df.index, crs=self.df.crs)
@@ -224,7 +224,7 @@ class TestDataFrame(unittest.TestCase):
 
     def test_to_json_na(self):
         # Set a value as nan and make sure it's written
-        self.df['Shape_Area'][self.df['BoroName']=='Queens'] = np.nan
+        self.df['Shape_Area'][self.df['BoroName'] == 'Queens'] = np.nan
 
         text = self.df.to_json()
         data = json.loads(text)
@@ -241,8 +241,8 @@ class TestDataFrame(unittest.TestCase):
             text = self.df.to_json(na='garbage')
 
     def test_to_json_dropna(self):
-        self.df['Shape_Area'][self.df['BoroName']=='Queens'] = np.nan
-        self.df['Shape_Leng'][self.df['BoroName']=='Bronx'] = np.nan
+        self.df['Shape_Area'][self.df['BoroName'] == 'Queens'] = np.nan
+        self.df['Shape_Leng'][self.df['BoroName'] == 'Bronx'] = np.nan
 
         text = self.df.to_json(na='drop')
         data = json.loads(text)
@@ -263,8 +263,8 @@ class TestDataFrame(unittest.TestCase):
                 self.assertEqual(len(props), 4)
 
     def test_to_json_keepna(self):
-        self.df['Shape_Area'][self.df['BoroName']=='Queens'] = np.nan
-        self.df['Shape_Leng'][self.df['BoroName']=='Bronx'] = np.nan
+        self.df['Shape_Area'][self.df['BoroName'] == 'Queens'] = np.nan
+        self.df['Shape_Leng'][self.df['BoroName'] == 'Bronx'] = np.nan
 
         text = self.df.to_json(na='keep')
         data = json.loads(text)
@@ -310,7 +310,7 @@ class TestDataFrame(unittest.TestCase):
     def test_mixed_types_to_file(self):
         """ Test that mixed geometry types raise error when writing to file """
         tempfilename = os.path.join(self.tempdir, 'test.shp')
-        s = GeoDataFrame({'geometry' : [Point(0, 0),
+        s = GeoDataFrame({'geometry': [Point(0, 0),
                                         Polygon([(0, 0), (1, 0), (1, 1)])]})
         with self.assertRaises(ValueError):
             s.to_file(tempfilename)
@@ -344,17 +344,17 @@ class TestDataFrame(unittest.TestCase):
         self.assert_(df.crs == crs)
 
     def test_from_features_unaligned_properties(self):
-        p1 = Point(1,1)
-        f1 = {'type': 'Feature', 
-                'properties': {'a': 0}, 
+        p1 = Point(1, 1)
+        f1 = {'type': 'Feature',
+                'properties': {'a': 0},
                 'geometry': p1.__geo_interface__}
 
-        p2 = Point(2,2)
+        p2 = Point(2, 2)
         f2 = {'type': 'Feature',
                 'properties': {'b': 1},
                 'geometry': p2.__geo_interface__}
 
-        p3 = Point(3,3)
+        p3 = Point(3, 3)
         f3 = {'type': 'Feature',
                 'properties': {'a': 2},
                 'geometry': p3.__geo_interface__}

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -30,6 +30,8 @@ class TestDataFrame(unittest.TestCase):
         self.df2 = GeoDataFrame([
             {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
             for x, y in zip(range(N), range(N))], crs=self.crs)
+        self.df3 = read_file('examples/null_geom.geojson')
+        self.line_paths = self.df3['Name']
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)
@@ -290,11 +292,20 @@ class TestDataFrame(unittest.TestCase):
         """ Test to_file and from_file """
         tempfilename = os.path.join(self.tempdir, 'boros.shp')
         self.df.to_file(tempfilename)
-        # Read layer back in?
+        # Read layer back in
         df = GeoDataFrame.from_file(tempfilename)
         self.assertTrue('geometry' in df)
         self.assertTrue(len(df) == 5)
         self.assertTrue(np.alltrue(df['BoroName'].values == self.boros))
+
+        # Write layer with null geometry out to file
+        tempfilename = os.path.join(self.tempdir, 'null_geom.shp')
+        self.df3.to_file(tempfilename)
+        # Read layer back in
+        df3 = GeoDataFrame.from_file(tempfilename)
+        self.assertTrue('geometry' in df3)
+        self.assertTrue(len(df3) == 2)
+        self.assertTrue(np.alltrue(df3['Name'].values == self.line_paths))
 
     def test_to_file_types(self):
         """ Test various integer type columns (GH#93) """

--- a/tests/test_geom_methods.py
+++ b/tests/test_geom_methods.py
@@ -246,6 +246,11 @@ class TestGeomMethods(unittest.TestCase):
         expected = Series(np.array([2 + np.sqrt(2), 4]), index=self.g1.index)
         self._test_unary_real('length', expected, self.g1)
 
+        expected = Series(
+                        np.array([2 + np.sqrt(2), np.nan]),
+                        index=self.na_none.index)
+        self._test_unary_real('length', expected, self.na_none)
+
     def test_crosses(self):
         expected = [False, False, False, False, False, False]
         assert_array_equal(expected, self.g0.crosses(self.t1))

--- a/tests/test_geom_methods.py
+++ b/tests/test_geom_methods.py
@@ -218,6 +218,9 @@ class TestGeomMethods(unittest.TestCase):
         self._test_unary_topological('boundary', expected, self.g1)
 
     def test_area(self):
+        expected = Series(np.array([0.5, 1.0]), index=self.g1.index)
+        self._test_unary_real('area', expected, self.g1)
+
         expected = Series(np.array([0.5, np.nan]), index=self.na_none.index)
         self._test_unary_real('area', expected, self.na_none)
 

--- a/tests/test_geom_methods.py
+++ b/tests/test_geom_methods.py
@@ -36,7 +36,7 @@ class TestGeomMethods(unittest.TestCase):
         self.g3.crs = {'init': 'epsg:4326', 'no_defs': True}
         self.g4 = GeoSeries([self.t2, self.t1])
         self.na = GeoSeries([self.t1, self.t2, Polygon()])
-        self.na_none = GeoSeries([self.t1, self.t2, None])
+        self.na_none = GeoSeries([self.t1, None])
         self.a1 = self.g1.copy()
         self.a1.index = ['A', 'B']
         self.a2 = self.g2.copy()
@@ -218,8 +218,8 @@ class TestGeomMethods(unittest.TestCase):
         self._test_unary_topological('boundary', expected, self.g1)
 
     def test_area(self):
-        expected = Series(np.array([0.5, 1.0]), index=self.g1.index)
-        self._test_unary_real('area', expected, self.g1)
+        expected = Series(np.array([0.5, np.nan]), index=self.na_none.index)
+        self._test_unary_real('area', expected, self.na_none)
 
     def test_bounds(self):
         # Set columns to get the order right

--- a/tests/test_geom_methods.py
+++ b/tests/test_geom_methods.py
@@ -22,6 +22,7 @@ class TestGeomMethods(unittest.TestCase):
     def setUp(self):
         self.t1 = Polygon([(0, 0), (1, 0), (1, 1)])
         self.t2 = Polygon([(0, 0), (1, 1), (0, 1)])
+        self.t3 = Polygon([(2, 0), (3, 0), (3, 1)])
         self.sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
         self.inner_sq = Polygon([(0.25, 0.25), (0.75, 0.25), (0.75, 0.75),
                             (0.25, 0.75)])
@@ -48,6 +49,7 @@ class TestGeomMethods(unittest.TestCase):
         self.l1 = LineString([(0, 0), (0, 1), (1, 1)])
         self.l2 = LineString([(0, 0), (1, 0), (1, 1), (0, 1)])
         self.g5 = GeoSeries([self.l1, self.l2])
+        self.g6 = GeoSeries([self.p0, self.t3])
 
         # Crossed lines
         self.l3 = LineString([(0, 0), (1, 1)])
@@ -262,9 +264,23 @@ class TestGeomMethods(unittest.TestCase):
         expected = [False, False, False, False, False, True]
         assert_array_equal(expected, self.g0.disjoint(self.t1))
 
+    def test_distance(self):
+        expected = Series(np.array([
+                          np.sqrt((5 - 1)**2 + (5 - 1)**2),
+                          np.nan]),
+                    self.na_none.index)
+        assert_array_equal(expected, self.na_none.distance(self.p0))
+
+        expected = Series(np.array([np.sqrt(4**2 + 4**2), np.nan]),
+                          self.g6.index)
+        assert_array_equal(expected, self.g6.distance(self.na_none))
+
     def test_intersects(self):
         expected = [True, True, True, True, True, False]
         assert_array_equal(expected, self.g0.intersects(self.t1))
+
+        expected = [True, False]
+        assert_array_equal(expected, self.na_none.intersects(self.t2))
 
     def test_overlaps(self):
         expected = [True, True, False, False, False, False]


### PR DESCRIPTION
This PR allows for more graceful handling of null geometries; as mentioned in https://github.com/geopandas/geopandas/issues/138 and https://github.com/geopandas/geopandas/issues/139.

Main improvements include:
- to_file and from_file handle read/write of null geometries
- Various geometric operations return nan, None or False.
    