### PR TITLE
GeoDataFrame.from_url()

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -264,6 +264,11 @@ Currently, the following methods are implemented for a ``GeoDataFrame``:
   Load a ``GeoDataFrame`` from a file from any format recognized by
   `fiona`_.  See ``read_file()``.
 
+.. classmethod:: GeoDataFrame.from_file(url)
+
+  Load a ``GeoDataFrame`` from a GeoJSON file hosted online. Inspired
+  by ``pandas.read_json()``.
+
 .. classmethod:: GeoDataFrame.from_postgis(sql, con, geom_col='geom', crs=None, index_col=None, coerce_float=True, params=None)
 
   Load a ``GeoDataFrame`` from a file from a PostGIS database.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -168,7 +168,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Inspired by pandas.read_json().
 
         """
-        raw, _, _ = get_filepath_or_buffer(url)
+        raw = get_filepath_or_buffer(url)[0]
         geojson = json.loads(raw.read())
         return GeoDataFrame.from_features(geojson['features'])
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -158,7 +158,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             return frame
 
     @classmethod
-    def from_url(cls, url, **kwargs):
+    def from_url(cls, url):
         """
         Alternate constructor to create a GeoDataFrame from a GeoJSON file online.
 
@@ -170,7 +170,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         raw, _, _ = get_filepath_or_buffer(url)
         geojson = json.loads(raw.read())
-        return GeoDataFrame.from_url(geojson['features'], **kwargs)
+        return GeoDataFrame.from_features(geojson['features'])
 
     @classmethod
     def from_file(cls, filename, **kwargs):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -148,8 +148,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         # Check that we are using a listlike of geometries
         if not all(isinstance(item, BaseGeometry) or not item for item in level):
-            raise TypeError(
-                "Input geometry column must contain valid geometry objects.")
+            raise TypeError("Input geometry column must contain valid geometry objects.")
         frame[geo_column_name] = level
         frame._geometry_column_name = geo_column_name
         frame.crs = crs
@@ -174,7 +173,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             data = data.decode('utf-8')
         geojson = json.loads(data)
         return GeoDataFrame.from_features(geojson['features'])
-
+        
     @classmethod
     def from_file(cls, filename, **kwargs):
         """
@@ -226,7 +225,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         """
         return geopandas.io.sql.read_postgis(sql, con, geom_col, crs, index_col,
-                                             coerce_float, params)
+                     coerce_float, params)
 
     def to_json(self, na='null', show_bbox=False, **kwargs):
         """
@@ -309,7 +308,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 'type': 'Feature',
                 'properties': properties,
                 'geometry': mapping(row[self._geometry_column_name])
-                if row[self._geometry_column_name] else None
+                            if row[self._geometry_column_name] else None
             }
 
             if show_bbox:
@@ -431,8 +430,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # concat operation: using metadata of the first object
         elif method == 'concat':
             for name in self._metadata:
-                object.__setattr__(self, name, getattr(
-                    other.objs[0], name, None))
+                object.__setattr__(self, name, getattr(other.objs[0], name, None))
         else:
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
@@ -463,6 +461,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     plot.__doc__ = plot_dataframe.__doc__
 
+
     def dissolve(self, by=None, aggfunc='first', as_index=True):
         """
         Dissolve geometries within `groupby` into single observation.
@@ -491,17 +490,16 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         data = self.drop(labels=self.geometry.name, axis=1)
         aggregated_data = data.groupby(by=by).agg(aggfunc)
 
+
         # Process spatial component
         def merge_geometries(block):
             merged_geom = block.unary_union
             return merged_geom
 
-        g = self.groupby(by=by, group_keys=False)[
-            self.geometry.name].agg(merge_geometries)
+        g = self.groupby(by=by, group_keys=False)[self.geometry.name].agg(merge_geometries)
 
         # Aggregate
-        aggregated_geometry = GeoDataFrame(
-            g, geometry=self.geometry.name, crs=self.crs)
+        aggregated_geometry = GeoDataFrame(g, geometry=self.geometry.name, crs=self.crs)
         # Recombine
         aggregated = aggregated_geometry.join(aggregated_data)
 
