### PR TITLE
Mock geocoding network calls.

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -3,5 +3,6 @@ SQLAlchemy>=0.8.3
 geopy==0.99
 matplotlib>=1.2.1
 descartes>=1.0
+mock>=1.0.1  # technically not need for python >= 3.3
 pytest-cov
 coveralls

--- a/tests/util.py
+++ b/tests/util.py
@@ -23,6 +23,11 @@ except ImportError:
         pass
 
 try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
+try:
     from pandas import read_sql_table
 except ImportError:
     PANDAS_NEW_SQL_API = False


### PR DESCRIPTION
I've been burned enough times by the `GeocoderTimedOut` errors, which cause us to restart the Travis builds This makes each Travis run to take at least 15 minutes longer. See #143.

Use the `mock` library to mock geopy's geocoding calls for our round-trip tests. The mocked methods are the `geocode` and `reverse` methods of one of the geocoders, which is GeoPandas interface to geopy.
