### PR TITLE
Use pandas.io.json

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,12 +3,12 @@ try:
 except ImportError:
     # Python 2.6
     from ordereddict import OrderedDict
-import json
 import os
 import sys
 
 import numpy as np
 from pandas import DataFrame, Series, Index
+from pandas.io import json
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 from six import string_types
@@ -226,11 +226,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             * drop: remove the property from the feature. This applies to
                     each feature individually so that features may have
                     different properties
-            * keep: output the missing entries as NaN
 
         show_bbox : include bbox (bounds) in the geojson
 
-        The remaining *kwargs* are passed to json.dumps().
+        The remaining *kwargs* are passed to pandas.io.json.dumps().
 
         """
         return json.dumps(self._to_geo(na=na, show_bbox=show_bbox), **kwargs)
@@ -287,8 +286,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         f = na_methods[na]
 
         for i, row in self.iterrows():
-            properties = f(row)
-            del properties[self._geometry_column_name]
+
+            properties = f(row.drop(self._geometry_column_name))
 
             feature = {
                 'id': str(i),

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1,11 +1,11 @@
 from functools import partial
-import json
 from warnings import warn
 
 import numpy as np
 from pandas import Series, DataFrame
 from pandas.core.indexing import _NDFrameIndexer
 from pandas.util.decorators import cache_readonly
+from pandas.io import json
 import pyproj
 from shapely.geometry import box, shape, Polygon, Point
 from shapely.geometry.collection import GeometryCollection
@@ -86,20 +86,20 @@ class GeoSeries(GeoPandasBase, Series):
     def from_file(cls, filename, **kwargs):
         """
         Alternate constructor to create a GeoSeries from a file
-        
+
         Parameters
         ----------
-        
+
         filename : str
             File path or file handle to read from. Depending on which kwargs
             are included, the content of filename may vary, see:
             http://toblerity.github.io/fiona/README.html#usage
             for usage details.
         kwargs : key-word arguments
-            These arguments are passed to fiona.open, and can be used to 
+            These arguments are passed to fiona.open, and can be used to
             access multi-layer data, data stored within archives (zip files),
             etc.
-        
+
         """
         import fiona
         geoms = []
@@ -125,7 +125,7 @@ class GeoSeries(GeoPandasBase, Series):
                           index=self.index)
         data.crs = self.crs
         data.to_file(filename, driver, **kwargs)
-        
+
     #
     # Implement pandas methods
     #
@@ -241,7 +241,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     def plot(self, *args, **kwargs):
         return plot_series(self, *args, **kwargs)
-    
+
     plot.__doc__ = plot_series.__doc__
 
     #
@@ -287,7 +287,7 @@ class GeoSeries(GeoPandasBase, Series):
 
         Parameters
         ----------
-        *kwargs* that will be passed to json.dumps().
+        *kwargs* that will be passed to pandas.io.json.dumps().
         """
         return json.dumps(self.__geo_interface__, **kwargs)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from six import string_types
 
 import json
 import os
@@ -287,7 +288,7 @@ class TestDataFrame(unittest.TestCase):
         data = json.loads(text)
         for f in data['features']:
             props = f['properties']
-            self.assertTrue(type(props['established']) == str)
+            self.assertTrue(isinstance(props['established'], string_types))
 
     def test_copy(self):
         df2 = self.df.copy()


### PR DESCRIPTION
This uses the pandas json libraries for df.to_json.

Advantages:
- pandas datetime series can be exported as timestamps or isoformat
- float precision can be set

Disadvantages:
- can no longer set na='keep' to keep nan's, instead they are converted to null

I tested it on py2 and 3, added tests, updated docstring (although not iterating each new option)

Want to add it?