### PR TITLE
Fix GeoDataFrame.merge / pd.merge to return valid GeoDataFrame

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -198,7 +198,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         to_remove = None
         geo_column_name = self._geometry_column_name
-        if isinstance(col, (Series, list, np.ndarray)):
+        if isinstance(col, (Series, list, np.ndarray,
+                            vectorized.GeometryArray)):
             level = col
             to_remove = geo_column_name
         elif hasattr(col, 'ndim') and col.ndim != 1:
@@ -520,7 +521,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 g = vectorized.from_shapely(values)
             else:
                 g = values
-            result[geo_col] = list(g)
+            # TODO setting the geometry with __setitem__ does not yet preserve
+            # geometry block
+            result.set_geometry(g, inplace=True)
+            # result[geo_col] = list(g)
             result._geometry_column_name = geo_col
             result._invalidate_sindex()
         elif isinstance(result, DataFrame) and geo_col not in result:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -541,6 +541,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if method == 'merge':
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other.left, name, None))
+            self._ensure_geometry_array()
         # concat operation: using metadata of the first object
         elif method == 'concat':
             for name in self._metadata:
@@ -549,6 +550,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
         return self
+
+    def _ensure_geometry_array(self):
+        """"
+        Ensure the underlying geometry values are a GeometryArray
+        object and not an numpy array of geometries.
+
+        This should in principle only be used if a pandas method is not
+        preserving the GeometryBlock (until that is fixed in pandas).
+        """
+        if not isinstance(self._geometry_array, vectorized.GeometryArray):
+            self.set_geometry(self._geometry_array, inplace=True)
 
     def copy(self, deep=True):
         """

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -4,6 +4,7 @@ import pandas as pd
 from shapely.geometry import Point
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas.vectorized import GeometryArray
 from geopandas.tests.util import unittest
 
 
@@ -27,6 +28,7 @@ class TestMerging(unittest.TestCase):
 
         # check result is a GeoDataFrame
         self.assert_(isinstance(res, GeoDataFrame))
+        self.assert_(isinstance(res._geometry_array, GeometryArray))
 
         # check geometry property gives GeoSeries
         self.assert_(isinstance(res.geometry, GeoSeries))

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -24,26 +24,34 @@ class TestMerging(unittest.TestCase):
 
     def test_merge(self):
 
-        res = self.gdf.merge(self.df, left_on='values', right_on='col1')
+        gdf, df = self.gdf, self.df
 
-        # check result is a GeoDataFrame
-        self.assert_(isinstance(res, GeoDataFrame))
-        self.assert_(isinstance(res._geometry_array, GeometryArray))
+        for res in [gdf.merge(df, left_on='values', right_on='col1'),
+                    pd.merge(gdf, df, left_on='values', right_on='col1')]:
 
-        # check geometry property gives GeoSeries
-        self.assert_(isinstance(res.geometry, GeoSeries))
+            # check result is a GeoDataFrame
+            self.assert_(isinstance(res, GeoDataFrame))
+            self.assert_(isinstance(res._geometry_array, GeometryArray))
 
-        # check metadata
-        self._check_metadata(res)
+            # check geometry property gives GeoSeries
+            self.assert_(isinstance(res.geometry, GeoSeries))
+
+            # check metadata
+            self._check_metadata(res)
 
         ## test that crs and other geometry name are preserved
-        self.gdf.crs = {'init' :'epsg:4326'}
-        self.gdf = (self.gdf.rename(columns={'geometry': 'points'})
-                            .set_geometry('points'))
-        res = self.gdf.merge(self.df, left_on='values', right_on='col1')
-        self.assert_(isinstance(res, GeoDataFrame))
-        self.assert_(isinstance(res.geometry, GeoSeries))
-        self._check_metadata(res, 'points', self.gdf.crs)
+        gdf.crs = {'init' :'epsg:4326'}
+        gdf = (gdf.rename(columns={'geometry': 'points'})
+                  .set_geometry('points'))
+
+        for res in [gdf.merge(df, left_on='values', right_on='col1'),
+                    pd.merge(gdf, df, left_on='values', right_on='col1')]:
+            self.assert_(isinstance(res, GeoDataFrame))
+            self.assert_(isinstance(res.geometry, GeoSeries))
+            self._check_metadata(res, 'points', gdf.crs)
+
+    def test_pd_merge(self):
+        res = pd.merge(self.gdf, self.df, left_on='values', right_on='col1')
 
     def test_concat_axis0(self):
 


### PR DESCRIPTION
`merge` was already kind of working, but only did not preserve the geometry block (it resulted in a GeoDataFrame but with ObjectBlock / `_geometry_array` of shapely objects.

@mrocklin possibly relevant for https://github.com/geopandas/geopandas/pull/475