@@ -511,7 +509,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         return aggregated
 
-
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     if inplace:
         raise ValueError("Can't do inplace setting when converting from"
@@ -519,7 +516,6 @@ def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     gf = GeoDataFrame(self)
     # this will copy so that BlockManager gets copied
     return gf.set_geometry(col, drop=drop, inplace=False, crs=crs)
-
 
 if PY3:
     DataFrame.set_geometry = _dataframe_set_geometry

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -169,7 +169,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         """
         raw = get_filepath_or_buffer(url)[0]
-        geojson = json.loads(raw.read())
+        data = raw.read()
+        if isinstance(data, bytes):
+            data = data.decode('utf-8')
+        geojson = json.loads(data)
         return GeoDataFrame.from_features(geojson['features'])
 
     @classmethod

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -13,6 +13,7 @@ from geopandas.base import GeoPandasBase
 from geopandas.plotting import plot_dataframe
 import geopandas.io
 
+from pandas.io.common import get_filepath_or_buffer
 
 DEFAULT_GEO_COLUMN_NAME = 'geometry'
 
@@ -147,13 +148,29 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         # Check that we are using a listlike of geometries
         if not all(isinstance(item, BaseGeometry) or not item for item in level):
-            raise TypeError("Input geometry column must contain valid geometry objects.")
+            raise TypeError(
+                "Input geometry column must contain valid geometry objects.")
         frame[geo_column_name] = level
         frame._geometry_column_name = geo_column_name
         frame.crs = crs
         frame._invalidate_sindex()
         if not inplace:
             return frame
+
+    @classmethod
+    def from_url(cls, url, **kwargs):
+        """
+        Alternate constructor to create a GeoDataFrame from a GeoJSON file online.
+
+        Example:
+            df = geopandas.GeoDataFrame.from_url('https://raw.githubusercontent.com/geopandas/geopandas/master/examples/null_geom.geojson')
+
+        Inspired by pandas.read_json().
+
+        """
+        raw, _, _ = get_filepath_or_buffer(url)
+        geojson = json.loads(raw.read())
+        return GeoDataFrame.from_url(geojson['features'], **kwargs)
 
     @classmethod
     def from_file(cls, filename, **kwargs):
@@ -206,7 +223,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         """
         return geopandas.io.sql.read_postgis(sql, con, geom_col, crs, index_col,
-                     coerce_float, params)
+                                             coerce_float, params)
 
     def to_json(self, na='null', show_bbox=False, **kwargs):
         """
@@ -289,7 +306,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 'type': 'Feature',
                 'properties': properties,
                 'geometry': mapping(row[self._geometry_column_name])
-                            if row[self._geometry_column_name] else None
+                if row[self._geometry_column_name] else None
             }
 
             if show_bbox:
@@ -411,7 +428,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # concat operation: using metadata of the first object
         elif method == 'concat':
             for name in self._metadata:
-                object.__setattr__(self, name, getattr(other.objs[0], name, None))
+                object.__setattr__(self, name, getattr(
+                    other.objs[0], name, None))
         else:
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
@@ -442,7 +460,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     plot.__doc__ = plot_dataframe.__doc__
 
-
     def dissolve(self, by=None, aggfunc='first', as_index=True):
         """
         Dissolve geometries within `groupby` into single observation.
@@ -471,16 +488,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         data = self.drop(labels=self.geometry.name, axis=1)
         aggregated_data = data.groupby(by=by).agg(aggfunc)
 
-
         # Process spatial component
         def merge_geometries(block):
             merged_geom = block.unary_union
             return merged_geom
 
-        g = self.groupby(by=by, group_keys=False)[self.geometry.name].agg(merge_geometries)
+        g = self.groupby(by=by, group_keys=False)[
+            self.geometry.name].agg(merge_geometries)
 
         # Aggregate
