### PR TITLE
Drop support for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
 


### PR DESCRIPTION
Is anyone using GeoPandas with 3.2? And would anyone object to dropping support for it? We'll still support 3.3 and up.

We've been having problems with geopy and now Fiona on 3.2 (https://travis-ci.org/jwass/geopandas/jobs/37751221#L544). Those libraries don't try to support 3.2. The errors are due to 3.2 not supporting unicode literals, e.g. `u'blah'` is `SyntaxError` in 3.2. Unicode literals were reintroduced in 3.3. 

Also, dropping some Travis runs wouldn't be so terrible either :)

Otherwise we need the dependencies to support 3.2, which seems to be less common.
