### PR TITLE
Test pandas 0.18 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
     - python: 2.7
       env: PANDAS_VERSION=0.17.1
     - python: 2.7
+      env: PANDAS_VERSION=0.18.0
+    - python: 2.7
       env: PANDAS_VERSION=master
       
     - python: 3.5
@@ -46,6 +48,8 @@ matrix:
       env: PANDAS_VERSION=0.16.2
     - python: 3.5
       env: PANDAS_VERSION=0.17.1
+    - python: 2.7
+      env: PANDAS_VERSION=0.18.0
     - python: 3.5
       env: PANDAS_VERSION=master
   


### PR DESCRIPTION
Add the [pandas 0.18 release](http://pandas.pydata.org/pandas-docs/version/0.18.0/whatsnew.html#v0-18-0-march-13-2016) to the test matrix (for python 2.7 and 3.5 only).