### PR TITLE
DOC: add rtree and pysal to doc requirements

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -7,10 +7,12 @@ dependencies:
 - shapely
 - fiona
 - pyproj
+- rtree
 - six
 - geopy
 - matplotlib
 - descartes
+- pysal
 - sphinx
 - sphinx_rtd_theme
 - ipython=4.0.1


### PR DESCRIPTION
Needed for new mapping and merging docs (currently the build was failing on readthedocs)