### PR TITLE
TST: test with latest 0.18.x pandas release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
-  
+
 # matrix creates 3+5x2 = 13 tests
 matrix:
   include:
@@ -29,7 +29,7 @@ matrix:
     - python: 3.3
       env: PANDAS=0.17.1 MATPLOTLIB=1.3.1
     - python: 3.4
-      env: PANDAS=0.18.0 MATPLOTLIB=1.5.1
+      env: PANDAS=0.18.1 MATPLOTLIB=1.5.1
 
     # Python 2.7 and 3.5 test all supported Pandas versions
     - python: 2.7
@@ -39,7 +39,7 @@ matrix:
     - python: 2.7
       env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
     - python: 2.7
-      env: PANDAS=0.18.0  MATPLOTLIB=1.5.1
+      env: PANDAS=0.18.1  MATPLOTLIB=1.5.1
     - python: 2.7
       env: PANDAS=master  MATPLOTLIB=master
 
@@ -51,14 +51,14 @@ matrix:
     - python: 3.5
       env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
     - python: 3.5
-      env: PANDAS=0.18.0  MATPLOTLIB=1.5.1
+      env: PANDAS=0.18.1  MATPLOTLIB=1.5.1
     - python: 3.5
       env: PANDAS=master  MATPLOTLIB=master
 
   # matplotlib 2.x (development version) causes a few tests to fail
   allow_failures:
     - env: PANDAS=master  MATPLOTLIB=master
-  
+
 
 before_install:
   - pip install -U pip


### PR DESCRIPTION
Tests were using 0.18.0, while 0.18.1 is the latest release.