### PR TITLE
TST: fix numpy version for old python versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - pip install wheel
 
 install:
-  - pip wheel numpy
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip wheel numpy==1.11.3; else pip wheel numpy; fi
   - pip wheel -r requirements.txt
   - pip wheel -r requirements.test.txt
 


### PR DESCRIPTION
Travis (pip) is automatically downloading the latest numpy (0.12), which does not support python 2.6 and 3.3 anymore, therefore travis is failing. 
Will open an issue to remove support for those python versions, but in the meantime a fix.