### PR TITLE
CLN: Remove deprecated PANDAS_NEW_SQL_API check

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -25,7 +25,7 @@ def read_file(filename, **kwargs):
             f_filt = f.filter(bbox=bbox)
         else:
             f_filt = f
-        gdf = GeoDataFrame.from_features(f, crs=crs)
+        gdf = GeoDataFrame.from_features(f_filt, crs=crs)
 
     return gdf
 

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -4,7 +4,7 @@ import fiona
 
 from geopandas import read_postgis, read_file
 from geopandas.tests.util import download_nybb, connect, create_db, \
-     PANDAS_NEW_SQL_API, unittest, validate_boro_df
+     unittest, validate_boro_df
 
 
 class TestIO(unittest.TestCase):
@@ -25,9 +25,6 @@ class TestIO(unittest.TestCase):
             sql = "SELECT * FROM nybb;"
             df = read_postgis(sql, con)
         finally:
-            if PANDAS_NEW_SQL_API:
-                # It's not really a connection, it's an engine
-                con = con.connect()
             con.close()
 
         validate_boro_df(self, df)
@@ -44,9 +41,6 @@ class TestIO(unittest.TestCase):
                      FROM nybb;"""
             df = read_postgis(sql, con, geom_col='__geometry__')
         finally:
-            if PANDAS_NEW_SQL_API:
-                # It's not really a connection, it's an engine
-                con = con.connect()
             con.close()
 
         validate_boro_df(self, df)
@@ -68,5 +62,3 @@ class TestIO(unittest.TestCase):
         filtered_df_shape = filtered_df.shape
         assert(full_df_shape != filtered_df_shape)
         assert(filtered_df_shape == (2, 5))
-
-

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -54,3 +54,15 @@ class TestIO(unittest.TestCase):
         df = self.df.rename(columns=lambda x: x.lower())
         validate_boro_df(self, df)
         self.assert_(df.crs == self.crs)
+
+    def test_filtered_read_file(self):
+        full_df_shape = self.df.shape
+        nybb_filename, nybb_zip_path = download_nybb()
+        vfs = 'zip://' + nybb_filename
+        bbox = (1031051.7879884212, 224272.49231459625, 1047224.3104931959, 244317.30894023244)
+        filtered_df = read_file(nybb_zip_path, vfs=vfs, bbox=bbox)
+        filtered_df_shape = filtered_df.shape
+        assert(full_df_shape != filtered_df_shape)
+        assert(filtered_df_shape == (2, 5))
+
+

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -13,7 +13,7 @@ from shapely.geometry import Point, Polygon
 import fiona
 from geopandas import GeoDataFrame, read_file, GeoSeries
 from geopandas.tests.util import assert_geoseries_equal, connect, create_db, \
-    download_nybb, PACKAGE_DIR, PANDAS_NEW_SQL_API, unittest, validate_boro_df
+    download_nybb, PACKAGE_DIR, unittest, validate_boro_df
 
 
 class TestDataFrame(unittest.TestCase):
@@ -328,7 +328,7 @@ class TestDataFrame(unittest.TestCase):
         """
         Ensure that the file is written according to the schema
         if it is specified
-        
+
         """
         try:
             from collections import OrderedDict
@@ -425,9 +425,6 @@ class TestDataFrame(unittest.TestCase):
             sql = "SELECT * FROM nybb;"
             df = GeoDataFrame.from_postgis(sql, con)
         finally:
-            if PANDAS_NEW_SQL_API:
-                # It's not really a connection, it's an engine
-                con = con.connect()
             con.close()
 
         validate_boro_df(self, df)
@@ -444,9 +441,6 @@ class TestDataFrame(unittest.TestCase):
                      FROM nybb;"""
             df = GeoDataFrame.from_postgis(sql, con, geom_col='__geometry__')
         finally:
-            if PANDAS_NEW_SQL_API:
-                # It's not really a connection, it's an engine
-                con = con.connect()
             con.close()
 
         validate_boro_df(self, df)

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -24,13 +24,6 @@ try:
 except ImportError:
     import mock
 
-try:
-    from pandas import read_sql_table
-except ImportError:
-    PANDAS_NEW_SQL_API = False
-else:
-    PANDAS_NEW_SQL_API = True
-
 
 def download_nybb():
     """ Returns the path to the NYC boroughs file. Downloads if necessary.


### PR DESCRIPTION
Per @jorisvandenbossche comments in #440, remove the statements in database testing functions designed to handle pandas version <0.14.