### PR TITLE
Catch failed geocoded addresses so the entire command doesn't fail

### DIFF
--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from geopandas.geoseries import GeoSeries
 from geopandas.geodataframe import GeoDataFrame
-from geopandas.tools.geocoding import geocoding
+from geopandas.tools.geocoding import geocode
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -5,7 +5,6 @@ except ImportError:
 
 from geopandas.geoseries import GeoSeries
 from geopandas.geodataframe import GeoDataFrame
-from geopandas.tools.geocoding import geocode
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -5,6 +5,7 @@ except ImportError:
 
 from geopandas.geoseries import GeoSeries
 from geopandas.geodataframe import GeoDataFrame
+from geopandas.tools.geocoding import geocoding
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -159,7 +159,12 @@ def _prepare_geocode_result(results):
     index = []
 
     for i, s in iteritems(results):
-        address, loc = s
+        
+        try:
+            address, loc = s
+        except TypeError as e:
+            # geocoder was unable to find a match
+            continue
 
         # loc is lat, lon and we want lon, lat
         if loc is None:


### PR DESCRIPTION
Currently if you try to geocode `['123 Valid Address ...', 'n/a', ...]` the `geopandas.geocode.geocode` command will throw a `TypeError` when it tries to unpack the result for the `n/a` row. This causes the whole thing to fail. I would rather it just skipped that in the output.
