### PR TITLE
ENH: Add error checking to CRS; framework for future improvements

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -92,15 +92,15 @@ class GeoSeries(GeoPandasBase, Series):
         # (like " +units=m +init=epsg:4328 +proj=geocent
         # +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
         # (https://github.com/jswhit/pyproj/pull/78)
-        # if value is not None:
-        #     try:
-        #         pyproj.Proj(value, preserve_units=True)
-        #     except:
-        #         try:
-        #             from fiona.crs import from_epsg
-        #             pyproj.Proj(from_epsg(value), preserve_units=True)
-        #         except:
-        #             raise ValueError("Not valid CRS")
+        if value is not None:
+            try:
+                pyproj.Proj(value, preserve_units=True)
+            except:
+                try:
+                    from fiona.crs import from_epsg
+                    pyproj.Proj(from_epsg(value), preserve_units=True)
+                except:
+                    raise ValueError("Not valid CRS")
 
         self._crs = value
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -54,11 +54,11 @@ class TestDataFrame(unittest.TestCase):
         self.assertEqual(df._geometry_column_name, 'location')
 
         geom2 = [Point(x, y) for x, y in zip(range(5, 10), range(5))]
-        df2 = df.set_geometry(geom2, crs='dummy_crs')
+        df2 = df.set_geometry(geom2, crs='4326')
         self.assert_('geometry' in df2)
         self.assert_('location' in df2)
-        self.assertEqual(df2.crs, 'dummy_crs')
-        self.assertEqual(df2.geometry.crs, 'dummy_crs')
+        self.assertEqual(df2.crs, '4326')
+        self.assertEqual(df2.geometry.crs, '4326')
         # reset so it outputs okay
         df2.crs = df.crs
         assert_geoseries_equal(df2.geometry, GeoSeries(geom2, crs=df2.crs))
@@ -99,9 +99,9 @@ class TestDataFrame(unittest.TestCase):
         assert_geoseries_equal(df['geometry'], new_geom)
 
         # new crs
-        gs = GeoSeries(new_geom, crs="epsg:26018")
+        gs = GeoSeries(new_geom, crs="3975")
         df.geometry = gs
-        self.assertEqual(df.crs, "epsg:26018")
+        self.assertEqual(df.crs, "3975")
 
     def test_geometry_property_errors(self):
         with self.assertRaises(AttributeError):
@@ -152,14 +152,14 @@ class TestDataFrame(unittest.TestCase):
             self.df.set_geometry(self.df)
 
         # new crs - setting should default to GeoSeries' crs
-        gs = GeoSeries(geom, crs="epsg:26018")
+        gs = GeoSeries(geom, crs="2263")
         new_df = self.df.set_geometry(gs)
-        self.assertEqual(new_df.crs, "epsg:26018")
+        self.assertEqual(new_df.crs, "2263")
 
         # explicit crs overrides self and dataframe
-        new_df = self.df.set_geometry(gs, crs="epsg:27159")
-        self.assertEqual(new_df.crs, "epsg:27159")
-        self.assertEqual(new_df.geometry.crs, "epsg:27159")
+        new_df = self.df.set_geometry(gs, crs="4326")
+        self.assertEqual(new_df.crs, "4326")
+        self.assertEqual(new_df.geometry.crs, "4326")
 
         # Series should use dataframe's
         new_df = self.df.set_geometry(geom.values)
@@ -332,7 +332,7 @@ class TestDataFrame(unittest.TestCase):
         """
         Ensure that the file is written according to the schema
         if it is specified
-        
+
         """
         try:
             from collections import OrderedDict

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -180,12 +180,15 @@ class TestSeries(unittest.TestCase):
         reprojected_dict = self.g3.to_crs({'proj': 'utm', 'zone': '30N'})
         self.assertTrue(np.alltrue(reprojected_string.geom_almost_equals(reprojected_dict)))
 
-    # def test_proj4errorchecking(self):
-    #     t1 = Polygon([(0, 0), (1, 0), (1, 1)])
-    #     sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-    #     g1 = GeoSeries([t1, sq])
-    #     with self.assertRaises(ValueError):
-    #         g1.crs = 'jibberish'
+    def test_proj4errorchecking(self):
+        t1 = Polygon([(0, 0), (1, 0), (1, 1)])
+        sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        g1 = GeoSeries([t1, sq])
+        with self.assertRaises(ValueError):
+            g1.crs = 'jibberish'
+
+        with self.assertRaises(ValueError):
+            g1.crs = '+init=epsg:9999999'
 
 
 if __name__ == '__main__':

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -180,5 +180,13 @@ class TestSeries(unittest.TestCase):
         reprojected_dict = self.g3.to_crs({'proj': 'utm', 'zone': '30N'})
         self.assertTrue(np.alltrue(reprojected_string.geom_almost_equals(reprojected_dict)))
 
+    # def test_proj4errorchecking(self):
+    #     t1 = Polygon([(0, 0), (1, 0), (1, 1)])
+    #     sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    #     g1 = GeoSeries([t1, sq])
+    #     with self.assertRaises(ValueError):
+    #         g1.crs = 'jibberish'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, CRS validity isn't checked unless a user attempts to use `to_crs`. This way it's checked when run.

In addition, if https://github.com/jswhit/pyproj/pull/78 gets integrated, this offers scaffolding to convert all CRS strings to informative CRS strings, so if someone uses an EPSG code, the CRS will be converted to a string with actual parameters. 

@micahcochran Here's my interest in keeping `pyproj` #315 

(as evidence of value, note several updates to tests with improper syntax!)
