### PR TITLE
_can_hold_na now returns True

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -157,7 +157,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def _can_hold_na(self):
-        return False
+        return True
 
     def __finalize__(self, other, method=None, **kwargs):
         """ propagate metadata from other to self """


### PR DESCRIPTION
to make .dropna() drop na.
See https://github.com/geopandas/geopandas/issues/314#issuecomment-284180090
Tested, it works now:
```
In [4]: a = gpd.GeoSeries([Point(1,1), Point(2,2), gpd.np.nan, Point(3,3)])
In [5]: a.dropna()
Out[5]: 
0    POINT (1 1)
1    POINT (2 2)
3    POINT (3 3)
dtype: object
```