### PR TITLE
Travis: "Matrix" Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,41 @@ addons:
     - libgdal-dev
     - libspatialindex-dev
 
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-
 env:
-  matrix:
-    - PANDAS_VERSION=0.15.2
-    - PANDAS_VERSION=master
-    - PANDAS_VERSION=0.16.2
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
+  
+# matrix creates 3+4x2 = 11 tests
+matrix:
+  include:
+    # Only one test for these Python versions
+    - python: 2.6
+      env: PANDAS_VERSION=0.15.2
+    - python: 3.3
+      env: PANDAS_VERSION=0.16.2
+    - python: 3.4
+      env: PANDAS_VERSION=0.17.1
+
+    # Python 2.7 and 3.5 test all supported Pandas versions
+    - python: 2.7
+      env: PANDAS_VERSION=0.15.2
+    - python: 2.7
+      env: PANDAS_VERSION=0.16.2
+    - python: 2.7
+      env: PANDAS_VERSION=0.17.1
+    - python: 2.7
+      env: PANDAS_VERSION=master
+      
+    - python: 3.5
+      env: PANDAS_VERSION=0.15.2
+    - python: 3.5
+      env: PANDAS_VERSION=0.16.2
+    - python: 3.5
+      env: PANDAS_VERSION=0.17.1
+    - python: 3.5
+      env: PANDAS_VERSION=master
+  
 
 before_install:
   - pip install -U pip


### PR DESCRIPTION
This is not the most beautiful way to change the Travis builds, but it is an attempt at resolving issues raised in PR #243 and Issue #271.  

This results in 11 test and removes the test combinations aspect of the matrix.  Eight (8) tests focused on testing Python 2.7 and 3.5 with many versions of Pandas.

I did not attempt to add multiple versions of matplotlib to the travis tests.  (I've made a similar travis test "suite" for basemap.) I'm not trying to avoid doing that, but I am trying to make sure that this is acceptable before spending too much time on it.