-        aggregated_geometry = GeoDataFrame(g, geometry=self.geometry.name, crs=self.crs)
+        aggregated_geometry = GeoDataFrame(
+            g, geometry=self.geometry.name, crs=self.crs)
         # Recombine
         aggregated = aggregated_geometry.join(aggregated_data)
 
@@ -490,6 +508,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         return aggregated
 
+
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     if inplace:
         raise ValueError("Can't do inplace setting when converting from"
@@ -497,6 +516,7 @@ def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     gf = GeoDataFrame(self)
     # this will copy so that BlockManager gets copied
     return gf.set_geometry(col, drop=drop, inplace=False, crs=crs)
+
 
 if PY3:
     DataFrame.set_geometry = _dataframe_set_geometry

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -32,7 +32,8 @@ class TestDataFrame(unittest.TestCase):
         self.df2 = GeoDataFrame([
             {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
             for x, y in zip(range(N), range(N))], crs=self.crs)
-        self.df3 = read_file(os.path.join(PACKAGE_DIR, 'examples', 'null_geom.geojson'))
+        self.df3 = read_file(os.path.join(
+            PACKAGE_DIR, 'examples', 'null_geom.geojson'))
         self.line_paths = self.df3['Name']
 
     def tearDown(self):
@@ -74,7 +75,8 @@ class TestDataFrame(unittest.TestCase):
         self.assert_(not isinstance(df['geometry'], GeoSeries))
         self.assert_(isinstance(df['location'], GeoSeries))
 
-        data["geometry"] = [Point(x + 1, y - 1) for x, y in zip(range(5), range(5))]
+        data["geometry"] = [Point(x + 1, y - 1)
+                            for x, y in zip(range(5), range(5))]
         df = GeoDataFrame(data, crs=self.crs)
         self.assert_(isinstance(df.geometry, GeoSeries))
         self.assert_(isinstance(df['geometry'], GeoSeries))
@@ -83,11 +85,11 @@ class TestDataFrame(unittest.TestCase):
 
     def test_geometry_property(self):
         assert_geoseries_equal(self.df.geometry, self.df['geometry'],
-                                  check_dtype=True, check_index_type=True)
+                               check_dtype=True, check_index_type=True)
 
         df = self.df.copy()
         new_geom = [Point(x, y) for x, y in zip(range(len(self.df)),
-                                               range(len(self.df)))]
+                                                range(len(self.df)))]
         df.geometry = new_geom
 
         new_geom = GeoSeries(new_geom, index=df.index, crs=df.crs)
@@ -190,7 +192,7 @@ class TestDataFrame(unittest.TestCase):
         #
         # Reverse the index order
         # Set the Series to be Point(i,i) where i is the index
-        self.df.index = range(len(self.df)-1, -1, -1)
+        self.df.index = range(len(self.df) - 1, -1, -1)
 
         d = {}
         for i in range(len(self.df)):
@@ -224,7 +226,7 @@ class TestDataFrame(unittest.TestCase):
 
     def test_to_json_na(self):
         # Set a value as nan and make sure it's written
-        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
 
         text = self.df.to_json()
         data = json.loads(text)
@@ -241,8 +243,8 @@ class TestDataFrame(unittest.TestCase):
             text = self.df.to_json(na='garbage')
 
     def test_to_json_dropna(self):
-        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
-        self.df.loc[self.df['BoroName']=='Bronx', 'Shape_Leng'] = np.nan
+        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName'] == 'Bronx', 'Shape_Leng'] = np.nan
 
         text = self.df.to_json(na='drop')
         data = json.loads(text)
@@ -263,8 +265,8 @@ class TestDataFrame(unittest.TestCase):
                 self.assertEqual(len(props), 4)
 
     def test_to_json_keepna(self):
-        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
-        self.df.loc[self.df['BoroName']=='Bronx', 'Shape_Leng'] = np.nan
+        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName'] == 'Bronx', 'Shape_Leng'] = np.nan
 
         text = self.df.to_json(na='keep')
         data = json.loads(text)
