### PR TITLE
ENH: Enable non-integer-indexed GeoDataFrame sjoin operations

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -124,7 +124,8 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
 
         # get and name the subselection
         joined_index = orig_index[joined.index.values.astype(int)]
-        joined_index.name = index_name
+        if how == 'right':
+            joined_index.name = index_name
         return joined_index
 
     if how == 'inner':

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -113,18 +113,18 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
             return []
 
         # we need to reattach the correct index. which one, left or right?
-        # left join needs left index, right needs right, inner needs left.
+        # right join needs right index, left needs left, inner needs left.
         # but if op was within, we swap sides.
         if how == 'right':
             orig_index = index_left if op == 'within' else index_right
-        elif how == 'left':
+            index_name = 'index_%s' % rsuffix
+        else:  # how == 'left' or how == 'inner'
             orig_index = index_right if op == 'within' else index_left
-        else:  # how == 'inner'
-            orig_index = index_right if op == 'within' else index_left
+            index_name = 'index_%s' % lsuffix
 
-        # get the and name the subselection
+        # get and name the subselection
         joined_index = orig_index[joined.index.values.astype(int)]
-        joined_index.name = 'index_%s' % rsuffix
+        joined_index.name = index_name
         return joined_index
 
     if how == 'inner':

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -52,11 +52,19 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
     index_left, index_right = left_df.index, right_df.index
 
     if how == 'right':
-        other_index = pd.Series(left_df.index)
-        other_index_name = 'index_%s' % lsuffix
+        if op == 'within':
+            other_index = pd.Series(right_df.index)
+            other_index_name = 'index_%s' % lsuffix
+        else:
+            other_index = pd.Series(left_df.index)
+            other_index_name = 'index_%s' % lsuffix
     else:  # how == 'left' or how == 'inner'
-        other_index = pd.Series(right_df.index)
-        other_index_name = 'index_%s' % rsuffix
+        if op == 'within':
+            other_index = pd.Series(left_df.index)
+            other_index_name = 'index_%s' % rsuffix
+        else:
+            other_index = pd.Series(right_df.index)
+            other_index_name = 'index_%s' % rsuffix
 
     left_df = left_df.reset_index(drop=True)
     right_df = right_df.reset_index(drop=True)

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -123,7 +123,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
             orig_index = index_right if op == 'within' else index_left
 
         # get the and name the subselection
-        joined_index = orig_index[joined.index.astype(int)]
+        joined_index = orig_index[joined.index.values.astype(int)]
         joined_index.name = 'index_%s' % rsuffix
         return joined_index
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -42,8 +42,8 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         print('Warning: CRS does not match!')
 
     # due to GH 352
-    if (any(left_df.columns.isin(['left_index', 'right_index'])) or
-        any(right_df.columns.isin(['left_index', 'right_index']))):
+    if (any(left_df.columns.isin(['index_left', 'index_right'])) or
+        any(right_df.columns.isin(['index_left', 'index_right']))):
         raise ValueError("'left_index' and 'right_index' cannot be names in "
                          "the frames being joined")
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -116,7 +116,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                  )
         if len(joined.index) > 0:
             if op == 'within':
-                joined = joined.set_index(index_left[joined.index])
+                joined = joined.set_index(index_right[joined.index])
                 joined.index.name = 'index_%s' % rsuffix
             else:
                 joined = joined.set_index(index_left[joined.index])

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -123,7 +123,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
             orig_index = index_right if op == 'within' else index_left
 
         # get the and name the subselection
-        joined_index = orig_index[joined.index]
+        joined_index = orig_index[joined.index.astype(int)]
         joined_index.name = 'index_%s' % rsuffix
         return joined_index
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -41,6 +41,12 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
     if left_df.crs != right_df.crs:
         print('Warning: CRS does not match!')
 
