### PR TITLE
pandas 0.16.0 -> 0.16.2 for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 env:
   - PANDAS_VERSION=v0.15.2
-  - PANDAS_VERSION=v0.16.0
+  - PANDAS_VERSION=v0.16.2
   - PANDAS_VERSION=master
 
 before_install:


### PR DESCRIPTION
Use the latest pandas release in tests.