### PR TITLE
ENH: Optimized spatial join

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -52,7 +52,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects', lsuffix='left', rsuff
     idxmatch = idxmatch[idxmatch.str.len() > 0]
 
     r_idx = np.concatenate(idxmatch.values)
-    l_idx = np.concatenate((idxmatch.str.len()*pd.Series([[i] for i in idxmatch.index], index=idxmatch.index)).values)
+    l_idx = idxmatch.index.values.repeat(idxmatch.str.len().values) 
 
     # VECTORIZE PREDICATE OPERATIONS
     def find_intersects(a1, a2):

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,10 +1,10 @@
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rtree
 from shapely import prepared
+import geopandas as gpd
 
-def sjoin(left_df, right_df, how='left', op='intersects', convert_crs=True, lsuffix='left', rsuffix='right', **kwargs):
+def sjoin(left_df, right_df, how='inner', op='intersects', lsuffix='left', rsuffix='right', **kwargs):
     """Spatial join of two GeoDataFrames.
 
     left_df, right_df are GeoDataFrames
@@ -14,6 +14,8 @@ def sjoin(left_df, right_df, how='left', op='intersects', convert_crs=True, lsuf
         inner -> use intersection of keys from both dfs; retain only left_df geometry column
     op: binary predicate {'intersects', 'contains', 'within'}
         see http://toblerity.org/shapely/manual.html#binary-predicates
+    lsuffix: suffix to apply to overlapping column names (left GeoDataFrame)
+    rsuffix: suffix to apply to overlapping column names (right GeoDataFrame)
     """
 
     # CHECK VALIDITY OF JOIN TYPE
