### PR TITLE
make crs more flexible

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -350,6 +350,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         joining points are assumed to be lines in the current
         projection, not geodesics.  Objects crossing the dateline (or
         other projection boundary) will have undesirable behavior.
+
+        `to_crs` passes the `crs` argument to the `Proj` function from the
+        `pyproj` library (with the option `preserve_units=True`). It can
+        therefore accept proj4 projections in any format
+        supported by `Proj`, including dictionaries, or proj4 strings.
+
         """
         if inplace:
             df = self

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -264,8 +264,8 @@ class GeoSeries(GeoPandasBase, Series):
                 crs = from_epsg(epsg)
             except TypeError:
                 raise TypeError('Must set either crs or epsg for output.')
-        proj_in = pyproj.Proj(preserve_units=True, **self.crs)
-        proj_out = pyproj.Proj(preserve_units=True, **crs)
+        proj_in = pyproj.Proj(self.crs, preserve_units=True)
+        proj_out = pyproj.Proj(crs, preserve_units=True)
         project = partial(pyproj.transform, proj_in, proj_out)
         result = self.apply(lambda geom: transform(project, geom))
         result.__class__ = GeoSeries

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -254,6 +254,12 @@ class GeoSeries(GeoPandasBase, Series):
         joining points are assumed to be lines in the current
         projection, not geodesics.  Objects crossing the dateline (or
         other projection boundary) will have undesirable behavior.
+
+        `to_crs` passes the `crs` argument to the `Proj` function from the
+        `pyproj` library (with the option `preserve_units=True`). It can
+        therefore accept proj4 projections in any format
+        supported by `Proj`, including dictionaries, or proj4 strings.
+
         """
         from fiona.crs import from_epsg
         if self.crs is None:

--- a/tests/test_geoseries.py
+++ b/tests/test_geoseries.py
@@ -151,5 +151,24 @@ class TestSeries(unittest.TestCase):
         self.assertEqual(len(self.g1.__geo_interface__['features']),
                          self.g1.shape[0])
 
+    def test_proj4strings(self):
+
+        # As string
+        reprojected = self.g3.to_crs('+proj=utm +zone=30N')
+        reprojected_back = reprojected.to_crs(epsg=4326)
+        self.assertTrue(np.alltrue(self.g3.geom_almost_equals(reprojected_back)))
+
+        # As dict
+        reprojected = self.g3.to_crs({'proj': 'utm', 'zone': '30N'})
+        reprojected_back = reprojected.to_crs(epsg=4326)
+        self.assertTrue(np.alltrue(self.g3.geom_almost_equals(reprojected_back)))
+
+        # Set to equivalent string, convert, compare to original
+        copy = self.g3.copy()
+        copy.crs = '+init=epsg:4326'
+        reprojected = copy.to_crs({'proj': 'utm', 'zone': '30N'})
+        reprojected_back = reprojected.to_crs(epsg=4326)
+        self.assertTrue(np.alltrue(self.g3.geom_almost_equals(reprojected_back)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_geoseries.py
+++ b/tests/test_geoseries.py
@@ -152,7 +152,6 @@ class TestSeries(unittest.TestCase):
                          self.g1.shape[0])
 
     def test_proj4strings(self):
-
         # As string
         reprojected = self.g3.to_crs('+proj=utm +zone=30N')
         reprojected_back = reprojected.to_crs(epsg=4326)
@@ -169,6 +168,11 @@ class TestSeries(unittest.TestCase):
         reprojected = copy.to_crs({'proj': 'utm', 'zone': '30N'})
         reprojected_back = reprojected.to_crs(epsg=4326)
         self.assertTrue(np.alltrue(self.g3.geom_almost_equals(reprojected_back)))
+
+        # Conversions by different format
+        reprojected_string = self.g3.to_crs('+proj=utm +zone=30N')
+        reprojected_dict = self.g3.to_crs({'proj': 'utm', 'zone': '30N'})
+        self.assertTrue(np.alltrue(reprojected_string.geom_almost_equals(reprojected_dict)))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Right now, the CRS tools won't accept a proj4 string -- it requires they be broken out into a dictionary. But behind the scenes is the pyproj library which can parse proj4 strings. This just adjusts the call to pyproj slightly so `to_crs()` can take proj4 strings in addition to full dictionaries. Dictionaries still work!