### PR TITLE
Add legend_kwds to plot()

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -309,7 +309,8 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
 
 def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
                    categorical=False, legend=False, scheme=None, k=5,
-                   vmin=None, vmax=None, figsize=None, **style_kwds):
+                   vmin=None, vmax=None, figsize=None, legend_kwds=None,
+                   **style_kwds):
     """
     Plot a GeoDataFrame.
 
@@ -341,6 +342,9 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
 
     legend : bool (default False)
         Plot a legend. Ignored if no `column` is given, or if `color` is given.
+
+    legend_kwds : dict (default None)
+        Keyword arguments to pass to ax.legend()
 
     ax : matplotlib.pyplot.Artist (default None)
         axes on which to draw the plot
@@ -467,7 +471,11 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
                     Line2D([0], [0], linestyle="none", marker="o",
                            alpha=style_kwds.get('alpha', 1), markersize=10,
                            markerfacecolor=n_cmap.to_rgba(value)))
-            ax.legend(patches, categories, numpoints=1, loc='best')
+            if legend_kwds is None:
+                legend_kwds = {}
+            legend_kwds.setdefault('numpoints', 1)
+            legend_kwds.setdefault('loc', 'best')
+            ax.legend(patches, categories, **legend_kwds)
         else:
             n_cmap.set_array([])
             ax.get_figure().colorbar(n_cmap)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -272,6 +272,12 @@ class TestPolygonPlotting:
         _check_colors(2, ax.collections[0].get_facecolors(), ['g'] * 2, alpha=0.4)
         _check_colors(2, ax.collections[0].get_edgecolors(), ['r'] * 2, alpha=0.4)
 
+    def test_legend_kwargs(self):
+
+        ax = self.df.plot(column='values', categorical=True, legend=True,
+                          legend_kwds={'frameon': False})
+        assert ax.get_legend().get_frame_on() is False
+
     def test_multipolygons(self):
 
         # MultiPolygons


### PR DESCRIPTION
closes https://github.com/geopandas/geopandas/issues/377 and https://github.com/geopandas/geopandas/issues/355

I know you guys are considering overhauling the plotting methods (https://github.com/geopandas/geopandas/issues/405), so I won't mind if you'd rather not merge without a clear concept for geopandas' plottin API. 

the ``*_kwarg={}`` strategy is the one we follow in xarray, until now without too much trouble (the drawback is the high number of kwargs of course).