### PR TITLE
DOC: disable other formats on readthedocs (for faster build)

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,5 @@
+formats:
+    - none
 conda:
     file: doc/environment.yml
 python:


### PR DESCRIPTION
This should solve #333 for now. 
I don't think the pdf and epub versions of the documentation are really essential.