### PR TITLE
Fix for issue 251 

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -47,8 +47,8 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                 .apply(lambda x: list(tree_idx.intersection(x))))
     idxmatch = idxmatch[idxmatch.apply(len) > 0]
 
-    if idxmatch.shape[0]>0: # if output from  join has overlapping geometries
-
+    if idxmatch.shape[0] > 0:
+        # if output from  join has overlapping geometries
         r_idx = np.concatenate(idxmatch.values)
         l_idx = np.concatenate([[i] * len(v) for i, v in idxmatch.iteritems()])
 
@@ -83,7 +83,8 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                   .drop('match_bool', axis=1)
                   )
 
-    else: # when output from the join has no overlapping geometries
+    else:
+        # when output from the join has no overlapping geometries
         result = pd.DataFrame(columns=['index_%s' % lsuffix, 'index_%s' % rsuffix])
 
     if op == "within":

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -47,39 +47,44 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                 .apply(lambda x: list(tree_idx.intersection(x))))
     idxmatch = idxmatch[idxmatch.apply(len) > 0]
 
-    r_idx = np.concatenate(idxmatch.values)
-    l_idx = np.concatenate([[i] * len(v) for i, v in idxmatch.iteritems()])
+    if idxmatch.shape[0]>0: # if output from  join has overlapping geometries
 
-    # Vectorize predicate operations
-    def find_intersects(a1, a2):
-        return a1.intersects(a2)
+        r_idx = np.concatenate(idxmatch.values)
+        l_idx = np.concatenate([[i] * len(v) for i, v in idxmatch.iteritems()])
 
-    def find_contains(a1, a2):
-        return a1.contains(a2)
+        # Vectorize predicate operations
+        def find_intersects(a1, a2):
+            return a1.intersects(a2)
 
-    predicate_d = {'intersects': find_intersects,
-                   'contains': find_contains,
-                   'within': find_contains}
+        def find_contains(a1, a2):
+            return a1.contains(a2)
 
-    check_predicates = np.vectorize(predicate_d[op])
+        predicate_d = {'intersects': find_intersects,
+                       'contains': find_contains,
+                       'within': find_contains}
 
-    result = (
-              pd.DataFrame(
-                  np.column_stack(
-                      [l_idx,
-                       r_idx,
-                       check_predicates(
-                           left_df['geometry']
-                           .apply(lambda x: prepared.prep(x))[l_idx],
-                           right_df['geometry'][r_idx])
-                       ]))
-               )
+        check_predicates = np.vectorize(predicate_d[op])
 
-    result.columns = ['index_%s' % lsuffix, 'index_%s' % rsuffix, 'match_bool']
-    result = (
-              pd.DataFrame(result[result['match_bool']==1])
-              .drop('match_bool', axis=1)
-              )
+        result = (
+                  pd.DataFrame(
+                      np.column_stack(
+                          [l_idx,
+                           r_idx,
+                           check_predicates(
+                               left_df['geometry']
+                               .apply(lambda x: prepared.prep(x))[l_idx],
+                               right_df['geometry'][r_idx])
+                           ]))
+                   )
+
+        result.columns = ['index_%s' % lsuffix, 'index_%s' % rsuffix, 'match_bool']
+        result = (
+                  pd.DataFrame(result[result['match_bool']==1])
+                  .drop('match_bool', axis=1)
+                  )
+
+    else: # when output from the join has no overlapping geometries
+        result = pd.DataFrame(columns=['index_%s' % lsuffix, 'index_%s' % rsuffix])
 
     if op == "within":
         # within implemented as the inverse of contains; swap names

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -95,9 +95,14 @@ class TestSpatialJoin(unittest.TestCase):
         df_left = sjoin(self.pointdf.iloc[17:], self.polydf, how='left')
         df_right = sjoin(self.pointdf.iloc[17:], self.polydf, how='right')
 
+        # Recent Pandas development has introduced a new way of handling merges
+        # this change has altered the output when no overlapping geometries
+        if str(pd.__version__) > LooseVersion('0.18.1'):
+            right_idxs = pd.Series(name='index_right',dtype='int64', index=range(0,5))
+        else:
+            right_idxs = pd.Series(name='index_right',dtype='int64')
 
