### PR TITLE
Fix208

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -74,7 +74,7 @@ def gencolor(N, colormap='Set1'):
         yield colors[i % n_colors]
 
 
-def plot_series(s, colormap='Set1', axes=None, linewidth=1.0, figsize=None, **color_kwds):
+def plot_series(s, colormap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kwds):
     """ Plot a GeoSeries
 
         Generate a plot of a GeoSeries geometry with matplotlib.
@@ -95,7 +95,7 @@ def plot_series(s, colormap='Set1', axes=None, linewidth=1.0, figsize=None, **co
 
                 Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
 
-        axes : matplotlib.pyplot.Artist (default None)
+        ax : matplotlib.pyplot.Artist (default None)
             axes on which to draw the plot
 
         linewidth : float (default 1.0)
@@ -103,7 +103,7 @@ def plot_series(s, colormap='Set1', axes=None, linewidth=1.0, figsize=None, **co
 
         figsize : pair of floats (default None)
             Size of the resulting matplotlib.figure.Figure. If the argument
-            axes is given explicitly, figsize is ignored.
+            ax is given explicitly, figsize is ignored.
 
         **color_kwds : dict
             Color options to be passed on to plot_polygon
@@ -114,11 +114,9 @@ def plot_series(s, colormap='Set1', axes=None, linewidth=1.0, figsize=None, **co
         matplotlib axes instance
     """
     import matplotlib.pyplot as plt
-    if axes is None:
+    if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
-    else:
-        ax = axes
     color = gencolor(len(s), colormap=colormap)
     for geom in s:
         if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
@@ -132,7 +130,7 @@ def plot_series(s, colormap='Set1', axes=None, linewidth=1.0, figsize=None, **co
 
 
 def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
-                   categorical=False, legend=False, axes=None,
+                   categorical=False, legend=False, ax=None,
                    scheme=None, k=5, vmin=None, vmax=None, figsize=None,
                    **color_kwds
                    ):
@@ -169,7 +167,7 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
             Plot a legend (Experimental; currently for categorical
             plots only)
 
-        axes : matplotlib.pyplot.Artist (default None)
+        ax : matplotlib.pyplot.Artist (default None)
             axes on which to draw the plot
 
         scheme : pysal.esda.mapclassify.Map_Classifier
@@ -212,7 +210,7 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
     from matplotlib import cm
 
     if column is None:
-        return plot_series(s.geometry, colormap=colormap, axes=axes, linewidth=linewidth, figsize=figsize, **color_kwds)
+        return plot_series(s.geometry, colormap=colormap, ax=ax, linewidth=linewidth, figsize=figsize, **color_kwds)
     else:
         if s[column].dtype is np.dtype('O'):
             categorical = True
@@ -234,11 +232,9 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
             categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
                           for i in range(len(binedges)-1)]
         cmap = norm_cmap(values, colormap, Normalize, cm, vmin=vmin, vmax=vmax)
-        if axes is None:
+        if ax is None:
             fig, ax = plt.subplots(figsize=figsize)
             ax.set_aspect('equal')
-        else:
-            ax = axes
         for geom, value in zip(s.geometry, values):
             if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
                 plot_multipolygon(ax, geom, facecolor=cmap.to_rgba(value), linewidth=linewidth, **color_kwds)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -74,7 +74,7 @@ def gencolor(N, colormap='Set1'):
         yield colors[i % n_colors]
 
 
