### PR TITLE
TST: Omit tests from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,7 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:
+omit =
+    geopandas/tests/*
+    geopandas/io/tests/*
+    geopandas/tools/tests/*


### PR DESCRIPTION
The inclusion of tests as part of the coverage seems a little distracting to me. Of course, if there's a good reason to keep them, it isn't that big a deal, but the projects with which I'm most familiar all seem to exclude tests.