-        empty_result_df = pd.concat([pd.Series(name='index_left',dtype='int64'),
-                                     pd.Series(name='index_right',dtype='int64')],axis=1)
+        empty_result_df = pd.concat([pd.Series(name='index_left',dtype='int64'), right_idxs], axis=1)
 
         expected_inner_df = pd.concat([self.pointdf.iloc[:0],
                                        empty_result_df.index_right,

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -102,23 +102,21 @@ class TestSpatialJoin(unittest.TestCase):
         else:
             right_idxs = pd.Series(name='index_right',dtype='int64')
 
-        empty_result_df = pd.concat([pd.Series(name='index_left',dtype='int64'), right_idxs], axis=1)
-
         expected_inner_df = pd.concat([self.pointdf.iloc[:0],
-                                       empty_result_df.index_right,
+                                       pd.Series(name='index_right', dtype='int64'),
                                        self.polydf.drop('geometry', axis = 1).iloc[:0]], axis = 1)
 
         expected_inner = GeoDataFrame(expected_inner_df, crs = {'init': 'epsg:4326', 'no_defs': True})
 
         expected_right_df = pd.concat([self.pointdf.drop('geometry', axis = 1).iloc[:0],
-                                       empty_result_df,
+                                       pd.concat([pd.Series(name='index_left',dtype='int64'), right_idxs], axis=1),
                                        self.polydf], axis = 1)
 
         expected_right = GeoDataFrame(expected_right_df, crs = {'init': 'epsg:4326', 'no_defs': True})\
                             .set_index('index_right')
 
         expected_left_df = pd.concat([self.pointdf.iloc[17:],
-                                      empty_result_df.index_right,
+                                      pd.Series(name='index_right', dtype='int64'),
                                       self.polydf.iloc[:0].drop('geometry', axis=1)], axis = 1)
 
         expected_left = GeoDataFrame(expected_left_df, crs = {'init': 'epsg:4326', 'no_defs': True})

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 
 import numpy as np
+import pandas as pd
 from shapely.geometry import Point
 
 from geopandas import GeoDataFrame, read_file, base
@@ -116,7 +117,7 @@ class TestSpatialJoin(unittest.TestCase):
         self.assertTrue(expected_inner.equals(df_inner))
         self.assertTrue(expected_right.equals(df_right))
         self.assertTrue(expected_left.equals(df_left))
-        
+
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):
         df = sjoin(self.pointdf, self.polydf, how="outer")

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -98,7 +98,7 @@ class TestSpatialJoin(unittest.TestCase):
         # Recent Pandas development has introduced a new way of handling merges
         # this change has altered the output when no overlapping geometries
         if str(pd.__version__) > LooseVersion('0.18.1'):
-            right_idxs = pd.Series(name='index_right',dtype='int64', index=range(0,5))
+            right_idxs = pd.Series(range(0,5), name='index_right',dtype='int64')
         else:
             right_idxs = pd.Series(name='index_right',dtype='int64')
 

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -89,15 +89,18 @@ class TestSpatialJoin(unittest.TestCase):
         subset_pointdf = self.pointdf.iloc[17:]
 
         df_inner = sjoin(subset_pointdf, self.polydf, how='inner')
+        self.assertEquals(df_inner.columns.tolist()[:5], ['geometry', 'pointattr1', 'pointattr2','index_right','BoroCode'])
         self.assertEquals(df_inner.shape, (0,8))
 
         df_left = sjoin(subset_pointdf, self.polydf, how='left')
         self.assertEquals(df_left.shape, (4,8))
         self.assertTrue(df_left.BoroCode.notnull().sum()==0)
+        self.assertTrue(df_left.pointattr2.isnull().sum()==0)
 
         df_right = sjoin(subset_pointdf, self.polydf, how='right')
         self.assertEquals(df_right.shape, (5,8))
         self.assertTrue(df_right.pointattr2.notnull().sum()==0)
+        self.assertTrue(df_right.BoroCode.isnull().sum()==0)
 
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -82,6 +82,23 @@ class TestSpatialJoin(unittest.TestCase):
         df = sjoin(self.polydf, self.pointdf, how='left')
         self.assertEquals(df.shape, (12,8))
 
+def test_no_overlapping_geometry(self):
+    # Note: these tests are for correctly returning GeoDataFrame
+    # when result of the join is empty
+
+    subset_pointdf = self.pointdf.iloc[17:]
+
+    df_inner = sjoin(subset_pointdf, self.polydf, how='inner')
+    self.assertEquals(df_inner.shape, (0,8))
+
+    df_left = sjoin(subset_pointdf, self.polydf, how='left')
+    self.assertEquals(df_left.shape, (4,8))
+    self.assertTrue(df_left.BoroCode.notnull().sum()==0)
+
+    df_right = sjoin(subset_pointdf, self.polydf, how='right')
+    self.assertEquals(df_right.shape, (5,8))
+    self.assertTrue(df_right.pointattr2.notnull().sum()==0)
+
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):
         df = sjoin(self.pointdf, self.polydf, how="outer")

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -82,22 +82,22 @@ class TestSpatialJoin(unittest.TestCase):
         df = sjoin(self.polydf, self.pointdf, how='left')
         self.assertEquals(df.shape, (12,8))
 
