### PR TITLE
ENH: preserve column order in read_file (#378).

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -14,7 +14,7 @@ def read_file(filename, **kwargs):
 
     *filename* is either the absolute or relative path to the file to be
     opened and *kwargs* are keyword args to be passed to the `open` method
-    in the fiona library when opening the file. For more information on 
+    in the fiona library when opening the file. For more information on
     possible keywords, type: ``import fiona; help(fiona.open)``
     """
     bbox = kwargs.pop('bbox', None)
@@ -27,8 +27,8 @@ def read_file(filename, **kwargs):
             f_filt = f
         gdf = GeoDataFrame.from_features(f_filt, crs=crs)
 
-        # re-order with column order from metadata, with geometry first
-        columns = ["geometry"] + list(f.meta["schema"]["properties"])
+        # re-order with column order from metadata, with geometry last
+        columns = list(f.meta["schema"]["properties"]) + ["geometry"]
         gdf = gdf[columns]
 
     return gdf

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -27,6 +27,10 @@ def read_file(filename, **kwargs):
             f_filt = f
         gdf = GeoDataFrame.from_features(f_filt, crs=crs)
 
+        # re-order with column order from metadata, with geometry first
+        columns = ["geometry"] + list(f.meta["schema"]["properties"])
+        gdf = gdf[columns]
+
     return gdf
 
 

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -57,7 +57,7 @@ class TestIO(unittest.TestCase):
         self.assert_(df.crs == self.crs)
         # get lower case columns, and exclude geometry column from comparison
         lower_columns = [c.lower() for c in self.columns]
-        self.assert_((df.columns[1:] == lower_columns).all())
+        self.assert_((df.columns[:-1] == lower_columns).all())
 
     def test_filtered_read_file(self):
         full_df_shape = self.df.shape

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -14,6 +14,7 @@ class TestIO(unittest.TestCase):
         self.df = read_file(nybb_zip_path, vfs=vfs)
         with fiona.open(nybb_zip_path, vfs=vfs) as f:
             self.crs = f.crs
+            self.columns = list(f.meta["schema"]["properties"].keys())
 
     def test_read_postgis_default(self):
         con = connect('test_geopandas')
@@ -54,6 +55,9 @@ class TestIO(unittest.TestCase):
         df = self.df.rename(columns=lambda x: x.lower())
         validate_boro_df(self, df)
         self.assert_(df.crs == self.crs)
+        # get lower case columns, and exclude geometry column from comparison
+        lower_columns = [c.lower() for c in self.columns]
+        self.assert_((df.columns[1:] == lower_columns).all())
 
     def test_filtered_read_file(self):
         full_df_shape = self.df.shape


### PR DESCRIPTION
Closes #378 

Use ordered dict from meta["schema"]["properties"] with column order, as suggested by @jorisvandenbossche.

I added a couple of lines to `TestIO.test_read_file` verifying that the column order matches. In doing so, I needed to convert the fiona column names to lower case to match a conversion happening to the geodataframe. I see that `validate_boro_df` has the columns in lower case, presumably motivating that lower case transformation in `test_read_file`, but it wasn't clear to me why it was necessary in `validate_boro_df`.