### PR TITLE
Revive readthedocs build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 QUALIFIER = ''
+if os.environ.get('READTHEDOCS', False) == 'True':
+    INSTALL_REQUIRES = []
+else:
+    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'descartes', 'pyproj']
 
 FULLVERSION = VERSION
 if not ISRELEASED:
@@ -86,4 +90,4 @@ setup(name='geopandas',
       url='http://geopandas.org',
       long_description=LONG_DESCRIPTION,
       packages=['geopandas', 'geopandas.io', 'geopandas.tools'],
-      install_requires=['pandas', 'shapely', 'fiona', 'descartes', 'pyproj'])
+      install_requires=INSTALL_REQUIRES)


### PR DESCRIPTION
Let's get the RTD build working again.

This skips installing requirements when installing on readthedocs. Otherwise it fails on the binary libraries. I did try mocking out the libraries instead of skipping them, as listed [here](http://docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules), but that didn't work for me (I must be doing something wrong).

Link for the build associated with this branch: http://geopandas.readthedocs.org/en/doc-readthedocs-requirements