### PR TITLE
ENH: add cx indexer to GeoDataFrame (#471)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -29,6 +29,7 @@ such as PostGIS.
   Installation <install>
   Data Structures <data_structures>
   Reading and Writing Files <io>
+  Indexing and Selecting Data <indexing>
   Making Maps <mapping>
   Managing Projections <projections>
   Geometric Manipulations <geometric_manipulations>

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1,0 +1,30 @@
+.. currentmodule:: geopandas
+
+.. ipython:: python
+   :suppress:
+
+   import geopandas as gpd
+
+
+Indexing and Selecting Data
+=========================================
+
+GeoPandas inherits the standard ``pandas`` methods for indexing/selecting data. This includes label based indexing with ``.loc`` and integer position based indexing with ``.iloc``, which apply to both ``GeoSeries`` and ``GeoDataFrame`` objects. For more information on indexing/selecting, see the pandas_ documentation.
+
+.. _pandas: http://pandas.pydata.org/pandas-docs/stable/indexing.html
+
+In addition to the standard ``pandas`` methods, GeoPandas also provides
+coordinate based indexing with the ``cx`` indexer, which slices using a bounding
+box. Geometries in the ``GeoSeries`` or ``GeoDataFrame`` that intersect the
+bounding box will be returned.
+
+Using the ``world`` dataset, we can use this functionality to quickly select all
+countries whose boundaries extend into the southern hemisphere.
+
+.. ipython:: python
+
+   world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
+   southern_world = world.cx[:, :0]
+   @savefig world_southern.png width=5in
+   southern_world.plot();
+

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -7,7 +7,7 @@
 
 
 Indexing and Selecting Data
-=========================================
+===========================
 
 GeoPandas inherits the standard ``pandas`` methods for indexing/selecting data. This includes label based indexing with ``.loc`` and integer position based indexing with ``.iloc``, which apply to both ``GeoSeries`` and ``GeoDataFrame`` objects. For more information on indexing/selecting, see the pandas_ documentation.
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -8,8 +8,8 @@ from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 from six import string_types, PY3
 
-from geopandas import GeoSeries
 from geopandas.base import GeoPandasBase
+from geopandas.geoseries import GeoSeries, _CoordinateIndexer
 from geopandas.plotting import plot_dataframe
 import geopandas.io
 
@@ -504,3 +504,6 @@ else:
     import types
     DataFrame.set_geometry = types.MethodType(_dataframe_set_geometry, None,
                                               DataFrame)
+
+
+GeoDataFrame._create_indexer('cx', _CoordinateIndexer)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -8,8 +8,8 @@ from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 from six import string_types, PY3
 
-from geopandas.base import GeoPandasBase
-from geopandas.geoseries import GeoSeries, _CoordinateIndexer
+from geopandas.base import GeoPandasBase, _CoordinateIndexer
+from geopandas.geoseries import GeoSeries
 from geopandas.plotting import plot_dataframe
 import geopandas.io
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -4,16 +4,15 @@ from warnings import warn
 
 import numpy as np
 from pandas import Series, DataFrame
-from pandas.core.indexing import _NDFrameIndexer
 
 import pyproj
-from shapely.geometry import box, shape, Polygon, Point
+from shapely.geometry import shape, Polygon, Point
 from shapely.geometry.collection import GeometryCollection
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform
 
 from geopandas.plotting import plot_series
-from geopandas.base import GeoPandasBase, _series_unary_op
+from geopandas.base import GeoPandasBase, _series_unary_op, _CoordinateIndexer
 
 
 def _is_empty(x):
@@ -21,28 +20,6 @@ def _is_empty(x):
         return x.is_empty
     except:
         return False
-
-
-class _CoordinateIndexer(_NDFrameIndexer):
-    """ Indexing by coordinate slices """
-    def _getitem_tuple(self, tup):
-        obj = self.obj
-        xs, ys = tup
-        # handle numeric values as x and/or y coordinate index
-        if type(xs) is not slice:
-            xs = slice(xs, xs)
-        if type(ys) is not slice:
-            ys = slice(ys, ys)
-        # don't know how to handle step; should this raise?
-        if xs.step is not None or ys.step is not None:
-            warn("Ignoring step - full interval is used.")
-        xmin, ymin, xmax, ymax = obj.total_bounds
-        bbox = box(xs.start if xs.start is not None else xmin,
-                   ys.start if ys.start is not None else ymin,
-                   xs.stop if xs.stop is not None else xmax,
-                   ys.stop if ys.stop is not None else ymax)
-        idx = obj.intersects(bbox)
-        return obj[idx]
 
 
 class GeoSeries(GeoPandasBase, Series):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -362,7 +362,7 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue(type(df) is GeoDataFrame)
 
     def test_coord_slice_points(self):
-        assert(self.df2.cx[-2:-1, -2:-1].empty)
+        self.assertTrue(self.df2.cx[-2:-1, -2:-1].empty)
         assert_frame_equal(self.df2, self.df2.cx[:, :])
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, :])
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[:, 5:])

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -361,6 +361,13 @@ class TestDataFrame(unittest.TestCase):
         self.assertTrue('Bronx' in boros)
         self.assertTrue(type(df) is GeoDataFrame)
 
+    def test_coord_slice_points(self):
+        assert(self.df2.cx[-2:-1, -2:-1].empty)
+        assert_frame_equal(self.df2, self.df2.cx[:, :])
+        assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, :])
+        assert_frame_equal(self.df2.loc[5:], self.df2.cx[:, 5:])
+        assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, 5:])
+
     def test_transform(self):
         df2 = self.df2.copy()
         df2.crs = {'init': 'epsg:26918', 'no_defs': True}


### PR DESCRIPTION
In addition to applying the existing cx slicing functionality for `GeoSeries` to `GeoDataFrame` objects, I added a minimal page to the docs on indexing geodataframes, which includes an example of using the `cx` method.