### PR TITLE
moved docs for plotting to more accessible location

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -435,6 +435,54 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return GeoDataFrame(data).__finalize__(self)
 
     def plot(self, *args, **kwargs):
+        """ Plot a GeoDataFrame
+        Generate a plot of a GeoDataFrame with matplotlib.  If a
+        column is specified, the plot coloring will be based on values
+        in that column.  Otherwise, a categorical plot of the
+        geometries in the `geometry` column will be generated.
+        Parameters
+        ----------
+        GeoDataFrame
+            The GeoDataFrame to be plotted.  Currently Polygon,
+            MultiPolygon, LineString, MultiLineString and Point
+            geometries can be plotted.
+        column : str (default None)
+            The name of the column to be plotted.
+        categorical : bool (default False)
+            If False, cmap will reflect numerical values of the
+            column being plotted.  For non-numerical columns (or if
+            column=None), this will be set to True.
+        cmap : str (default 'Set1')
+            The name of a colormap recognized by matplotlib.
+        color : str (default None)
+            If specified, all objects will be colored uniformly.
+        linewidth : float (default 1.0)
+            Line width for geometries.
+        legend : bool (default False)
+            Plot a legend (Experimental; currently for categorical
+            plots only)
+        ax : matplotlib.pyplot.Artist (default None)
+            axes on which to draw the plot
+        scheme : pysal.esda.mapclassify.Map_Classifier
+            Choropleth classification schemes (requires PySAL)
+        k   : int (default 5)
+            Number of classes (ignored if scheme is None)
+        vmin : None or float (default None)
+            Minimum value of cmap. If None, the minimum data value
+            in the column to be plotted is used.
+        vmax : None or float (default None)
+            Maximum value of cmap. If None, the maximum data value
+            in the column to be plotted is used.
+        figsize
+            Size of the resulting matplotlib.figure.Figure. If the argument
+            axes is given explicitly, figsize is ignored.
+        **color_kwds : dict
+            Color options to be passed on to the actual plot function
+        Returns
+        -------
+        matplotlib axes instance
+        """
+
         return plot_dataframe(self, *args, **kwargs)
 
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -435,55 +435,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return GeoDataFrame(data).__finalize__(self)
 
     def plot(self, *args, **kwargs):
-        """ Plot a GeoDataFrame
-        Generate a plot of a GeoDataFrame with matplotlib.  If a
-        column is specified, the plot coloring will be based on values
-        in that column.  Otherwise, a categorical plot of the
-        geometries in the `geometry` column will be generated.
-        Parameters
-        ----------
-        GeoDataFrame
-            The GeoDataFrame to be plotted.  Currently Polygon,
-            MultiPolygon, LineString, MultiLineString and Point
-            geometries can be plotted.
-        column : str (default None)
-            The name of the column to be plotted.
-        categorical : bool (default False)
-            If False, cmap will reflect numerical values of the
-            column being plotted.  For non-numerical columns (or if
-            column=None), this will be set to True.
-        cmap : str (default 'Set1')
-            The name of a colormap recognized by matplotlib.
-        color : str (default None)
-            If specified, all objects will be colored uniformly.
-        linewidth : float (default 1.0)
-            Line width for geometries.
-        legend : bool (default False)
-            Plot a legend (Experimental; currently for categorical
-            plots only)
-        ax : matplotlib.pyplot.Artist (default None)
-            axes on which to draw the plot
-        scheme : pysal.esda.mapclassify.Map_Classifier
-            Choropleth classification schemes (requires PySAL)
-        k   : int (default 5)
-            Number of classes (ignored if scheme is None)
-        vmin : None or float (default None)
-            Minimum value of cmap. If None, the minimum data value
-            in the column to be plotted is used.
-        vmax : None or float (default None)
-            Maximum value of cmap. If None, the maximum data value
-            in the column to be plotted is used.
-        figsize
-            Size of the resulting matplotlib.figure.Figure. If the argument
-            axes is given explicitly, figsize is ignored.
-        **color_kwds : dict
-            Color options to be passed on to the actual plot function
-        Returns
-        -------
-        matplotlib axes instance
-        """
 
         return plot_dataframe(self, *args, **kwargs)
+
+    plot.__doc__ = plot_dataframe.__doc__
 
 
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -239,40 +239,10 @@ class GeoSeries(GeoPandasBase, Series):
         else:
             return False
 
-
     def plot(self, *args, **kwargs):
-
-        """ Plot a GeoSeries
-        Generate a plot of a GeoSeries geometry with matplotlib.
-        Parameters
-        ----------
-        Series
-            The GeoSeries to be plotted.  Currently Polygon,
-            MultiPolygon, LineString, MultiLineString and Point
-            geometries can be plotted.
-        cmap : str (default 'Set1')
-            The name of a colormap recognized by matplotlib.  Any
-            colormap will work, but categorical colormaps are
-            generally recommended.  Examples of useful discrete
-            colormaps include:
-                Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
-        color : str (default None)
-            If specified, all objects will be colored uniformly.
-        ax : matplotlib.pyplot.Artist (default None)
-            axes on which to draw the plot
-        linewidth : float (default 1.0)
-            Line width for geometries.
-        figsize : pair of floats (default None)
-            Size of the resulting matplotlib.figure.Figure. If the argument
-            ax is given explicitly, figsize is ignored.
-        **color_kwds : dict
-            Color options to be passed on to the actual plot function
-        Returns
-        -------
-        matplotlib axes instance
-        """
-
         return plot_series(self, *args, **kwargs)
+    
+    plot.__doc__ = plot_series.__doc__
 
     #
     # Additional methods

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -241,6 +241,37 @@ class GeoSeries(GeoPandasBase, Series):
 
 
     def plot(self, *args, **kwargs):
+
+        """ Plot a GeoSeries
+        Generate a plot of a GeoSeries geometry with matplotlib.
+        Parameters
+        ----------
+        Series
+            The GeoSeries to be plotted.  Currently Polygon,
+            MultiPolygon, LineString, MultiLineString and Point
+            geometries can be plotted.
+        cmap : str (default 'Set1')
+            The name of a colormap recognized by matplotlib.  Any
+            colormap will work, but categorical colormaps are
+            generally recommended.  Examples of useful discrete
+            colormaps include:
+                Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
+        color : str (default None)
+            If specified, all objects will be colored uniformly.
+        ax : matplotlib.pyplot.Artist (default None)
+            axes on which to draw the plot
+        linewidth : float (default 1.0)
+            Line width for geometries.
+        figsize : pair of floats (default None)
+            Size of the resulting matplotlib.figure.Figure. If the argument
+            ax is given explicitly, figsize is ignored.
+        **color_kwds : dict
+            Color options to be passed on to the actual plot function
+        Returns
+        -------
+        matplotlib axes instance
+        """
+
         return plot_series(self, *args, **kwargs)
 
     #


### PR DESCRIPTION
Closes #264

Doc strings for plotting were not accessible to the user. This moves them up to associate them with the appropriate methods. 