### PR TITLE
ENH: plot with single colors

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -49,10 +49,9 @@ def plot_multilinestring(ax, geom, color='red', linewidth=1.0):
             plot_linestring(ax, line, color=color, linewidth=linewidth)
 
 
-def plot_point(ax, pt, marker='o', markersize=2, color="black"):
+def plot_point(ax, pt, marker='o', markersize=2, color='black'):
     """ Plot a single Point geometry """
-    ax.plot(pt.x, pt.y, marker=marker, markersize=markersize, linewidth=0,
-            color=color)
+    ax.plot(pt.x, pt.y, marker=marker, markersize=markersize, color=color)
 
 
 def gencolor(N, colormap='Set1'):
@@ -75,7 +74,8 @@ def gencolor(N, colormap='Set1'):
         yield colors[i % n_colors]
 
 
-def plot_series(s, cmap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kwds):
+def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
+                figsize=None, **color_kwds):
     """ Plot a GeoSeries
 
         Generate a plot of a GeoSeries geometry with matplotlib.
@@ -95,6 +95,9 @@ def plot_series(s, cmap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kw
             colormaps include:
 
                 Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
+
+        color : str (default None)
+            If specified, all objects will be colored uniformly.
 
         ax : matplotlib.pyplot.Artist (default None)
             axes on which to draw the plot
@@ -127,23 +130,26 @@ def plot_series(s, cmap='Set1', ax=None, linewidth=1.0, figsize=None, **color_kw
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
-    color = gencolor(len(s), colormap=cmap)
+    color_generator = gencolor(len(s), colormap=cmap)
     for geom in s:
+        if color is None:
+            col = next(color_generator)
+        else:
+            col = color
         if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
-            plot_multipolygon(ax, geom, facecolor=next(color), linewidth=linewidth, **color_kwds)
+            plot_multipolygon(ax, geom, facecolor=col, linewidth=linewidth, **color_kwds)
         elif geom.type == 'LineString' or geom.type == 'MultiLineString':
-            plot_multilinestring(ax, geom, color=next(color), linewidth=linewidth)
+            plot_multilinestring(ax, geom, color=col, linewidth=linewidth)
         elif geom.type == 'Point':
-            plot_point(ax, geom, color=next(color))
+            plot_point(ax, geom, color=col)
     plt.draw()
     return ax
 
 
-def plot_dataframe(s, column=None, cmap=None, linewidth=1.0,
+def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
                    categorical=False, legend=False, ax=None,
                    scheme=None, k=5, vmin=None, vmax=None, figsize=None,
-                   **color_kwds
-                   ):
+                   **color_kwds):
     """ Plot a GeoDataFrame
 
         Generate a plot of a GeoDataFrame with matplotlib.  If a
@@ -169,6 +175,9 @@ def plot_dataframe(s, column=None, cmap=None, linewidth=1.0,
 
         cmap : str (default 'Set1')
             The name of a colormap recognized by matplotlib.
+
+        color : str (default None)
+            If specified, all objects will be colored uniformly.
 
         linewidth : float (default 1.0)
             Line width for geometries.
@@ -229,7 +238,9 @@ def plot_dataframe(s, column=None, cmap=None, linewidth=1.0,
     from matplotlib import cm
 
     if column is None:
-        return plot_series(s.geometry, cmap=cmap, ax=ax, linewidth=linewidth, figsize=figsize, **color_kwds)
+        return plot_series(s.geometry, cmap=cmap, color=color,
+                           ax=ax, linewidth=linewidth, figsize=figsize,
+                           **color_kwds)
     else:
         if s[column].dtype is np.dtype('O'):
             categorical = True
@@ -255,12 +266,16 @@ def plot_dataframe(s, column=None, cmap=None, linewidth=1.0,
             fig, ax = plt.subplots(figsize=figsize)
             ax.set_aspect('equal')
         for geom, value in zip(s.geometry, values):
+            if color is None:
+                col = cmap.to_rgba(value)
+            else:
+                col = color
             if geom.type == 'Polygon' or geom.type == 'MultiPolygon':
-                plot_multipolygon(ax, geom, facecolor=cmap.to_rgba(value), linewidth=linewidth, **color_kwds)
+                plot_multipolygon(ax, geom, facecolor=col, linewidth=linewidth, **color_kwds)
             elif geom.type == 'LineString' or geom.type == 'MultiLineString':
-                plot_multilinestring(ax, geom, color=cmap.to_rgba(value), linewidth=linewidth)
+                plot_multilinestring(ax, geom, color=col, linewidth=linewidth)
             elif geom.type == 'Point':
-                plot_point(ax, geom, color=cmap.to_rgba(value))
+                plot_point(ax, geom, color=col)
         if legend:
             if categorical:
                 patches = []


### PR DESCRIPTION
Add the ability to specify `color` in `plot()` to plot all points/lines/polygons in a single color.

You can see it at work in this notebook: http://nbviewer.ipython.org/gist/jorisvandenbossche/47e6d587eec39a8357f0#