### PR TITLE
TST: speed up travis builds with containers and wheel caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
 language: python
 
+sudo: false
+
+cache:
+  directories:
+    - ~/.cache/pip
+
+addons:
+  apt:
+    packages:
+    - libgdal1h
+    - gdal-bin
+    - libgdal-dev
+    - libspatialindex-dev
+
 python:
   - 2.6
   - 2.7
@@ -7,27 +21,30 @@ python:
   - 3.4
 
 env:
-  - PANDAS_VERSION=v0.15.2
-  - PANDAS_VERSION=v0.16.2
-  - PANDAS_VERSION=master
+  matrix:
+    - PANDAS_VERSION=0.15.2
+    - PANDAS_VERSION=master
+    - PANDAS_VERSION=0.16.2
+  global:
+    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
+    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntugis/ppa
-  - sudo apt-get update
-  - sudo apt-get install libgdal1h gdal-bin libgdal-dev libspatialindex-dev libspatialindex1
-#  - sudo -u postgres psql -c "drop database if exists test_geopandas"
-#  - sudo -u postgres psql -c "create database test_geopandas"
-#  - sudo -u postgres psql -c "create extension postgis" -d test_geopandas
+  - pip install -U pip
+  - pip install wheel
 
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install -r requirements.test.txt --use-mirrors
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r .requirements-2.6.txt --use-mirrors; fi
-  - git clone git://github.com/pydata/pandas.git
-  - cd pandas
-  - git checkout $PANDAS_VERSION
-  - python setup.py install
-  - cd ..
+  - pip wheel numpy
+  - pip wheel -r requirements.txt
+  - pip wheel -r requirements.test.txt
+
+  - pip install numpy
+  - pip install -r requirements.txt
+  - pip install -r requirements.test.txt
+
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r .requirements-2.6.txt; fi
+
+  - if [[ $PANDAS_VERSION == 'master' ]]; then git clone git://github.com/pydata/pandas.git; cd pandas; pip install -e .; cd ..  ; else pip wheel pandas==$PANDAS_VERSION; pip install pandas==$PANDAS_VERSION; fi
 
 script:
   - py.test tests --cov geopandas -v --cov-report term-missing


### PR DESCRIPTION
Inspired by the speedups achieved [in rasterio](https://github.com/mapbox/rasterio/pull/474), these changes run the Travis builds on the new container-based infrastructure and build wheels for the dependencies. The wheels are cached so that subsequent builds will be much faster.

With the addition of [libspatialindex-dev]( https://github.com/travis-ci/apt-package-whitelist/issues/1100) to the travis apt package whitelist, all of the system deps are available in the containers.

Pandas master still requires a build but the pandas stable releases use pypi and build cacheable wheels.

After the initial build, I'm seeing travis runs completing 2-4x faster. 

Resolves #125 