### PR TITLE
BUG: fixed fiona filter results where bbox is not None

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -25,7 +25,7 @@ def read_file(filename, **kwargs):
             f_filt = f.filter(bbox=bbox)
         else:
             f_filt = f
-        gdf = GeoDataFrame.from_features(f, crs=crs)
+        gdf = GeoDataFrame.from_features(f_filt, crs=crs)
 
     return gdf
 

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -54,3 +54,15 @@ class TestIO(unittest.TestCase):
         df = self.df.rename(columns=lambda x: x.lower())
         validate_boro_df(self, df)
         self.assert_(df.crs == self.crs)
+
+    def test_filtered_read_file(self):
+        full_df_shape = self.df.shape
+        nybb_filename, nybb_zip_path = download_nybb()
+        vfs = 'zip://' + nybb_filename
+        bbox = (1031051.7879884212, 224272.49231459625, 1047224.3104931959, 244317.30894023244)
+        filtered_df = read_file(nybb_zip_path, vfs=vfs, bbox=bbox)
+        filtered_df_shape = filtered_df.shape
+        assert(full_df_shape != filtered_df_shape)
+        assert(filtered_df_shape == (2, 5))
+
+


### PR DESCRIPTION
Closes #371

This is a quick fix that ensures filtered results from Fiona's `filter` function are used to populate the `GeoDataFrame`. Previously, the entire selection of features were returned whether or not the `bbox` keyword argument was passed in while using `geopandas.read_file`.