### PR TITLE
Change cascaded_union property behavior

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -184,7 +184,7 @@ class GeoPandasBase(object):
     @property
     def cascaded_union(self):
         """Deprecated: Return the unary_union of all geometries"""
-        return cascaded_union(self.values)
+        return cascaded_union(self.geometry.values)
 
     @property
     def unary_union(self):


### PR DESCRIPTION
Maybe since `cascaded_union` is deprecated, this does not really
matter, but `gdf.unary_union` works, while `gdf.cascaded_union`
did not, and I thought as long as both are supported they should
behave the same way.

BTW, I'm seeing three test failures on plotting, but they are evidently
unrelated to this pull request. I'm guessing it is due to having
upgraded to matplotlib 2.0.0, but I'll look into it a bit more.