### PR TITLE
ENH: use row.name for id when exporting to GeoJSON

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -286,12 +286,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             raise ValueError('Unknown na method {0}'.format(na))
         f = na_methods[na]
 
-        for i, row in self.iterrows():
+        for _, row in self.iterrows():
             properties = f(row)
             del properties[self._geometry_column_name]
 
             feature = {
-                'id': str(i),
+                'id': str(row.name),
                 'type': 'Feature',
                 'properties': properties,
                 'geometry': mapping(row[self._geometry_column_name])

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -286,12 +286,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             raise ValueError('Unknown na method {0}'.format(na))
         f = na_methods[na]
 
-        for _, row in self.iterrows():
+        for name, row in self.iterrows():
             properties = f(row)
             del properties[self._geometry_column_name]
 
             feature = {
-                'id': str(row.name),
+                'id': str(name),
                 'type': 'Feature',
                 'properties': properties,
                 'geometry': mapping(row[self._geometry_column_name])


### PR DESCRIPTION
#390 asks that exporting an ID when exporting to GeoJSON be made an optional thing, per the specification. However, @sgillies (who is actually on the spec committee) stepped in and pointed out that this was due to a lack of consensus regarding an error correction in the previous spec and that actually having a meaningful ID is part of best practices.

In light of that I'm opposed to making exporting an ID optional, and in favor of making the ID exported meaningful. This PR is a tiny change that does the latter by replacing `str(i)` (the column number) with `str(row.name)` (the column index entry) in the export.