### PR TITLE
Remove test_merge_geo

### DIFF
--- a/tests/test_sindex.py
+++ b/tests/test_sindex.py
@@ -80,7 +80,8 @@ class TestFrameSindex(unittest.TestCase):
         self.assert_(self.df._sindex_valid == False)
 
 
-@unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
+# Skip to accommodate Shapely geometries being unhashable
+@unittest.skip
 class TestJoinSindex(unittest.TestCase):
 
     def setUp(self):
@@ -89,7 +90,6 @@ class TestJoinSindex(unittest.TestCase):
                     vfs="zip://examples/nybb_14aav.zip")
 
     def test_merge_geo(self):
-
         # First check that we gets hits from the boros frame.
         tree = self.boros.sindex
         hits = tree.intersection((1012821.80, 229228.26), objects=True)


### PR DESCRIPTION
When Shapely geometries become unhashable, this behavior is no longer
supported.

See #221.