### PR TITLE
Update pandas versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - 3.4
 
 env:
-  - PANDAS_VERSION=v0.13.1
-  - PANDAS_VERSION=v0.14.1
+  - PANDAS_VERSION=v0.15.2
+  - PANDAS_VERSION=v0.16.0
   - PANDAS_VERSION=master
 
 before_install:


### PR DESCRIPTION
The test versions of pandas used on Travis were out of date. This updates `travis.yml` to use 0.15.2 and 0.16.0, the latest 2 major releases, as well as master.