### PR TITLE
Added check for z dimension in plot_polygon; if yes, flatten before plot.

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -9,6 +9,10 @@ def plot_polygon(ax, poly, facecolor='red', edgecolor='black', alpha=0.5):
     """ Plot a single Polygon geometry """
     from descartes.patch import PolygonPatch
     a = np.asarray(poly.exterior)
+    if poly.has_z:
+        from shapely.geometry import Polygon
+        poly = Polygon(zip(*poly.exterior.xy))
+
     # without Descartes, we could make a Patch of exterior
     ax.add_patch(PolygonPatch(poly, facecolor=facecolor, alpha=alpha))
     ax.plot(a[:, 0], a[:, 1], color=edgecolor)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import numpy as np
 from six import next
 from six.moves import xrange
+from shapely.geometry import Polygon
 
 
 def plot_polygon(ax, poly, facecolor='red', edgecolor='black', alpha=0.5):
@@ -10,7 +11,6 @@ def plot_polygon(ax, poly, facecolor='red', edgecolor='black', alpha=0.5):
     from descartes.patch import PolygonPatch
     a = np.asarray(poly.exterior)
     if poly.has_z:
-        from shapely.geometry import Polygon
         poly = Polygon(zip(*poly.exterior.xy))
 
     # without Descartes, we could make a Patch of exterior


### PR DESCRIPTION
I added this because descartes does not accept polygons with a z coordinate. I could imagine wanting to do something a bit more sophisticated when the z coordinate contains interesting information, but in the meantime, this is nicer behavior than raising an exception.

I would not ordinarily have put the shapely import inside the if statement, but from the descartes import within the function, I guessed there was some desire to limit global imports. 