### PR TITLE
TST: remove explicit building wheels - wheels are now available on PyPI - use pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 
 sudo: false
 
-cache:
-  directories:
-    - ~/.cache/pip
-
 addons:
   apt:
     packages:
@@ -13,11 +9,6 @@ addons:
     - gdal-bin
     - libgdal-dev
     - libspatialindex-dev
-
-env:
-  global:
-    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
-    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
 
 # matrix creates 3+5x2 = 13 tests
 matrix:
@@ -62,13 +53,8 @@ matrix:
 
 before_install:
   - pip install -U pip
-  - pip install wheel
 
 install:
-  - pip wheel numpy
-  - pip wheel -r requirements.txt
-  - pip wheel -r requirements.test.txt
-
   - pip install numpy
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; else pip wheel matplotlib==$MATPLOTLIB; pip install matplotlib==$MATPLOTLIB; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 sudo: false
 
+cache: pip
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ before_install:
 
 install:
   - pip install numpy
-  - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; else pip wheel matplotlib==$MATPLOTLIB; pip install matplotlib==$MATPLOTLIB; fi
+  - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; else pip install matplotlib==$MATPLOTLIB; fi
 
   - pip install -r requirements.txt
   - pip install -r requirements.test.txt
 
-  - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; else pip wheel pandas==$PANDAS; pip install pandas==$PANDAS; fi
+  - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; else pip install pandas==$PANDAS; fi
 
 script:
   - py.test geopandas --cov geopandas -v --cov-report term-missing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Cython>=0.16
 shapely>=1.2.18
 fiona>=1.0.1
 pyproj>=1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Cython>=0.16
 shapely>=1.2.18
 fiona>=1.0.1
 pyproj>=1.9.3


### PR DESCRIPTION
Alternative to #406, and also a simplification of the travis.yml file: remove pip wheel commands (for the more recent versions, wheels are already available on PyPI, for the other ones pip nowadays automatically builds wheels the first time and then use pip cache).