### PR TITLE
BUG: nybb zip file no longer exists.

### DIFF
--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -46,7 +46,7 @@ def download_nybb():
     returns tuple (zip file name, shapefile's name and path within zip file)"""
     # Data from http://www.nyc.gov/html/dcp/download/bytes/nybb_14aav.zip
     # saved as geopandas/examples/nybb_14aav.zip.
-    filename = 'nybb_16a.zip'
+    filename = 'nybb_16c.zip'
     full_path_name = os.path.join(PACKAGE_DIR, 'examples', filename)
     if not os.path.exists(full_path_name):
         with io.open(full_path_name, 'wb') as f:

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -46,11 +46,11 @@ def download_nybb():
     returns tuple (zip file name, shapefile's name and path within zip file)"""
     # Data from http://www.nyc.gov/html/dcp/download/bytes/nybb_14aav.zip
     # saved as geopandas/examples/nybb_14aav.zip.
-    filename = 'nybb_16c.zip'
+    filename = 'nybb_16a.zip'
     full_path_name = os.path.join(PACKAGE_DIR, 'examples', filename)
     if not os.path.exists(full_path_name):
         with io.open(full_path_name, 'wb') as f:
-            response = urlopen('http://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/{0}'.format(filename))
+            response = urlopen('https://github.com/geopandas/geopandas/files/555970/{0}'.format(filename))
             f.write(response.read())
 
     shp_zip_path = None


### PR DESCRIPTION
I was able to find what appears to be the updated and only available zip file that is consistent with what the nybb_16a.zip file contained.

Unfortunately, the number of fields in the shapefiles appear to be different, and the hardcoded shapes that are used for verifying geodataframe shapes are no longer valid.

For example, the test below fails because the number of fields in the shapefile differs from the hardcoded reference tuple:
```
FAIL: test_intersection (geopandas.tests.test_overlay.TestDataFrame)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/nickg/geopandas/geopandas/tests/test_overlay.py", line 62, in test_intersection
    self.assertEquals(df.shape, (68, 7))
AssertionError: Tuples differ: (67, 7) != (68, 7)
```

It seems more work is needed to make the tests valid again given the new shapefile.