### PR TITLE
Changes hard-coded reference to geometry column in sjoin operation

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -46,11 +46,11 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         print('Warning: CRS does not match!')
 
     tree_idx = rtree.index.Index()
-    right_df_bounds = right_df[right_df.geometry.name].apply(lambda x: x.bounds)
+    right_df_bounds = right_df.geometry.apply(lambda x: x.bounds)
     for i in right_df_bounds.index:
         tree_idx.insert(i, right_df_bounds[i])
 
-    idxmatch = (left_df[left_df.geometry.name].apply(lambda x: x.bounds)
+    idxmatch = (left_df.geometry.apply(lambda x: x.bounds)
                 .apply(lambda x: list(tree_idx.intersection(x))))
     idxmatch = idxmatch[idxmatch.apply(len) > 0]
 
@@ -78,7 +78,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                           [l_idx,
                            r_idx,
                            check_predicates(
-                               left_df[left_df.geometry.name]
+                               left_df.geometry
                                .apply(lambda x: prepared.prep(x))[l_idx],
                                right_df[right_df.geometry.name][r_idx])
                            ]))

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -46,11 +46,11 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         print('Warning: CRS does not match!')
 
     tree_idx = rtree.index.Index()
-    right_df_bounds = right_df['geometry'].apply(lambda x: x.bounds)
+    right_df_bounds = right_df[right_df.geometry.name].apply(lambda x: x.bounds)
     for i in right_df_bounds.index:
         tree_idx.insert(i, right_df_bounds[i])
 
-    idxmatch = (left_df['geometry'].apply(lambda x: x.bounds)
+    idxmatch = (left_df[left_df.geometry.name].apply(lambda x: x.bounds)
                 .apply(lambda x: list(tree_idx.intersection(x))))
     idxmatch = idxmatch[idxmatch.apply(len) > 0]
 
@@ -78,9 +78,9 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                           [l_idx,
                            r_idx,
                            check_predicates(
-                               left_df['geometry']
+                               left_df[left_df.geometry.name]
                                .apply(lambda x: prepared.prep(x))[l_idx],
-                               right_df['geometry'][r_idx])
+                               right_df[right_df.geometry.name][r_idx])
                            ]))
                    )
 
@@ -106,7 +106,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         return (
                 left_df
                 .merge(result, left_index=True, right_index=True)
-                .merge(right_df.drop('geometry', axis=1),
+                .merge(right_df.drop(right_df.geometry.name, axis=1),
                     left_on='index_%s' % rsuffix, right_index=True,
                     suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
                 )
@@ -115,14 +115,14 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         return (
                 left_df
                 .merge(result, left_index=True, right_index=True, how='left')
-                .merge(right_df.drop('geometry', axis=1),
+                .merge(right_df.drop(right_df.geometry.name, axis=1),
                     how='left', left_on='index_%s' % rsuffix, right_index=True,
                     suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
                 )
     elif how == 'right':
         return (
                 left_df
-                .drop('geometry', axis=1)
+                .drop(left_df.geometry.name, axis=1)
                 .merge(result.merge(right_df,
                     left_on='index_%s' % rsuffix, right_index=True,
                     how='right'), left_index=True,

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -33,16 +33,14 @@ class TestSpatialJoin(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
-    def test_new_geom_column(self):
-        self.setUp()
+    def test_geometry_name(self):
+        # test sjoin is working with other geometry name
         polydf_original_geom_name = self.polydf.geometry.name
-        self.polydf["new_geom"] = self.polydf.geometry
-        self.polydf.set_geometry(col="new_geom", inplace=True)
+        self.polydf = (self.polydf.rename(columns={'geometry': 'new_geom'})
+                                  .set_geometry('new_geom'))
         self.assertNotEqual(polydf_original_geom_name, self.polydf.geometry.name)
-        self.polydf.drop("geometry", axis=1, inplace=True)
-        df = sjoin(self.polydf, self.pointdf, how="left", lsuffix="pointdf", rsuffix="polydf")
-        result_gdf = GeoDataFrame(data=df, geometry="new_geom", crs=self.polydf.crs)
-        self.assertEqual(self.polydf.geometry.name, result_gdf.geometry.name)
+        res = sjoin(self.polydf, self.pointdf, how="left")
+        self.assertEqual(self.polydf.geometry.name, res.geometry.name)
 
     def test_sjoin_left(self):
         df = sjoin(self.pointdf, self.polydf, how='left')

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -22,7 +22,6 @@ class TestSpatialJoin(unittest.TestCase):
         nybb_filename, nybb_zip_path = download_nybb()
         self.polydf = read_file(nybb_zip_path, vfs='zip://' + nybb_filename)
         self.tempdir = tempfile.mkdtemp()
-        #self.crs = {'init': 'epsg:4326'}
         self.crs = self.polydf.crs
         N = 20
         b = [int(x) for x in self.polydf.total_bounds]


### PR DESCRIPTION
The geometry columns were hardcoded in the sjoin operation, meaning if a user renamed their geometry column, the function would fail. Or worse yet, if a second geometry column were generated with a different name and set as the default geometry column, the sjoin operation would still run on the column named "geometry," unbeknownst to the user.

This PR ensures the actual default geometry column is called during sjoin operations.
