### PR TITLE
Travis:Test different versions of matplotlib

### DIFF
--- a/.requirements-2.6.txt
+++ b/.requirements-2.6.txt
@@ -1,2 +1,0 @@
-unittest2
-ordereddict

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,35 +19,45 @@ env:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
   
-# matrix creates 3+4x2 = 11 tests
+# matrix creates 3+5x2 = 13 tests
 matrix:
   include:
     # Only one test for these Python versions
+    # Pandas >= 0.18.0, is not Python 2.6 compatible
     - python: 2.6
-      env: PANDAS_VERSION=0.15.2
+      env: PANDAS=0.16.2 MATPLOTLIB=1.2.1
     - python: 3.3
-      env: PANDAS_VERSION=0.16.2
+      env: PANDAS=0.17.1 MATPLOTLIB=1.3.1
     - python: 3.4
-      env: PANDAS_VERSION=0.17.1
+      env: PANDAS=0.18.0 MATPLOTLIB=1.5.1
 
     # Python 2.7 and 3.5 test all supported Pandas versions
     - python: 2.7
-      env: PANDAS_VERSION=0.15.2
+      env: PANDAS=0.15.2  MATPLOTLIB=1.2.1
     - python: 2.7
-      env: PANDAS_VERSION=0.16.2
+      env: PANDAS=0.16.2  MATPLOTLIB=1.3.1
     - python: 2.7
-      env: PANDAS_VERSION=0.17.1
+      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
     - python: 2.7
-      env: PANDAS_VERSION=master
-      
+      env: PANDAS=0.18.0  MATPLOTLIB=1.5.1
+    - python: 2.7
+      env: PANDAS=master  MATPLOTLIB=master
+
+    # Note: Python 3.5 and matplotlib versions before 1.4.3 support is hit or miss.
     - python: 3.5
-      env: PANDAS_VERSION=0.15.2
+      env: PANDAS=0.15.2  MATPLOTLIB=1.4.3
     - python: 3.5
-      env: PANDAS_VERSION=0.16.2
+      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3
     - python: 3.5
-      env: PANDAS_VERSION=0.17.1
+      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
     - python: 3.5
-      env: PANDAS_VERSION=master
+      env: PANDAS=0.18.0  MATPLOTLIB=1.5.1
+    - python: 3.5
+      env: PANDAS=master  MATPLOTLIB=master
+
+  # matplotlib 2.x (development version) causes a few tests to fail
+  allow_failures:
+    - env: PANDAS=master  MATPLOTLIB=master
   
 
 before_install:
@@ -60,12 +70,12 @@ install:
   - pip wheel -r requirements.test.txt
 
   - pip install numpy
+  - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; else pip wheel matplotlib==$MATPLOTLIB; pip install matplotlib==$MATPLOTLIB; fi
+
   - pip install -r requirements.txt
   - pip install -r requirements.test.txt
 
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r .requirements-2.6.txt; fi
-
-  - if [[ $PANDAS_VERSION == 'master' ]]; then git clone git://github.com/pydata/pandas.git; cd pandas; pip install -e .; cd ..  ; else pip wheel pandas==$PANDAS_VERSION; pip install pandas==$PANDAS_VERSION; fi
+  - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; else pip wheel pandas==$PANDAS; pip install pandas==$PANDAS; fi
 
 script:
   - py.test tests --cov geopandas -v --cov-report term-missing

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ shapely>=1.2.18
 fiona>=1.0.1
 pyproj>=1.9.3
 six>=1.3.0
+# for Python 2.6 (environment marker support as of pip 6.0)
+unittest2 ; python_version < '2.7'
+ordereddict ; python_version < '2.7'


### PR DESCRIPTION
matplotlib testing was proposed in PR #243.   Add Pandas 0.18.0 to testing.  Have one requirements.txt file for all versions (remove .requirements-2.6.txt).  Allow MATPLOTLIB=master tests
to fail (which a few of the tests currently fail).