-def plot_series(s, colormap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kwds):
+def plot_series(s, cmap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kwds):
     """ Plot a GeoSeries
 
         Generate a plot of a GeoSeries geometry with matplotlib.
@@ -87,7 +87,7 @@ def plot_series(s, colormap='Set1', ax=None, linewidth=1.0, figsize=None, **colo
             MultiPolygon, LineString, MultiLineString and Point
             geometries can be plotted.
 
-        colormap : str (default 'Set1')
+        cmap : str (default 'Set1')
             The name of a colormap recognized by matplotlib.  Any
             colormap will work, but categorical colormaps are
             generally recommended.  Examples of useful discrete
@@ -117,7 +117,7 @@ def plot_series(s, colormap='Set1', ax=None, linewidth=1.0, figsize=None, **colo
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
-    color = gencolor(len(s), colormap=colormap)
+    color = gencolor(len(s), colormap=cmap)
     for geom in s:
         if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
             plot_multipolygon(ax, geom, facecolor=next(color), linewidth=linewidth, **color_kwds)
@@ -129,7 +129,7 @@ def plot_series(s, colormap='Set1', ax=None, linewidth=1.0, figsize=None, **colo
     return ax
 
 
-def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
+def plot_dataframe(s, column=None, cmap=None, linewidth=1.0,
                    categorical=False, legend=False, ax=None,
                    scheme=None, k=5, vmin=None, vmax=None, figsize=None,
                    **color_kwds
@@ -153,11 +153,11 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
             The name of the column to be plotted.
 
         categorical : bool (default False)
-            If False, colormap will reflect numerical values of the
+            If False, cmap will reflect numerical values of the
             column being plotted.  For non-numerical columns (or if
             column=None), this will be set to True.
 
-        colormap : str (default 'Set1')
+        cmap : str (default 'Set1')
             The name of a colormap recognized by matplotlib.
 
         linewidth : float (default 1.0)
@@ -184,12 +184,12 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
 
         vmin : None or float (default None)
 
-            Minimum value of colormap. If None, the minimum data value
+            Minimum value of cmap. If None, the minimum data value
             in the column to be plotted is used.
 
         vmax : None or float (default None)
 
-            Maximum value of colormap. If None, the maximum data value
+            Maximum value of cmap. If None, the maximum data value
             in the column to be plotted is used.
 
         figsize
@@ -210,13 +210,13 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
     from matplotlib import cm
 
     if column is None:
-        return plot_series(s.geometry, colormap=colormap, ax=ax, linewidth=linewidth, figsize=figsize, **color_kwds)
+        return plot_series(s.geometry, cmap=cmap, ax=ax, linewidth=linewidth, figsize=figsize, **color_kwds)
     else:
         if s[column].dtype is np.dtype('O'):
             categorical = True
         if categorical:
-            if colormap is None:
-                colormap = 'Set1'
+            if cmap is None:
+                cmap = 'Set1'
             categories = list(set(s[column].values))
             categories.sort()
             valuemap = dict([(k, v) for (v, k) in enumerate(categories)])
@@ -231,7 +231,7 @@ def plot_dataframe(s, column=None, colormap=None, linewidth=1.0,
             binedges = [binning.yb.min()] + binning.bins.tolist()
             categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
                           for i in range(len(binedges)-1)]
-        cmap = norm_cmap(values, colormap, Normalize, cm, vmin=vmin, vmax=vmax)
+        cmap = norm_cmap(values, cmap, Normalize, cm, vmin=vmin, vmax=vmax)
         if ax is None:
             fig, ax = plt.subplots(figsize=figsize)
             ax.set_aspect('equal')

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -103,7 +103,7 @@ class PlotTests(unittest.TestCase):
         df = GeoDataFrame({'geometry': polys, 'values': values})
 
         # Plot the GeoDataFrame using various keyword arguments to see if they are honoured
-        ax = df.plot(column='values', colormap=cm.RdBu, vmin=+2, vmax=None, figsize=(8, 4))
+        ax = df.plot(column='values', cmap=cm.RdBu, vmin=+2, vmax=None, figsize=(8, 4))
         self._compare_images(ax=ax, filename=filename)
 
 
@@ -121,7 +121,7 @@ class TestPySALPlotting(unittest.TestCase):
 
     def test_legend(self):
         ax = self.tracts.plot(column='CRIME', scheme='QUANTILES', k=3,
-                         colormap='OrRd', legend=True)
+                         cmap='OrRd', legend=True)
 
         labels = [t.get_text() for t in ax.get_legend().get_texts()]
         expected = [u'0.00 - 26.07', u'26.07 - 41.97', u'41.97 - 68.89']


### PR DESCRIPTION
This PR is an easy fix for #208 which replaces every instance of `axes` for `ax` and every `colormap` for `cmap` in the `plot_series` and `plot_dataframe` methods. This makes the plotting interface for geo objects much more inline with that of `pandas` for non-spatial plots. The PR includes an adaptation of the tests, and everything passes locally.