@@ -285,6 +287,15 @@ class TestDataFrame(unittest.TestCase):
         df2 = self.df.copy()
         self.assertTrue(type(df2) is GeoDataFrame)
         self.assertEqual(self.df.crs, df2.crs)
+
+    def test_from_url(self):
+        """ Test from_url """
+        # Write layer with null geometry out to file
+        testurl = 'https://raw.githubusercontent.com/geopandas/geopandas/master/examples/null_geom.geojson'
+        df3 = GeoDataFrame.from_url(testurl)
+        self.assertTrue('geometry' in df3)
+        self.assertTrue(len(df3) == 2)
+        self.assertTrue(np.alltrue(df3['Name'].values == self.line_paths))
 
     def test_to_file(self):
         """ Test to_file and from_file """
@@ -312,7 +323,7 @@ class TestDataFrame(unittest.TestCase):
                      np.uint8, np.uint16, np.uint32, np.uint64, np.long]
         geometry = self.df2.geometry
         data = dict((str(i), np.arange(len(geometry), dtype=dtype))
-                     for i, dtype in enumerate(int_types))
+                    for i, dtype in enumerate(int_types))
         df = GeoDataFrame(data, geometry=geometry)
         df.to_file(tempfilename)
 
@@ -320,7 +331,7 @@ class TestDataFrame(unittest.TestCase):
         """ Test that mixed geometry types raise error when writing to file """
         tempfilename = os.path.join(self.tempdir, 'test.shp')
         s = GeoDataFrame({'geometry': [Point(0, 0),
-                                        Polygon([(0, 0), (1, 0), (1, 1)])]})
+                                       Polygon([(0, 0), (1, 0), (1, 1)])]})
         with self.assertRaises(ValueError):
             s.to_file(tempfilename)
 
@@ -366,7 +377,8 @@ class TestDataFrame(unittest.TestCase):
         df2.crs = {'init': 'epsg:26918', 'no_defs': True}
         lonlat = df2.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
-        self.assertTrue(all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
+        self.assertTrue(
+            all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
 
     def test_to_crs_geo_column_name(self):
         # Test to_crs() with different geometry column name (GH#339)
@@ -378,7 +390,8 @@ class TestDataFrame(unittest.TestCase):
         utm = lonlat.to_crs(epsg=26918)
         self.assertEqual(lonlat.geometry.name, 'geom')
         self.assertEqual(utm.geometry.name, 'geom')
-        self.assertTrue(all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2)))
+        self.assertTrue(
+            all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2)))
 
     def test_from_features(self):
         nybb_filename, nybb_zip_path = download_nybb()
@@ -395,18 +408,18 @@ class TestDataFrame(unittest.TestCase):
     def test_from_features_unaligned_properties(self):
         p1 = Point(1, 1)
         f1 = {'type': 'Feature',
-                'properties': {'a': 0},
-                'geometry': p1.__geo_interface__}
+              'properties': {'a': 0},
+              'geometry': p1.__geo_interface__}
 
         p2 = Point(2, 2)
         f2 = {'type': 'Feature',
-                'properties': {'b': 1},
-                'geometry': p2.__geo_interface__}
+              'properties': {'b': 1},
+              'geometry': p2.__geo_interface__}
 
         p3 = Point(3, 3)
         f3 = {'type': 'Feature',
-                'properties': {'a': 2},
-                'geometry': p3.__geo_interface__}
+              'properties': {'a': 2},
+              'geometry': p3.__geo_interface__}
 
         df = GeoDataFrame.from_features([f1, f2, f3])
 
@@ -472,7 +485,8 @@ class TestDataFrame(unittest.TestCase):
             df.set_geometry('location', inplace=True)
 
     def test_geodataframe_geointerface(self):
