### PR TITLE
Universal Python Wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
... has the potential to make geopandas slightly easier to install.  Since geopandas itself it pure python, this should be an extra step during release: `python setup.py sdist bdist_wheel upload`

See: http://pythonwheels.com/