### PR TITLE
BUG: Fix handling of 0 slice in cx method (#477)

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -37,10 +37,10 @@ class _CoordinateIndexer(_NDFrameIndexer):
         if xs.step is not None or ys.step is not None:
             warn("Ignoring step - full interval is used.")
         xmin, ymin, xmax, ymax = obj.total_bounds
-        bbox = box(xs.start or xmin,
-                   ys.start or ymin,
-                   xs.stop or xmax,
-                   ys.stop or ymax)
+        bbox = box(xmin if xs.start is None else xs.start,
+                   ymin if ys.start is None else ys.start,
+                   xmax if xs.stop is None else xs.stop,
+                   ymax if ys.stop is None else ys.stop)
         idx = obj.intersects(bbox)
         return obj[idx]
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -37,10 +37,10 @@ class _CoordinateIndexer(_NDFrameIndexer):
         if xs.step is not None or ys.step is not None:
             warn("Ignoring step - full interval is used.")
         xmin, ymin, xmax, ymax = obj.total_bounds
-        bbox = box(xmin if xs.start is None else xs.start,
-                   ymin if ys.start is None else ys.start,
-                   xmax if xs.stop is None else xs.stop,
-                   ymax if ys.stop is None else ys.stop)
+        bbox = box(xs.start if xs.start is not None else xmin,
+                   ys.start if ys.start is not None else ymin,
+                   xs.stop if xs.stop is not None else xmax,
+                   ys.stop if ys.stop is not None else ymax)
         idx = obj.intersects(bbox)
         return obj[idx]
 

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -153,15 +153,15 @@ class TestSeries(unittest.TestCase):
         self.assertTrue(geom_equals(self.g3[[False, True]], self.g3.cx[0:0.1, 0.9:1.0]))
 
     def test_coord_slice_with_zero(self):
-        """Test that CoordinateSlice correctly handles zero slice (#GH477)."""
+        # Test that CoordinateSlice correctly handles zero slice (#GH477).
 
         gs = GeoSeries([Point(x, x) for x in range(-3, 4)])
-        assert(geom_equals(gs.cx[:0, :0], gs.loc[:3]))
-        assert(geom_equals(gs.cx[:, :0], gs.loc[:3]))
-        assert(geom_equals(gs.cx[:0, :], gs.loc[:3]))
-        assert(geom_equals(gs.cx[0:, 0:], gs.loc[3:]))
-        assert(geom_equals(gs.cx[0:, :], gs.loc[3:]))
-        assert(geom_equals(gs.cx[:, 0:], gs.loc[3:]))
+        self.assertTrue(geom_equals(gs.cx[:0, :0], gs.loc[:3]))
+        self.assertTrue(geom_equals(gs.cx[:, :0], gs.loc[:3]))
+        self.assertTrue(geom_equals(gs.cx[:0, :], gs.loc[:3]))
+        self.assertTrue(geom_equals(gs.cx[0:, 0:], gs.loc[3:]))
+        self.assertTrue(geom_equals(gs.cx[0:, :], gs.loc[3:]))
+        self.assertTrue(geom_equals(gs.cx[:, 0:], gs.loc[3:]))
 
     def test_geoseries_geointerface(self):
         self.assertEqual(self.g1.__geo_interface__['type'], 'FeatureCollection')

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -152,6 +152,17 @@ class TestSeries(unittest.TestCase):
         self.assertTrue(geom_equals(self.g3[[True, False]], self.g3.cx[0.9:, :0.1]))
         self.assertTrue(geom_equals(self.g3[[False, True]], self.g3.cx[0:0.1, 0.9:1.0]))
 
+    def test_coord_slice_with_zero(self):
+        """Test that CoordinateSlice correctly handles zero slice (#GH477)."""
+
+        gs = GeoSeries([Point(x, x) for x in range(-3, 4)])
+        assert(geom_equals(gs.cx[:0, :0], gs.loc[:3]))
+        assert(geom_equals(gs.cx[:, :0], gs.loc[:3]))
+        assert(geom_equals(gs.cx[:0, :], gs.loc[:3]))
+        assert(geom_equals(gs.cx[0:, 0:], gs.loc[3:]))
+        assert(geom_equals(gs.cx[0:, :], gs.loc[3:]))
+        assert(geom_equals(gs.cx[:, 0:], gs.loc[3:]))
+
     def test_geoseries_geointerface(self):
         self.assertEqual(self.g1.__geo_interface__['type'], 'FeatureCollection')
         self.assertEqual(len(self.g1.__geo_interface__['features']),


### PR DESCRIPTION
With the previous tests of the style `xs.start or xmin`, if `xs.start`
equalled 0, `xmin` was taken, ignoring the user specified slice boundary.
This fixes that issue, and adds miminal testing around slices with
boundaries at 0.

Closes #477