### PR TITLE
ENH/VIS: add legend for choropleth plots

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -224,7 +224,13 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
         else:
             values = s[column]
         if scheme is not None:
-            values = __pysal_choro(values, scheme, k=k)
+            binning = __pysal_choro(values, scheme, k=k)
+            values = binning.yb
+            # set categorical to True for creating the legend
+            categorical = True
+            binedges = [binning.yb.min()] + binning.bins.tolist()
+            categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
+                          for i in range(len(binedges)-1)]
         cmap = norm_cmap(values, colormap, Normalize, cm, vmin=vmin, vmax=vmax)
         if axes is None:
             fig, ax = plt.subplots(figsize=figsize)
@@ -293,7 +299,7 @@ def __pysal_choro(values, scheme, k=5):
             print('2<=k<=9, setting k=5 (default)')
             k = 5
         binning = schemes[scheme](values, k)
-        values = binning.yb
+        return binning
     except ImportError:
         print('PySAL not installed, setting map to default')
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 
+import warnings
+
 import numpy as np
 from six import next
 from six.moves import xrange
@@ -171,7 +173,7 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
             axes on which to draw the plot
 
         scheme : pysal.esda.mapclassify.Map_Classifier
-            Choropleth classification schemes
+            Choropleth classification schemes (requires PySAL)
 
         vmin : float
             Minimum value for color map.
@@ -270,7 +272,8 @@ def __pysal_choro(values, scheme, k=5):
             Series to be plotted
 
         scheme
-            pysal.esda.mapclassify classificatin scheme ['Equal_interval'|'Quantiles'|'Fisher_Jenks']
+            pysal.esda.mapclassify classificatin scheme
+            ['Equal_interval'|'Quantiles'|'Fisher_Jenks']
 
         k
             number of classes (2 <= k <=9)
@@ -278,8 +281,9 @@ def __pysal_choro(values, scheme, k=5):
         Returns
         -------
 
-        values
-            Series with values replaced with class identifier if PySAL is available, otherwise the original values are used
+        binning
+            Binning objects that holds the Series with values replaced with
+            class identifier and the bins.
     """
 
     try:
@@ -292,18 +296,16 @@ def __pysal_choro(values, scheme, k=5):
         scheme = scheme.lower()
         if scheme not in schemes:
             scheme = 'quantiles'
-            print('Unrecognized scheme: ', s0)
-            print('Using Quantiles instead')
+            warnings.warn('Unrecognized scheme "{0}". Using "Quantiles" '
+                          'instead'.format(s0), UserWarning, stacklevel=3)
         if k < 2 or k > 9:
-            print('Invalid k: ', k)
-            print('2<=k<=9, setting k=5 (default)')
+            warnings.warn('Invalid k: {0} (2 <= k <= 9), setting k=5 '
+                          '(default)'.format(k), UserWarning, stacklevel=3)
             k = 5
         binning = schemes[scheme](values, k)
         return binning
     except ImportError:
-        print('PySAL not installed, setting map to default')
-
-    return values
+        raise ImportError("PySAL is required to use the 'scheme' keyword")
 
 
 def norm_cmap(values, cmap, normalize, cm, vmin=None, vmax=None):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -15,7 +15,7 @@ from shapely.geometry import Polygon, LineString, Point
 from six.moves import xrange
 from .util import unittest
 
-from geopandas import GeoSeries, GeoDataFrame
+from geopandas import GeoSeries, GeoDataFrame, read_file
 
 
 # If set to True, generate images rather than perform tests (all tests will pass!)
@@ -27,7 +27,7 @@ TRAVIS = bool(os.environ.get('TRAVIS', False))
 
 
 class PlotTests(unittest.TestCase):
-    
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         return
@@ -105,6 +105,28 @@ class PlotTests(unittest.TestCase):
         # Plot the GeoDataFrame using various keyword arguments to see if they are honoured
         ax = df.plot(column='values', colormap=cm.RdBu, vmin=+2, vmax=None, figsize=(8, 4))
         self._compare_images(ax=ax, filename=filename)
+
+
+class TestPySALPlotting(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import pysal as ps
+        except ImportError:
+            raise unittest.SkipTest("PySAL is not installed")
+
+        pth = ps.examples.get_path("columbus.shp")
+        cls.tracts = read_file(pth)
+
+    def test_legend(self):
+        ax = self.tracts.plot(column='CRIME', scheme='QUANTILES', k=3,
+                         colormap='OrRd', legend=True)
+
+        labels = [t.get_text() for t in ax.get_legend().get_texts()]
+        expected = [u'0.00 - 26.07', u'26.07 - 41.97', u'41.97 - 68.89']
+        self.assertEqual(labels, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Based on a SO question, I added the ability to create a legend for choropleth figures based on PySAL schemes (see my answer: http://stackoverflow.com/questions/31755886/choropleth-map-from-geopandas-geodatafame?noredirect=1#comment51555293_31755886 and the notebook: http://nbviewer.ipython.org/gist/jorisvandenbossche/d4e6efedfa1e4e91ab65)

This lets you obtain something like:

![index](https://cloud.githubusercontent.com/assets/1020496/9069130/dce6287e-3ae7-11e5-8151-4b8d74c415d5.png)
