### PR TITLE
CLN/TST: remove usage of assert_isinstance from pandas (deprecated/removed)

### DIFF
--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -5,7 +5,6 @@ import unittest
 import zipfile
 
 from six.moves.urllib.request import urlopen
-from pandas.util.testing import assert_isinstance
 
 from geopandas import GeoDataFrame, GeoSeries
 
@@ -188,7 +187,7 @@ def assert_geoseries_equal(left, right, check_dtype=False,
     assert len(left) == len(right), "%d != %d" % (len(left), len(right))
 
     if check_index_type:
-        assert_isinstance(left.index, type(right.index))
+        assert isinstance(left.index, type(right.index))
 
     if check_dtype:
         assert left.dtype == right.dtype, "dtype: %s != %s" % (left.dtype,
@@ -196,7 +195,7 @@ def assert_geoseries_equal(left, right, check_dtype=False,
 
     if check_series_type:
         assert isinstance(left, GeoSeries)
-        assert_isinstance(left, type(right))
+        assert isinstance(left, type(right))
 
         if check_crs:
             assert(left.crs == right.crs)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/10458 and https://github.com/pandas-dev/pandas/pull/15652