### PR TITLE
Drop python 2.6/3.3, pandas 0.15, matplotlib 1.2/1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,35 +17,33 @@ matrix:
   include:
     # Only one test for these Python versions
     # Pandas >= 0.18.0, is not Python 2.6 compatible
-    - python: 2.6
-      env: PANDAS=0.16.2 MATPLOTLIB=1.2.1
-    - python: 3.3
-      env: PANDAS=0.17.1 MATPLOTLIB=1.3.1
     - python: 3.4
-      env: PANDAS=0.18.1 MATPLOTLIB=1.5.1
+      env: PANDAS=0.18.1 MATPLOTLIB=1.4.3
+    - python: 3.5
+      env: PANDAS=0.19.2 MATPLOTLIB=1.5.1
 
-    # Python 2.7 and 3.5 test all supported Pandas versions
+    # Python 2.7 and 3.6 test all supported Pandas versions
     - python: 2.7
-      env: PANDAS=0.15.2  MATPLOTLIB=1.2.1
-    - python: 2.7
-      env: PANDAS=0.16.2  MATPLOTLIB=1.3.1
+      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3
     - python: 2.7
       env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
     - python: 2.7
       env: PANDAS=0.18.1  MATPLOTLIB=1.5.1
+    - python: 2.7
+      env: PANDAS=0.19.2  MATPLOTLIB=1.5.1
     - python: 2.7
       env: PANDAS=master  MATPLOTLIB=master
 
-    # Note: Python 3.5 and matplotlib versions before 1.4.3 support is hit or miss.
-    - python: 3.5
-      env: PANDAS=0.15.2  MATPLOTLIB=1.4.3
-    - python: 3.5
+    # Note: Python 3.6 and matplotlib versions before 1.4.3 support is hit or miss.
+    - python: 3.6
       env: PANDAS=0.16.2  MATPLOTLIB=1.4.3
-    - python: 3.5
+    - python: 3.6
       env: PANDAS=0.17.1  MATPLOTLIB=1.4.3
-    - python: 3.5
+    - python: 3.6
       env: PANDAS=0.18.1  MATPLOTLIB=1.5.1
-    - python: 3.5
+    - python: 3.6
+      env: PANDAS=0.19.2  MATPLOTLIB=1.5.1
+    - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
   # matplotlib 2.x (development version) causes a few tests to fail

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -8,11 +8,8 @@ from geopandas.tools import overlay
 from .util import unittest, download_nybb
 from pandas.util.testing import assert_frame_equal
 from pandas import Index
-from distutils.version import LooseVersion
 import pandas as pd
 
-pandas_0_15_problem = 'fails under pandas < 0.16 due to issue 324,'\
-                      'not problem with dissolve.'
 
 class TestDataFrame(unittest.TestCase):
 
@@ -44,31 +41,25 @@ class TestDataFrame(unittest.TestCase):
         self.mean = merged_shapes.copy()
         self.mean['BoroCode'] = [4,1.5]
 
-
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_geom_dissolve(self):
         test = self.polydf.dissolve('manhattan_bronx')
         self.assertTrue(test.geometry.name == 'myshapes')
         self.assertTrue(test.geom_almost_equals(self.first).all())
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_dissolve_retains_existing_crs(self):
         assert self.polydf.crs is not None
         test = self.polydf.dissolve('manhattan_bronx')
         assert test.crs is not None
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_dissolve_retains_nonexisting_crs(self):
         self.polydf.crs = None
         test = self.polydf.dissolve('manhattan_bronx')
         assert test.crs is None
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_first_dissolve(self):
         test = self.polydf.dissolve('manhattan_bronx')
         assert_frame_equal(self.first, test, check_column_type=False)
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_mean_dissolve(self):
         test = self.polydf.dissolve('manhattan_bronx', aggfunc='mean')
         assert_frame_equal(self.mean, test, check_column_type=False)
@@ -76,7 +67,6 @@ class TestDataFrame(unittest.TestCase):
         test = self.polydf.dissolve('manhattan_bronx', aggfunc=np.mean)
         assert_frame_equal(self.mean, test, check_column_type=False)
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_multicolumn_dissolve(self):
         multi = self.polydf.copy()
         multi['dup_col'] = multi.manhattan_bronx
@@ -88,7 +78,6 @@ class TestDataFrame(unittest.TestCase):
 
         assert_frame_equal(multi_test, first, check_column_type=False)
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.16'), pandas_0_15_problem)
     def test_reset_index(self):
         test = self.polydf.dissolve('manhattan_bronx', as_index=False)
         comparison = self.first.reset_index()

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -1,6 +1,7 @@
 import io
 import os.path
 import sys
+import unittest
 import zipfile
 
 from six.moves.urllib.request import urlopen
@@ -11,14 +12,6 @@ from geopandas import GeoDataFrame, GeoSeries
 HERE = os.path.abspath(os.path.dirname(__file__))
 PACKAGE_DIR = os.path.dirname(os.path.dirname(HERE))
 
-# Compatibility layer for Python 2.6: try loading unittest2
-if sys.version_info[:2] == (2, 6):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        import unittest
-else:
-    import unittest
 
 try:
     import psycopg2


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/407

Drop support (at least testing) for python 2.6 and 3.3, pandas 0.15 (and added 019.2 in test matrix) and matplotlib < 1.4

Also changed the main test matrix to use python 3.6 instead of 3.5