### PR TITLE
DOC: add readthedocs yaml config file + use conda for doc deps

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,0 +1,16 @@
+name: geopandas_docs
+channels:
+- conda-forge
+dependencies:
+- python=3.4
+- pandas
+- shapely
+- fiona
+- pyproj
+- six
+- geopy
+- matplotlib
+- descartes
+- sphinx
+- sphinx_rtd_theme
+- ipython

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - descartes
 - sphinx
 - sphinx_rtd_theme
-- ipython
+- ipython=4.0.1

--- a/doc/source/data_structures.rst
+++ b/doc/source/data_structures.rst
@@ -4,7 +4,7 @@
    :suppress:
 
    import geopandas as gpd
-   world = gpd.GeoDataFrame().from_file('source/_example_data/naturalearth_lowres.shp')
+   world = gpd.GeoDataFrame().from_file('_example_data/naturalearth_lowres.shp')
    world = world.rename(columns={'geometry': 'borders'}).set_geometry('borders')
 
 Data Structures

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -4,7 +4,7 @@
    :suppress:
 
    import geopandas as gpd
-   world = gpd.GeoDataFrame().from_file('source/_example_data/naturalearth_lowres.shp')
+   world = gpd.GeoDataFrame().from_file('_example_data/naturalearth_lowres.shp')
 
 
 
@@ -18,7 +18,7 @@ Chloropleth Maps
 -----------------
 
 .. ipython:: python
-    
+
     # Examine country GeoDataFrame
     world.head()
 

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -4,7 +4,7 @@
    :suppress:
 
    import geopandas as gpd
-   world = gpd.GeoDataFrame().from_file('source/_example_data/naturalearth_lowres.shp')
+   world = gpd.GeoDataFrame().from_file('_example_data/naturalearth_lowres.shp')
 
 
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+conda:
+    file: doc/environment.yml
+python:
+    version: 3
+    setup_py_install: true

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,2 +1,0 @@
-sphinx_rtd_theme
-ipython


### PR DESCRIPTION
Starting with #283 PR from @nickeubank, the docs require a usable installed version of geopandas, because the examples are being built at doc build runtime. Installing these dependencies on read the docs is not done at the moment, and was also somewhat problematic, but they recently added conda support: http://docs.readthedocs.org/en/latest/conda.html

This PR adds therefore a readthedocs.yml config file and a conda environment file for installing all doc dependencies on read the docs using conda. 
This is currently working: http://readthedocs.org/projects/geopandas/builds/3894807/, only the docs are not yet fully correct because the example data used in the docs are not available in the installed version (but will open a separate issue for that): http://geopandas.readthedocs.org/en/doc-readthedocs-requirements/index.html

@kjordahl 