### PR TITLE
DOC: update minimum pandas version in install docs

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -20,9 +20,7 @@ You may install the latest development version by cloning the
     pip install .
 
 It is also possible to install the latest development version
-available on PyPI with `pip` by adding the ``--pre`` flag for pip 1.4
-and later, or to use `pip` to install directly from the GitHub
-repository with::
+directly from the GitHub repository with::
 
     pip install git+git://github.com/geopandas/geopandas.git
 
@@ -32,7 +30,7 @@ Dependencies
 Installation via `conda` should also install all dependencies, but a complete list is as follows:
 
 - `numpy`_
-- `pandas`_ (version 0.13 or later)
+- `pandas`_ (version 0.15.2 or later)
 - `shapely`_
 - `fiona`_
 - `six`_


### PR DESCRIPTION
Updated the version to the minimum one we are using in the tests (older version we cannot (and do not want) guarantee I think since we are not testing those).

(also removed a notion of the `--pre` tag, as I don't think development versions are uploaded to PyPI