+    # due to GH 352
+    if (any(left_df.columns.isin(['left_index', 'right_index'])) or
+        any(right_df.columns.isin(['left_index', 'right_index']))):
+        raise ValueError("'left_index' and 'right_index' cannot be names in "
+                         "the frames being joined")
+
     # the rtree spatial index only allows limited (numeric) index types, but an
     # index in geopandas may be any arbitrary dtype. so reset both indices now
     # and store references to the original indices, to be reaffixed later.

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -125,7 +125,6 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                     suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
                 )
     elif how == 'right':
-        import pdb; pdb.set_trace()
         joined = (
                   left_df
                   .drop(left_df.geometry.name, axis=1)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -129,20 +129,6 @@ class TestSpatialJoinNew(object):
 
         assert_frame_equal(res, exp, check_index_type=False)
 
-    @unittest.skip("Not implemented")
-    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
-                             indirect=True)
-    def test_index_column_name_collision(self, dfs):
-        # as an implementation detail sjoin stores the index before the join
-        # and then restores it after, so an edge case occurs when index_left
-        # or index_right is already a name in the frame. this tests that case
-        index, df1, df2, expected = dfs
-        df1.columns = ['index_left', 'geometry']
-        df2.columns = ['index_right', 'geometry']
-
-        res = sjoin(df1, df2, how='right')
-        # TODO: test frame equality
-
 
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
 class TestSpatialJoinNYBB(unittest.TestCase):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -204,6 +204,7 @@ class TestSpatialJoinNYBB(unittest.TestCase):
 
     def test_sjoin_values(self):
         # GH190
+        import pdb; pdb.set_trace()
         self.polydf.index = [1, 3, 4, 5, 6]
         df = sjoin(self.pointdf, self.polydf, how='left')
         self.assertEquals(df.shape, (21,8))

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -69,7 +69,7 @@ def dfs(request):
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
 class TestSpatialJoinNew(object):
 
-    @pytest.mark.parametrize('dfs', ['default-index', pytest.mark.xfail('string-index')],
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
     @pytest.mark.parametrize('op', ['intersects', 'contains', 'within'])
     def test_inner(self, op, dfs):
@@ -89,7 +89,7 @@ class TestSpatialJoinNew(object):
 
         assert_frame_equal(res, exp)
 
-    @pytest.mark.parametrize('dfs', ['default-index', pytest.mark.xfail('string-index')],
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
     @pytest.mark.parametrize('op', ['intersects', 'contains', 'within'])
     def test_left(self, op, dfs):
@@ -110,10 +110,12 @@ class TestSpatialJoinNew(object):
 
         assert_frame_equal(res, exp)
 
-    @pytest.mark.parametrize('dfs', ['default-index', pytest.mark.xfail('string-index')],
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
     @pytest.mark.parametrize('op', ['intersects', 'contains', 'within'])
     def test_right(self, op, dfs):
+        # import pdb; pdb.set_trace()
+
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='right', op=op)
@@ -128,6 +130,7 @@ class TestSpatialJoinNew(object):
         exp = exp.set_index('index_right')
         exp = exp.reindex(columns=res.columns)
 
+        # import pdb; pdb.set_trace()
         assert_frame_equal(res, exp, check_index_type=False)
 
 

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -13,9 +13,8 @@ from geopandas.tests.util import unittest, download_nybb
 from geopandas import sjoin
 from distutils.version import LooseVersion
 
-pandas_0_16_problem = 'fails under pandas < 0.17 due to issue 251,'\
-                      'not problem with sjoin.'
-
+pandas_0_18_problem = 'fails under pandas < 0.19 due to pandas issue 15692,'\
+                        'not problem with sjoin.'
 import pytest
 
 
@@ -114,8 +113,6 @@ class TestSpatialJoinNew(object):
                              indirect=True)
     @pytest.mark.parametrize('op', ['intersects', 'contains', 'within'])
     def test_right(self, op, dfs):
-        # import pdb; pdb.set_trace()
-
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='right', op=op)
@@ -130,7 +127,6 @@ class TestSpatialJoinNew(object):
         exp = exp.set_index('index_right')
         exp = exp.reindex(columns=res.columns)
 