-        self.assertEqual(self.df.__geo_interface__['type'], 'FeatureCollection')
+        self.assertEqual(self.df.__geo_interface__[
+                         'type'], 'FeatureCollection')
         self.assertEqual(len(self.df.__geo_interface__['features']),
                          self.df.shape[0])
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -32,8 +32,7 @@ class TestDataFrame(unittest.TestCase):
         self.df2 = GeoDataFrame([
             {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
             for x, y in zip(range(N), range(N))], crs=self.crs)
-        self.df3 = read_file(os.path.join(
-            PACKAGE_DIR, 'examples', 'null_geom.geojson'))
+        self.df3 = read_file(os.path.join(PACKAGE_DIR, 'examples', 'null_geom.geojson'))
         self.line_paths = self.df3['Name']
 
     def tearDown(self):
@@ -75,8 +74,7 @@ class TestDataFrame(unittest.TestCase):
         self.assert_(not isinstance(df['geometry'], GeoSeries))
         self.assert_(isinstance(df['location'], GeoSeries))
 
-        data["geometry"] = [Point(x + 1, y - 1)
-                            for x, y in zip(range(5), range(5))]
+        data["geometry"] = [Point(x + 1, y - 1) for x, y in zip(range(5), range(5))]
         df = GeoDataFrame(data, crs=self.crs)
         self.assert_(isinstance(df.geometry, GeoSeries))
         self.assert_(isinstance(df['geometry'], GeoSeries))
@@ -85,11 +83,11 @@ class TestDataFrame(unittest.TestCase):
 
     def test_geometry_property(self):
         assert_geoseries_equal(self.df.geometry, self.df['geometry'],
-                               check_dtype=True, check_index_type=True)
+                                  check_dtype=True, check_index_type=True)
 
         df = self.df.copy()
         new_geom = [Point(x, y) for x, y in zip(range(len(self.df)),
-                                                range(len(self.df)))]
+                                               range(len(self.df)))]
         df.geometry = new_geom
 
         new_geom = GeoSeries(new_geom, index=df.index, crs=df.crs)
@@ -192,7 +190,7 @@ class TestDataFrame(unittest.TestCase):
         #
         # Reverse the index order
         # Set the Series to be Point(i,i) where i is the index
-        self.df.index = range(len(self.df) - 1, -1, -1)
+        self.df.index = range(len(self.df)-1, -1, -1)
 
         d = {}
         for i in range(len(self.df)):
@@ -226,7 +224,7 @@ class TestDataFrame(unittest.TestCase):
 
     def test_to_json_na(self):
         # Set a value as nan and make sure it's written
-        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
 
         text = self.df.to_json()
         data = json.loads(text)
@@ -243,8 +241,8 @@ class TestDataFrame(unittest.TestCase):
             text = self.df.to_json(na='garbage')
 
     def test_to_json_dropna(self):
-        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
-        self.df.loc[self.df['BoroName'] == 'Bronx', 'Shape_Leng'] = np.nan
+        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName']=='Bronx', 'Shape_Leng'] = np.nan
 
         text = self.df.to_json(na='drop')
         data = json.loads(text)
@@ -265,8 +263,8 @@ class TestDataFrame(unittest.TestCase):
                 self.assertEqual(len(props), 4)
 
     def test_to_json_keepna(self):
-        self.df.loc[self.df['BoroName'] == 'Queens', 'Shape_Area'] = np.nan
-        self.df.loc[self.df['BoroName'] == 'Bronx', 'Shape_Leng'] = np.nan
+        self.df.loc[self.df['BoroName']=='Queens', 'Shape_Area'] = np.nan
+        self.df.loc[self.df['BoroName']=='Bronx', 'Shape_Leng'] = np.nan
 
         text = self.df.to_json(na='keep')
         data = json.loads(text)
@@ -295,7 +293,7 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue('geometry' in df3)
         self.assertTrue(len(df3) == 2)
         self.assertTrue(np.alltrue(df3['Name'].values == self.line_paths))
-
+        
     def test_to_file(self):
         """ Test to_file and from_file """
         tempfilename = os.path.join(self.tempdir, 'boros.shp')
