### PR TITLE
TST: fix matplotlib to 1.5.3 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION%"
   - activate test-environment
-  - conda install pandas shapely fiona pyproj rtree matplotlib descartes
+  - conda install pandas shapely fiona pyproj rtree matplotlib==1.5.3 descartes
   - conda install pytest mock
 
 test_script:


### PR DESCRIPTION
Our tests are still failing for the newest matplotlib 2.0 due to the style changes, so until that is fixed, pin matplotlib to 1.5 on appveyor.