### PR TITLE
Serialize metadata

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -37,7 +37,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         If str, column to use as geometry. If array, will be set as 'geometry'
         column on GeoDataFrame.
     """
+    _internal_names = ['_data', '_cacher', '_item_cache', '_cache',
+                       'is_copy', '_subtyp', '_index',
+                       '_default_kind', '_default_fill_value', '_metadata',
+                       '__array_struct__', '__array_interface__']
+
     _metadata = ['crs', '_geometry_column_name']
+
     _geometry_column_name = DEFAULT_GEO_COLUMN_NAME
 
     def __init__(self, *args, **kwargs):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -49,6 +49,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
 
+    def __getstate__(self):
+        meta = dict((k, getattr(self, k, None)) for k in self._metadata)
+        return dict(_data=self._data, _typ=self._typ,
+                    _metadata=self._metadata, **meta)
+
     def __setattr__(self, attr, val):
         # have to special case geometry b/c pandas tries to use as column...
         if attr == 'geometry':

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -37,6 +37,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         If str, column to use as geometry. If array, will be set as 'geometry'
         column on GeoDataFrame.
     """
+
+    # XXX: This will no longer be necessary in pandas 0.17
     _internal_names = ['_data', '_cacher', '_item_cache', '_cache',
                        'is_copy', '_subtyp', '_index',
                        '_default_kind', '_default_fill_value', '_metadata',
@@ -55,6 +57,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
 
+    # Serialize metadata (will no longer be necessary in pandas 0.17+)
+    # See https://github.com/pydata/pandas/pull/10557
     def __getstate__(self):
         meta = dict((k, getattr(self, k, None)) for k in self._metadata)
         return dict(_data=self._data, _typ=self._typ,

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -487,3 +487,10 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue(isinstance(geo['bbox'], tuple))
         for feature in geo['features']:
             self.assertTrue('bbox' in feature.keys())
+
+    def test_pickle(self):
+        filename = os.path.join(self.tempdir, 'df.pkl')
+        self.df.to_pickle(filename)
+        unpickled = pd.read_pickle(filename)
+        assert_frame_equal(self.df, unpickled)
+        self.assertEqual(self.df.crs, unpickled.crs)


### PR DESCRIPTION
Fixes #199 to correctly serialize/deserialize `crs` attribute. Not implemented for `GeoSeries` here, only for `GeoDataFrame`. A cleaner fix will be to do this upstream, as submitted in pydata/pandas#10557.