### PR TITLE
TST: switch remaining nose to pytest

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -232,8 +232,8 @@ use cases and writing corresponding tests.
 Adding tests is one of the most common requests after code is pushed to *geopandas*.  Therefore,
 it is worth getting in the habit of writing tests ahead of time so this is never an issue.
 
-Like many packages, *geopandas* uses the `Nose testing system
-<http://nose.readthedocs.org/en/latest/index.html>`_ and the convenient
+*geopandas* uses the `pytest testing system
+<http://doc.pytest.org/en/latest/>`_ and the convenient
 extensions in `numpy.testing
 <http://docs.scipy.org/doc/numpy/reference/routines.testing.html>`_.
 
@@ -255,7 +255,7 @@ Running the test suite
 The tests can then be run directly inside your Git clone (without having to
 install *geopandas*) by typing::
 
-    nosetests -v
+    pytest
 
 6) Updating the Documentation
 -----------------------------

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pandas.util.testing as tm
 from shapely.geometry import Point
 import geopandas as gpd
-import nose
+import pytest
 
 from geopandas import GeoSeries
 from geopandas.tools import geocode, reverse_geocode
@@ -18,10 +18,10 @@ def _skip_if_no_geopy():
     try:
         import geopy
     except ImportError:
-        raise nose.SkipTest("Geopy not installed. Skipping tests.")
+        raise pytest.skip("Geopy not installed. Skipping tests.")
     except SyntaxError:
-        raise nose.SkipTest("Geopy is known to be broken on Python 3.2. "
-                            "Skipping tests.")
+        raise pytest.skip("Geopy is known to be broken on Python 3.2. "
+                          "Skipping tests.")
 
 
 class ForwardMock(mock.MagicMock):


### PR DESCRIPTION
Alternative for #347 from @perrygeo. 
Since travis is already using pytest, I just removed the remaining usage of nose.

Closes #347