@@ -322,7 +320,7 @@ class TestDataFrame(unittest.TestCase):
                      np.uint8, np.uint16, np.uint32, np.uint64, np.long]
         geometry = self.df2.geometry
         data = dict((str(i), np.arange(len(geometry), dtype=dtype))
-                    for i, dtype in enumerate(int_types))
+                     for i, dtype in enumerate(int_types))
         df = GeoDataFrame(data, geometry=geometry)
         df.to_file(tempfilename)
 
@@ -330,7 +328,7 @@ class TestDataFrame(unittest.TestCase):
         """ Test that mixed geometry types raise error when writing to file """
         tempfilename = os.path.join(self.tempdir, 'test.shp')
         s = GeoDataFrame({'geometry': [Point(0, 0),
-                                       Polygon([(0, 0), (1, 0), (1, 1)])]})
+                                        Polygon([(0, 0), (1, 0), (1, 1)])]})
         with self.assertRaises(ValueError):
             s.to_file(tempfilename)
 
@@ -376,8 +374,7 @@ class TestDataFrame(unittest.TestCase):
         df2.crs = {'init': 'epsg:26918', 'no_defs': True}
         lonlat = df2.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
-        self.assertTrue(
-            all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
+        self.assertTrue(all(df2['geometry'].geom_almost_equals(utm['geometry'], decimal=2)))
 
     def test_to_crs_geo_column_name(self):
         # Test to_crs() with different geometry column name (GH#339)
@@ -389,8 +386,7 @@ class TestDataFrame(unittest.TestCase):
         utm = lonlat.to_crs(epsg=26918)
         self.assertEqual(lonlat.geometry.name, 'geom')
         self.assertEqual(utm.geometry.name, 'geom')
-        self.assertTrue(
-            all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2)))
+        self.assertTrue(all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2)))
 
     def test_from_features(self):
         nybb_filename, nybb_zip_path = download_nybb()
@@ -407,18 +403,18 @@ class TestDataFrame(unittest.TestCase):
     def test_from_features_unaligned_properties(self):
         p1 = Point(1, 1)
         f1 = {'type': 'Feature',
-              'properties': {'a': 0},
-              'geometry': p1.__geo_interface__}
+                'properties': {'a': 0},
+                'geometry': p1.__geo_interface__}
 
         p2 = Point(2, 2)
         f2 = {'type': 'Feature',
-              'properties': {'b': 1},
-              'geometry': p2.__geo_interface__}
+                'properties': {'b': 1},
+                'geometry': p2.__geo_interface__}
 
         p3 = Point(3, 3)
         f3 = {'type': 'Feature',
-              'properties': {'a': 2},
-              'geometry': p3.__geo_interface__}
+                'properties': {'a': 2},
+                'geometry': p3.__geo_interface__}
 
         df = GeoDataFrame.from_features([f1, f2, f3])
 
@@ -484,8 +480,7 @@ class TestDataFrame(unittest.TestCase):
             df.set_geometry('location', inplace=True)
 
     def test_geodataframe_geointerface(self):
-        self.assertEqual(self.df.__geo_interface__[
-                         'type'], 'FeatureCollection')
+        self.assertEqual(self.df.__geo_interface__['type'], 'FeatureCollection')
         self.assertEqual(len(self.df.__geo_interface__['features']),
                          self.df.shape[0])
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -290,7 +290,6 @@ class TestDataFrame(unittest.TestCase):
 
     def test_from_url(self):
         """ Test from_url """
-        # Write layer with null geometry out to file
         testurl = 'https://raw.githubusercontent.com/geopandas/geopandas/master/examples/null_geom.geojson'
         df3 = GeoDataFrame.from_url(testurl)
         self.assertTrue('geometry' in df3)


### PR DESCRIPTION
Added method to GeoDataFrame for ingesting GeoJSON files that are hosted online (for example https://data.cityofnewyork.us/resource/kk4q-3rt2.geojson). This is intended to provide similar functionality to `pandas.read_json()`. Included a somewhat trivial test against the url for `geopandas/examples/null_geom.geojson` on Github.

There's a bunch of unrelated deletions/insertions where my editor changed things w/ automatic PEP8 adjustments – sorry.