-def test_no_overlapping_geometry(self):
-    # Note: these tests are for correctly returning GeoDataFrame
-    # when result of the join is empty
+    def test_no_overlapping_geometry(self):
+        # Note: these tests are for correctly returning GeoDataFrame
+        # when result of the join is empty
 
-    subset_pointdf = self.pointdf.iloc[17:]
+        subset_pointdf = self.pointdf.iloc[17:]
 
-    df_inner = sjoin(subset_pointdf, self.polydf, how='inner')
-    self.assertEquals(df_inner.shape, (0,8))
+        df_inner = sjoin(subset_pointdf, self.polydf, how='inner')
+        self.assertEquals(df_inner.shape, (0,8))
 
-    df_left = sjoin(subset_pointdf, self.polydf, how='left')
-    self.assertEquals(df_left.shape, (4,8))
-    self.assertTrue(df_left.BoroCode.notnull().sum()==0)
+        df_left = sjoin(subset_pointdf, self.polydf, how='left')
+        self.assertEquals(df_left.shape, (4,8))
+        self.assertTrue(df_left.BoroCode.notnull().sum()==0)
 
-    df_right = sjoin(subset_pointdf, self.polydf, how='right')
-    self.assertEquals(df_right.shape, (5,8))
-    self.assertTrue(df_right.pointattr2.notnull().sum()==0)
+        df_right = sjoin(subset_pointdf, self.polydf, how='right')
+        self.assertEquals(df_right.shape, (5,8))
+        self.assertTrue(df_right.pointattr2.notnull().sum()==0)
 
     @unittest.skip("Not implemented")
     def test_sjoin_outer(self):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -10,7 +10,10 @@ from shapely.geometry import Point
 from geopandas import GeoDataFrame, read_file, base
 from geopandas.tests.util import unittest, download_nybb
 from geopandas import sjoin
+from distutils.version import LooseVersion
 
+pandas_0_16_problem = 'fails under pandas < 0.17 due to issue 251,'\
+                      'not problem with sjoin.'
 
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
 class TestSpatialJoin(unittest.TestCase):
@@ -83,6 +86,7 @@ class TestSpatialJoin(unittest.TestCase):
         df = sjoin(self.polydf, self.pointdf, how='left')
         self.assertEquals(df.shape, (12,8))
 
+    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.17'), pandas_0_16_problem)
     def test_no_overlapping_geometry(self):
         # Note: these tests are for correctly returning GeoDataFrame
         # when result of the join is empty

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -105,7 +105,7 @@ class TestSpatialJoin(unittest.TestCase):
 
         expected_inner = GeoDataFrame(expected_inner_df, crs = {'init': 'epsg:4326', 'no_defs': True})
 
-        expected_right_df = pd.concat([self.pointdf.iloc[17:].drop('geometry', axis = 1).iloc[:0],
+        expected_right_df = pd.concat([self.pointdf.drop('geometry', axis = 1).iloc[:0],
                                        empty_result_df,
                                        self.polydf], axis = 1)
 


### PR DESCRIPTION
This is a fix for issue https://github.com/geopandas/geopandas/issues/251 

The problem is an obscure error when performing an sjoin where the result of sjoin has no overlapping geometries. Now instead of an error it returns an empty GeoDataFrame on inner join as well as left_df and right_df when performing respectively left and right joins.

The only pieces of code are the added if, else part with handling of empty results.

