### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ readable code.  Performance matters, but not at the expense of those
 goals.
 
 In general, GeoPandas follows the conventions of the pandas project
-where applicable.  Please read [pandas contributing
-guidelines](https://github.com/pydata/pandas/blob/master/CONTRIBUTING.md).
+where applicable.  Please read the [pandas contributing
+guidelines](http://pandas.pydata.org/pandas-docs/stable/contributing.html).
 
 In particular, when submitting a pull request:
 


### PR DESCRIPTION
Fix link to pandas contribution guidelines. Though they are fairly extensive, and perhaps overkill, so perhaps the line should be removed?