### PR TITLE
Add cache skip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ geopandas/version.py
 *.py~
 doc/_static/world_*
 examples/nybb_*.zip
+.cache/


### PR DESCRIPTION
`pytest` creates a `.cache/` file when it runs, so let's add that to the `.gitignore` to avoid having to delete it when we want to commit (`pandas` already has this).