### PR TITLE
RLS: add pre-0.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+Changes
+=======
+
+Next
+----
+
+Improvements:
+
+* improved plotting performance using ``matplotlib.collections`` (#267)
+* return empty data frame rather than raising an error when performing a spatial join with non overlapping geodataframes (#335)
+* enable ``sjoin`` on non-integer-index GeoDataFrames (#422)
+* provide access to x/y coordinates as attributes for Point GeoSeries (#383)
+
+Bug fixes:
+
+* fixed ``fiona.filter`` results when bbox is not None (#372)
+* fixed ``dissolve`` to retain CRS (#389)
+
+
 Version 0.2.0
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ Improvements:
 
 * Improve plotting performance using ``matplotlib.collections`` (#267)
 * Return empty data frame rather than raising an error when performing a spatial join with non overlapping geodataframes (#335)
-* Enable ``sjoin`` on non-integer-index GeoDataFrames (#422)
 * Provide access to x/y coordinates as attributes for Point GeoSeries (#383)
 * Make the NYBB dataset available through ``geopandas.datasets`` (#384)
 * Use index label instead of integer id in output of ``iterfeatures`` and
   ``to_json`` (#421)
+* Enable ``sjoin`` on non-integer-index GeoDataFrames (#422)
+* Add ``cx`` indexer to GeoDataFrame (#482)
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ Next
 
 Improvements:
 
-* improved plotting performance using ``matplotlib.collections`` (#267)
-* return empty data frame rather than raising an error when performing a spatial join with non overlapping geodataframes (#335)
-* enable ``sjoin`` on non-integer-index GeoDataFrames (#422)
-* provide access to x/y coordinates as attributes for Point GeoSeries (#383)
+* Improve plotting performance using ``matplotlib.collections`` (#267)
+* Return empty data frame rather than raising an error when performing a spatial join with non overlapping geodataframes (#335)
+* Enable ``sjoin`` on non-integer-index GeoDataFrames (#422)
+* Provide access to x/y coordinates as attributes for Point GeoSeries (#383)
+* Make the NYBB dataset available through ``geopandas.datasets`` (#384)
+* Use index label instead of integer id in output of ``iterfeatures`` and
+  ``to_json`` (#421)
 
 Bug fixes:
 
-* fixed ``fiona.filter`` results when bbox is not None (#372)
-* fixed ``dissolve`` to retain CRS (#389)
-
+* Fix ``fiona.filter`` results when bbox is not None (#372)
+* Fix ``dissolve`` to retain CRS (#389)
+* Fix ``cx`` behavior when using index of 0 (#478)
 
 Version 0.2.0
 -------------


### PR DESCRIPTION
I followed the example in `rasterio` (whose change logs I like) and labeled the changes with "next", to be updated to `0.3.0` once we merge everything we want to include and release. I also changed the extension since it is written with markdown already, and improves the readability when browsing on github, but happy to change back if there is some reason I'm not seeing for it not having an extension.