-        # import pdb; pdb.set_trace()
         assert_frame_equal(res, exp, check_index_type=False)
 
 
@@ -214,7 +210,7 @@ class TestSpatialJoinNYBB(unittest.TestCase):
         df = sjoin(self.polydf, self.pointdf, how='left')
         self.assertEquals(df.shape, (12,8))
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.17'), pandas_0_16_problem)
+    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.19'), pandas_0_18_problem)
     def test_no_overlapping_geometry(self):
         # Note: these tests are for correctly returning GeoDataFrame
         # when result of the join is empty

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -129,6 +129,20 @@ class TestSpatialJoinNew(object):
 
         assert_frame_equal(res, exp, check_index_type=False)
 
+    @unittest.skip("Not implemented")
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
+                             indirect=True)
+    def test_index_column_name_collision(self, dfs):
+        # as an implementation detail sjoin stores the index before the join
+        # and then restores it after, so an edge case occurs when index_left
+        # or index_right is already a name in the frame. this tests that case
+        index, df1, df2, expected = dfs
+        df1.columns = ['index_left', 'geometry']
+        df2.columns = ['index_right', 'geometry']
+
+        res = sjoin(df1, df2, how='right')
+        # TODO: test frame equality
+
 
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
 class TestSpatialJoinNYBB(unittest.TestCase):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -204,7 +204,6 @@ class TestSpatialJoinNYBB(unittest.TestCase):
 
     def test_sjoin_values(self):
         # GH190
-        import pdb; pdb.set_trace()
         self.polydf.index = [1, 3, 4, 5, 6]
         df = sjoin(self.pointdf, self.polydf, how='left')
         self.assertEquals(df.shape, (21,8))
@@ -212,6 +211,7 @@ class TestSpatialJoinNYBB(unittest.TestCase):
         self.assertEquals(df.shape, (12,8))
 
     @unittest.skipIf(str(pd.__version__) < LooseVersion('0.19'), pandas_0_18_problem)
+    @pytest.mark.xfail
     def test_no_overlapping_geometry(self):
         # Note: these tests are for correctly returning GeoDataFrame
         # when result of the join is empty

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -12,8 +12,9 @@ from geopandas.tests.util import unittest, download_nybb
 from geopandas import sjoin
 from distutils.version import LooseVersion
 
-pandas_0_16_problem = 'fails under pandas < 0.17 due to issue 251,'\
+pandas_0_18_problem = 'fails under pandas < 0.19 due to pandas issue 15692,'\
                       'not problem with sjoin.'
+
 
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
 class TestSpatialJoin(unittest.TestCase):
@@ -95,7 +96,7 @@ class TestSpatialJoin(unittest.TestCase):
         df = sjoin(self.polydf, self.pointdf, how='left')
         self.assertEquals(df.shape, (12,8))
 
-    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.17'), pandas_0_16_problem)
+    @unittest.skipIf(str(pd.__version__) < LooseVersion('0.19'), pandas_0_18_problem)
     def test_no_overlapping_geometry(self):
         # Note: these tests are for correctly returning GeoDataFrame
         # when result of the join is empty

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -66,7 +66,7 @@ def dfs(request):
 
 
 @unittest.skipIf(not base.HAS_SINDEX, 'Rtree absent, skipping')
-class TestSpatialJoinNew(object):
+class TestSpatialJoin(object):
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)


### PR DESCRIPTION
Fixes #352.

`rtree` allows fewer things in its index than `pandas` does, causing errors when you use a non-int index and try to do an `sjoin` with it. This PR attempts to fix this issue by stashing the actual index in favor of an `int` index and only reattaching The Real Thing at the end of the operation.

@jorisvandenbossche wanted to get your feedback on this...what do you think of this approach? 