### PR TITLE
Use _geometry_column_name in set_geometry()

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -125,7 +125,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             crs = getattr(col, 'crs', self.crs)
 
         to_remove = None
-        geo_column_name = DEFAULT_GEO_COLUMN_NAME
+        geo_column_name = self._geometry_column_name
         if isinstance(col, (Series, list, np.ndarray)):
             level = col
         elif hasattr(col, 'ndim') and col.ndim != 1:
@@ -139,7 +139,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 raise
             if drop:
                 to_remove = col
-                geo_column_name = DEFAULT_GEO_COLUMN_NAME
+                geo_column_name = self._geometry_column_name
             else:
                 geo_column_name = col
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -372,9 +372,7 @@ class TestDataFrame(unittest.TestCase):
         """ Test to_crs() with different geometry column name (GH#339) """
         df2 = self.df2.copy()
         df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        cols = df2.columns.tolist()
-        cols[cols.index('geometry')] = 'geom'
-        df2.columns = cols
+        df2 = df2.rename(columns={'geometry': 'geom'})
         df2.set_geometry('geom', inplace=True)
         lonlat = df2.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -369,7 +369,7 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue(all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
 
     def test_to_crs_geo_column_name(self):
-        """ Test to_crs() with different geometry column name (GH#339) """
+        # Test to_crs() with different geometry column name (GH#339)
         df2 = self.df2.copy()
         df2.crs = {'init': 'epsg:26918', 'no_defs': True}
         df2 = df2.rename(columns={'geometry': 'geom'})

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -372,6 +372,20 @@ class TestDataFrame(unittest.TestCase):
         utm = lonlat.to_crs(epsg=26918)
         self.assertTrue(all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
 
+    def test_to_crs_geo_column_name(self):
+        """ Test to_crs() with different geometry column name (GH#339) """
+        df2 = self.df2.copy()
+        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
+        cols = df2.columns.tolist()
+        cols[cols.index('geometry')] = 'geom'
+        df2.columns = cols
+        df2.set_geometry('geom', inplace=True)
+        lonlat = df2.to_crs(epsg=4326)
+        utm = lonlat.to_crs(epsg=26918)
+        self.assertEqual(lonlat.geometry.name, 'geom')
+        self.assertEqual(utm.geometry.name, 'geom')
+        self.assertTrue(all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2)))
+
     def test_from_features(self):
         nybb_filename, nybb_zip_path = download_nybb()
         with fiona.open(nybb_zip_path,

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -55,16 +55,12 @@ class TestDataFrame(unittest.TestCase):
 
         geom2 = [Point(x, y) for x, y in zip(range(5, 10), range(5))]
         df2 = df.set_geometry(geom2, crs='dummy_crs')
-        self.assert_('geometry' in df2)
         self.assert_('location' in df2)
         self.assertEqual(df2.crs, 'dummy_crs')
         self.assertEqual(df2.geometry.crs, 'dummy_crs')
         # reset so it outputs okay
         df2.crs = df.crs
         assert_geoseries_equal(df2.geometry, GeoSeries(geom2, crs=df2.crs))
-        # for right now, non-geometry comes back as series
-        assert_geoseries_equal(df2['location'], df['location'],
-                                  check_series_type=False, check_dtype=False)
 
     def test_geo_getitem(self):
         data = {"A": range(5), "B": range(-5, 0),


### PR DESCRIPTION
This changes the behavior of `set_geometry()` in the case of a geometry column not named `geometry`, but I believe the previous behavior was incorrect. Previously, passing in a column to `set_geometry()` would always create a column called `geometry`, and leave the existing geometry column if it had a different name. This change will honor the geometry column name, and overwrite the existing one (as it already did in the case of a column actually called `geometry`).

Fix #339.