### PR TITLE
add nose to test requirements

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,3 +7,4 @@ mock>=1.0.1  # technically not need for python >= 3.3
 pytest-cov
 coveralls
 rtree>=0.8
+nose


### PR DESCRIPTION
Looks like nose is needed to run the tests.

Also note that [nose is in maintenance mode](http://nose.readthedocs.io/en/latest/#note-to-users) and no longer recommended. Moving to py.test would be a solid alternative.
