### PR TITLE
Fix usage of versioneer in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [bdist_wheel]
 universal = 1
 
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(name='geopandas',
       packages=['geopandas', 'geopandas.io', 'geopandas.tools',
                 'geopandas.datasets'],
       package_data={'geopandas': data_files},
-      install_requires=INSTALL_REQUIRES)
+      install_requires=INSTALL_REQUIRES,
+      cmdclass=versioneer.get_cmdclass())


### PR DESCRIPTION
xref https://github.com/geopandas/geopandas/issues/361

Seems I forgot the `cmdclass` in setup.py 
Tested it, and now it generates the correct version in the packaged source.