@@ -38,12 +40,6 @@ def sjoin(left_df, right_df, how='left', op='intersects', convert_crs=True, lsuf
     # CONVERT CRS IF NOT EQUAL
     if left_df.crs != right_df.crs:
         print('Warning: CRS does not match!')
-        if convert_crs == True:
-            print('Converting CRS...')
-            if left_df.values.nbytes >= right_df.values.nbytes:
-                right_df = right_df.to_crs(left_df.crs)
-            elif left_df.values.nbytes < right_df.values.nbytes:
-                left_df = left_df.to_crs(right_df.crs)
 
     # CONSTRUCT SPATIAL INDEX FOR RIGHT DATAFRAME
     tree_idx = rtree.index.Index()

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,8 +1,10 @@
+import geopandas as gpd
+import numpy as np
 import pandas as pd
-from geopandas import GeoDataFrame
-from .overlay import _uniquify
+import rtree
+from shapely import prepared
 
-def sjoin(left_df, right_df, how="left", op="intersects", use_sindex=True, **kwargs):
+def sjoin(left_df, right_df, how='left', op='intersects', crs_convert=True, lsuffix='left', rsuffix='right', **kwargs):
     """Spatial join of two GeoDataFrames.
 
     left_df, right_df are GeoDataFrames
@@ -15,48 +17,70 @@ def sjoin(left_df, right_df, how="left", op="intersects", use_sindex=True, **kwa
     use_sindex : Use the spatial index to speed up operation? Default is True
     kwargs: passed to op method
     """
+
+    # CHECK VALIDITY OF JOIN TYPE
     allowed_hows = ['left', 'right', 'inner']
 
     if how not in allowed_hows:
         raise ValueError("`how` was \"%s\" but is expected to be in %s" % \
             (how, allowed_hows))
+    
+    # CHECK VALIDITY OF PREDICATE OPERATION
+    allowed_ops = ['contains', 'within', 'intersects']
 
-    if how == "right":
-        # right outer join just implemented as the inverse of left; swap names
+    if op not in allowed_ops:
+        raise ValueError("`op` was \"%s\" but is expected to be in %s" % \
+            (op, allowed_ops))
+
+    # IF WITHIN, SWAP NAMES
+    if op == "within":
+        # within implemented as the inverse of contains; swap names
         left_df, right_df = right_df, left_df
 
-    collection = []
-    for i, feat in left_df.iterrows():
-        geom = feat.geometry
+    # CONVERT CRS IF NOT EQUAL
+    if left_df.crs != right_df.crs:
+        print 'Warning: CRS does not match!'
+        if crs_convert == True:
+            print 'Converting CRS...'
+            if left_df.values.nbytes >= right_df.values.nbytes:
+                right_df = right_df.to_crs(left_df.crs)
+            elif left_df.values.nbytes < right_df.values.nbytes:
+                left_df = left_df.to_crs(right_df.crs)
 
-        if use_sindex and right_df.sindex:
-            candidates = [x.object for x in
-                           right_df.sindex.intersection(geom.bounds, objects=True)]
-        else:
-            candidates = [i for i, x in right_df.iterrows()]
+    # CONSTRUCT SPATIAL INDEX FOR RIGHT DATAFRAME
+    tree_idx = rtree.index.Index()
+    right_df_bounds = right_df['geometry'].apply(lambda x: x.bounds)
+    for i in right_df_bounds.index:
+        tree_idx.insert(i, right_df_bounds[i])
 
-        feature_hits = 0
-        for cand_id in candidates:
-            candidate = right_df.ix[cand_id]
-            if getattr(geom, op)(candidate.geometry, **kwargs):
-                newseries = candidate.drop(right_df._geometry_column_name) 
-                newfeat = pd.concat([feat, newseries])
-                newfeat.index = _uniquify(newfeat.index)
-                collection.append(newfeat)
-                feature_hits += 1
+    # FIND INTERSECTION OF SPATIAL INDEX
+    idxmatch = left_df['geometry'].apply(lambda x: x.bounds).apply(lambda x: list(tree_idx.intersection(x)))
+    idxmatch = idxmatch[idxmatch.str.len() > 0]
 
-        # TODO Should we perform aggregation if feature_hit > 1?
-        # Advantage: single step and possible performance improvement
-        # Disadvantage: Pandas already has groupby so user can do this later
+    r_idx = np.concatenate(idxmatch.values)
+    l_idx = np.concatenate((idxmatch.str.len()*pd.Series([[i] for i in idxmatch.index], index=idxmatch.index)).values)
 
-        # If left does not spatially join with any right features,
-        # Fill in the right columns with NA
-        if how != 'inner' and feature_hits == 0:
-            empty = pd.Series(dict.fromkeys(right_df.columns, None))
-            empty.drop(right_df._geometry_column_name, inplace=True) 
+    # VECTORIZE PREDICATE OPERATIONS
+    def find_intersects(a1, a2):
+        return a1.intersects(a2)
 
-            newfeat = pd.concat([feat, empty])
-            newfeat.index = _uniquify(newfeat.index)
-            collection.append(newfeat)
+    def find_contains(a1, a2):
+        return a1.contains(a2)
 
-    return GeoDataFrame(collection, index=range(len(collection)))
+    predicate_d = {'intersects': find_intersects, 'contains': find_contains, 'within': find_contains}
+
+    check_predicates = np.vectorize(predicate_d[op])
+
+    # CHECK PREDICATES
+    result = pd.DataFrame(np.column_stack([l_idx, r_idx, check_predicates(left_df['geometry'].apply(lambda x: prepared.prep(x)).values[l_idx], right_df['geometry'].values[r_idx])]))
+    result.columns = ['index_%s' % lsuffix, 'index_%s' % rsuffix, 'match_bool']
+    result = pd.DataFrame(result[result['match_bool']==1].set_index('index_%s' % lsuffix)['index_%s' % rsuffix])
+
+    # IF 'WITHIN', SWAP NAMES AGAIN
+    if op == "within":
+        # within implemented as the inverse of contains; swap names
+        left_df, right_df = right_df, left_df
+        result = result.reset_index().rename(columns={'index_%s' % (lsuffix): 'index_%s' % (rsuffix), 'index_%s' % (rsuffix): 'index_%s' % (lsuffix)}).set_index('index_left').sort_index()    
+
+    # APPLY JOIN
+    return left_df.merge(result, left_index=True, right_index=True).merge(right_df, left_on='index_%s' % rsuffix, right_index=True, how=how, suffixes=('_%s' % lsuffix, '_%s' % rsuffix))

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -14,8 +14,6 @@ def sjoin(left_df, right_df, how='left', op='intersects', convert_crs=True, lsuf
         inner -> use intersection of keys from both dfs; retain only left_df geometry column
     op: binary predicate {'intersects', 'contains', 'within'}
         see http://toblerity.org/shapely/manual.html#binary-predicates
-    use_sindex : Use the spatial index to speed up operation? Default is True
-    kwargs: passed to op method
     """
 
     # CHECK VALIDITY OF JOIN TYPE

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -46,6 +46,8 @@ def sjoin(left_df, right_df, how='left', op='intersects', crs_convert=True, lsuf
                 right_df = right_df.to_crs(left_df.crs)
             elif left_df.values.nbytes < right_df.values.nbytes:
                 left_df = left_df.to_crs(right_df.crs)
+	else:
+	    pass
 
     # CONSTRUCT SPATIAL INDEX FOR RIGHT DATAFRAME
     tree_idx = rtree.index.Index()

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -44,8 +44,6 @@ def sjoin(left_df, right_df, how='left', op='intersects', convert_crs=True, lsuf
                 right_df = right_df.to_crs(left_df.crs)
             elif left_df.values.nbytes < right_df.values.nbytes:
                 left_df = left_df.to_crs(right_df.crs)
-	else:
-	    pass
 
     # CONSTRUCT SPATIAL INDEX FOR RIGHT DATAFRAME
     tree_idx = rtree.index.Index()

--- a/tests/test_sjoin.py
+++ b/tests/test_sjoin.py
@@ -25,51 +25,52 @@ class TestSpatialJoin(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_sjoin_left(self):
-        df = sjoin(self.pointdf, self.polydf)
-        self.assertEquals(df.shape, (21,7))
-        for i, row in df.iterrows():
-            self.assertEquals(row.geometry.type, 'Point')
+        df = sjoin(self.pointdf, self.polydf, crs_convert=False)
+        self.assertEquals(df.shape, (11,9))
+#        for i, row in df.iterrows():
+#            self.assertEquals(row.geometry.type, 'Point')
         self.assertTrue('pointattr1' in df.columns)
         self.assertTrue('BoroCode' in df.columns)
 
     def test_sjoin_right(self):
         # the inverse of left
-        df = sjoin(self.pointdf, self.polydf, how="right")
-        df2 = sjoin(self.polydf, self.pointdf, how="left")
-        self.assertEquals(df.shape, (12, 7))
-        self.assertEquals(df.shape, df2.shape)
-        for i, row in df.iterrows():
-            self.assertEquals(row.geometry.type, 'MultiPolygon')
-        for i, row in df2.iterrows():
-            self.assertEquals(row.geometry.type, 'MultiPolygon')
+        df = sjoin(self.pointdf, self.polydf, how="right", crs_convert=False)
+        df2 = sjoin(self.polydf, self.pointdf, how="left", crs_convert=False)
+        self.assertEquals(df.shape, (12, 9))
+#        self.assertEquals(df.shape, df2.shape)
+#        for i, row in df.iterrows():
+#            self.assertEquals(row.geometry.type, 'MultiPolygon')
+#        for i, row in df2.iterrows():
+#            self.assertEquals(row.geometry.type, 'MultiPolygon')
 
     def test_sjoin_inner(self):
-        df = sjoin(self.pointdf, self.polydf, how="inner")
-        self.assertEquals(df.shape, (11, 7))
+        df = sjoin(self.pointdf, self.polydf, how="inner", crs_convert=False)
+        self.assertEquals(df.shape, (11, 9))
 
     def test_sjoin_op(self):
         # points within polygons
-        df = sjoin(self.pointdf, self.polydf, how="left", op="within")
-        self.assertEquals(df.shape, (21,7))
+        df = sjoin(self.pointdf, self.polydf, how="left", op="within", crs_convert=False)
+        self.assertEquals(df.shape, (11,9))
         self.assertAlmostEquals(df.ix[1]['Shape_Leng'], 330454.175933)
 
         # points contain polygons? never happens so we should have nulls
-        df = sjoin(self.pointdf, self.polydf, how="left", op="contains")
-        self.assertEquals(df.shape, (21, 7))
-        self.assertEquals(df.ix[1]['Shape_Area'], None)
+#        df = sjoin(self.pointdf, self.polydf, how="left", op="contains", crs_convert=False)
+#        self.assertEquals(df.shape, (11, 9))
+#        self.assertEquals(df.ix[1]['Shape_Area'], None)
 
-    def test_sjoin_bad_op(self):
+    def test_sjoin_bad_op(self, crs_convert=False):
         # AttributeError: 'Point' object has no attribute 'spandex'
-        self.assertRaises(AttributeError, sjoin,
+        self.assertRaises(ValueError, sjoin,
             self.pointdf, self.polydf, how="left", op="spandex")
 
-    def test_sjoin_duplicate_column_name(self):
+    @unittest.skip("Not implemented")
+    def test_sjoin_duplicate_column_name(self, crs_convert=False):
         pointdf2 = self.pointdf.rename(columns={'pointattr1': 'Shape_Area'})
-        df = sjoin(pointdf2, self.polydf, how="left")
+        df = sjoin(pointdf2, self.polydf, how="left", crs_convert=False)
         self.assertTrue('Shape_Area' in df.columns)
         self.assertTrue('Shape_Area_2' in df.columns)
 
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):
         df = sjoin(self.pointdf, self.polydf, how="outer")
-        self.assertEquals(df.shape, (21,7))
+        self.assertEquals(df.shape, (21,9))

--- a/tests/test_sjoin.py
+++ b/tests/test_sjoin.py
@@ -27,7 +27,7 @@ class TestSpatialJoin(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_sjoin_left(self):
-        df = sjoin(self.pointdf, self.polydf, convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how='left')
         self.assertEquals(df.shape, (21,8))
         for i, row in df.iterrows():
             self.assertEquals(row.geometry.type, 'Point')
@@ -36,8 +36,8 @@ class TestSpatialJoin(unittest.TestCase):
 
     def test_sjoin_right(self):
         # the inverse of left
-        df = sjoin(self.pointdf, self.polydf, how="right", convert_crs=False)
-        df2 = sjoin(self.polydf, self.pointdf, how="left", convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how="right")
+        df2 = sjoin(self.polydf, self.pointdf, how="left")
         self.assertEquals(df.shape, (12, 8))
         self.assertEquals(df.shape, df2.shape)
         for i, row in df.iterrows():
@@ -46,32 +46,32 @@ class TestSpatialJoin(unittest.TestCase):
             self.assertEquals(row.geometry.type, 'MultiPolygon')
 
     def test_sjoin_inner(self):
-        df = sjoin(self.pointdf, self.polydf, how="inner", convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how="inner")
         self.assertEquals(df.shape, (11, 8))
 
     def test_sjoin_op(self):
         # points within polygons
-        df = sjoin(self.pointdf, self.polydf, how="left", op="within", convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how="left", op="within")
         self.assertEquals(df.shape, (21,8))
         self.assertAlmostEquals(df.ix[1]['Shape_Leng'], 330454.175933)
 
         # points contain polygons? never happens so we should have nulls
-        df = sjoin(self.pointdf, self.polydf, how="left", op="contains", convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how="left", op="contains")
         self.assertEquals(df.shape, (21, 8))
         self.assertTrue(np.isnan(df.ix[1]['Shape_Area']))
 
     def test_sjoin_bad_op(self):
         # AttributeError: 'Point' object has no attribute 'spandex'
         self.assertRaises(ValueError, sjoin,
-            self.pointdf, self.polydf, how="left", op="spandex", convert_crs=False)
+            self.pointdf, self.polydf, how="left", op="spandex")
 
     def test_sjoin_duplicate_column_name(self):
         pointdf2 = self.pointdf.rename(columns={'pointattr1': 'Shape_Area'})
-        df = sjoin(pointdf2, self.polydf, how="left", convert_crs=False)
+        df = sjoin(pointdf2, self.polydf, how="left")
         self.assertTrue('Shape_Area_left' in df.columns)
         self.assertTrue('Shape_Area_right' in df.columns)
 
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):
-        df = sjoin(self.pointdf, self.polydf, how="outer", convert_crs=False)
+        df = sjoin(self.pointdf, self.polydf, how="outer")
         self.assertEquals(df.shape, (21,8))

--- a/tests/test_sjoin.py
+++ b/tests/test_sjoin.py
@@ -1,6 +1,8 @@
+
 from __future__ import absolute_import
 import tempfile
 import shutil
+import numpy as np
 from shapely.geometry import Point
 from geopandas import GeoDataFrame, read_file
 from geopandas.tools import sjoin
@@ -25,52 +27,51 @@ class TestSpatialJoin(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_sjoin_left(self):
-        df = sjoin(self.pointdf, self.polydf, crs_convert=False)
-        self.assertEquals(df.shape, (11,9))
-#        for i, row in df.iterrows():
-#            self.assertEquals(row.geometry.type, 'Point')
+        df = sjoin(self.pointdf, self.polydf, convert_crs=False)
+        self.assertEquals(df.shape, (21,8))
+        for i, row in df.iterrows():
+            self.assertEquals(row.geometry.type, 'Point')
         self.assertTrue('pointattr1' in df.columns)
         self.assertTrue('BoroCode' in df.columns)
 
     def test_sjoin_right(self):
         # the inverse of left
-        df = sjoin(self.pointdf, self.polydf, how="right", crs_convert=False)
-        df2 = sjoin(self.polydf, self.pointdf, how="left", crs_convert=False)
-        self.assertEquals(df.shape, (12, 9))
-#        self.assertEquals(df.shape, df2.shape)
-#        for i, row in df.iterrows():
-#            self.assertEquals(row.geometry.type, 'MultiPolygon')
-#        for i, row in df2.iterrows():
-#            self.assertEquals(row.geometry.type, 'MultiPolygon')
+        df = sjoin(self.pointdf, self.polydf, how="right", convert_crs=False)
+        df2 = sjoin(self.polydf, self.pointdf, how="left", convert_crs=False)
+        self.assertEquals(df.shape, (12, 8))
+        self.assertEquals(df.shape, df2.shape)
+        for i, row in df.iterrows():
+            self.assertEquals(row.geometry.type, 'MultiPolygon')
+        for i, row in df2.iterrows():
+            self.assertEquals(row.geometry.type, 'MultiPolygon')
 
     def test_sjoin_inner(self):
-        df = sjoin(self.pointdf, self.polydf, how="inner", crs_convert=False)
-        self.assertEquals(df.shape, (11, 9))
+        df = sjoin(self.pointdf, self.polydf, how="inner", convert_crs=False)
+        self.assertEquals(df.shape, (11, 8))
 
     def test_sjoin_op(self):
         # points within polygons
-        df = sjoin(self.pointdf, self.polydf, how="left", op="within", crs_convert=False)
-        self.assertEquals(df.shape, (11,9))
+        df = sjoin(self.pointdf, self.polydf, how="left", op="within", convert_crs=False)
+        self.assertEquals(df.shape, (21,8))
         self.assertAlmostEquals(df.ix[1]['Shape_Leng'], 330454.175933)
 
         # points contain polygons? never happens so we should have nulls
-#        df = sjoin(self.pointdf, self.polydf, how="left", op="contains", crs_convert=False)
-#        self.assertEquals(df.shape, (11, 9))
-#        self.assertEquals(df.ix[1]['Shape_Area'], None)
+        df = sjoin(self.pointdf, self.polydf, how="left", op="contains", convert_crs=False)
+        self.assertEquals(df.shape, (21, 8))
+        self.assertTrue(np.isnan(df.ix[1]['Shape_Area']))
 
-    def test_sjoin_bad_op(self, crs_convert=False):
+    def test_sjoin_bad_op(self):
         # AttributeError: 'Point' object has no attribute 'spandex'
         self.assertRaises(ValueError, sjoin,
-            self.pointdf, self.polydf, how="left", op="spandex")
+            self.pointdf, self.polydf, how="left", op="spandex", convert_crs=False)
 
-    @unittest.skip("Not implemented")
-    def test_sjoin_duplicate_column_name(self, crs_convert=False):
+    def test_sjoin_duplicate_column_name(self):
         pointdf2 = self.pointdf.rename(columns={'pointattr1': 'Shape_Area'})
-        df = sjoin(pointdf2, self.polydf, how="left", crs_convert=False)
-        self.assertTrue('Shape_Area' in df.columns)
-        self.assertTrue('Shape_Area_2' in df.columns)
+        df = sjoin(pointdf2, self.polydf, how="left", convert_crs=False)
+        self.assertTrue('Shape_Area_left' in df.columns)
+        self.assertTrue('Shape_Area_right' in df.columns)
 
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):
-        df = sjoin(self.pointdf, self.polydf, how="outer")
-        self.assertEquals(df.shape, (21,9))
+        df = sjoin(self.pointdf, self.polydf, how="outer", convert_crs=False)
+        self.assertEquals(df.shape, (21,8))


### PR DESCRIPTION
This PR increases the performance of geopandas' spatial join function (sjoin.py). The work is based largely on @perrygeo's original work, but introduces a number of optimizations that (a) improve the speed of the join, and (b) reduce memory consumption, allowing the function to handle larger datasets.

Performance increases are primarily achieved by vectorizing operations that were previously handled through iteration (e.g. querying the Rtree index, checking binary predicates). Performance increases are also obtained by generating 'prepared geometry' instances using the `shapely.prepared` package.

Sample speed tests are shown below. The original sjoin function is indicated by `tools.sjoin` while the new sjoin function is indicated by `fast_sjoin`. Join speed is increased by about an order of magnitude for a small dataset (23,000 polygons), by about 14x for a medium dataset (200,000 polygons) and by almost 20x for a large dataset (600,000 polygons).

#### Test 1: ~23000x1500 polygons

```
In [2]: (l_df.shape, r_df.shape)
Out[2]: ((1526, 10), (22669, 9))

In [3]: %timeit fast_sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 4.13 s per loop

In [4]: %timeit tools.sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 53.9 s per loop

```

#### Test 2: ~200000x1500 polygons

```
In [2]: (l_df.shape, r_df.shape)
Out[2]: ((1526, 10), (201853, 9))

In [3]: %timeit fast_sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 31.8 s per loop

In [4]: %timeit tools.sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 7min 27s per loop

```

#### Test 3: ~600000x1500 polygons

```
In [2]: (l_df.shape, r_df.shape)
Out[2]: ((1526, 10), (598502, 9))

In [3]: %timeit fast_sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 2min 9s per loop

In [4]: %timeit tools.sjoin(l_df, r_df, op='contains')
1 loops, best of 3: 37min 12s per loop
```

Let me know what you think!

Thanks,
MDB

Note: special cases (namely, point-in-polygon joins) can probably be optimized further using the `shapely.vectorized` module. However, I haven't implemented these special cases yet.