### PR TITLE
ENH: Fix facecolor conflict

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -110,7 +110,8 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
             ax is given explicitly, figsize is ignored.
 
         **color_kwds : dict
-            Color options to be passed on to plot_polygon
+            Color options to be passed on to plot_polygon, plot_linestring, or
+            plot_point
 
         Returns
         -------
@@ -137,11 +138,14 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
         else:
             col = color
         if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
-            plot_multipolygon(ax, geom, facecolor=col, linewidth=linewidth, **color_kwds)
+            if 'facecolor' in color_kwds:
+                plot_multipolygon(ax, geom, linewidth=linewidth, **color_kwds)
+            else:
+                plot_multipolygon(ax, geom, facecolor=col, linewidth=linewidth, **color_kwds)
         elif geom.type == 'LineString' or geom.type == 'MultiLineString':
-            plot_multilinestring(ax, geom, color=col, linewidth=linewidth)
+            plot_multilinestring(ax, geom, color=col, linewidth=linewidth, **color_kwds)
         elif geom.type == 'Point':
-            plot_point(ax, geom, color=col)
+            plot_point(ax, geom, color=col, **color_kwds)
     plt.draw()
     return ax
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -223,6 +223,15 @@ class TestPolygonPlotting(unittest.TestCase):
         cmap = get_cmap('Set1', 2)
         self.assertEqual(ax.patches[0].get_facecolor(), ax.patches[1].get_facecolor())
 
+    def test_facecolor(self):
+        t1 = Polygon([(0, 0), (1, 0), (1, 1)])
+        t2 = Polygon([(1, 0), (2, 0), (2, 1)])
+        polys = GeoSeries([t1, t2])
+        df = GeoDataFrame({'geometry': polys, 'values': [0, 1]})
+
+        ax = polys.plot(facecolor='k')
+        _check_colors(ax.patches, ['k']*2, alpha=0.5)
+
 
 class TestPySALPlotting(unittest.TestCase):
 


### PR DESCRIPTION
This PR fixes the problem mentioned in Issue #204 where one cannot pass a fixed color to `plot_series` or `plot_dataframe`. Before the PR, the following line:

```python
df.plot(facecolor='white')
```

Returns the error that `facecolor` is referenced twice. This is solved with the patch.

In addition, the patch also allows related problems also mentioned in the issue, where arguments for `plot_linestring` and `plot_point` are not passed properly.

After the patch, all the tests continue passing locally.