### PR TITLE
TST: Add (failing) tests of drop_duplicates

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -157,6 +157,27 @@ def test_select_dtypes(df):
     assert_frame_equal(res, exp)
 
 
+@pytest.mark.xfail
+def test_drop_duplicates_series():
+    # currently, geoseries with identical values are not recognized as
+    # duplicates
+    dups = GeoSeries([Point(0, 0), Point(0, 0)])
+    dropped = dups.drop_duplicates()
+    assert len(dropped) == 1
+
+
+@pytest.mark.xfail
+def test_drop_duplicates_frame():
+    # currently, dropping duplicates in a geodataframe produces a TypeError
+    # better behavior would be dropping the duplicated points
+    gdf_len = 3
+    dup_gdf = GeoDataFrame({'geometry': [Point(0, 0) for x in range(gdf_len)],
+                            'value1': [x for x in range(gdf_len)]})
+    dropped_geometry = dup_gdf.drop_duplicates(subset="geometry")
+    assert len(dropped_geometry) == 1
+    dropped_all = dup_gdf.drop_duplicates()
+    assert len(dropped_all) == gdf_len
+
 # Missing values
 
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -156,28 +156,6 @@ def test_select_dtypes(df):
     exp = df[['value1', 'value2']]
     assert_frame_equal(res, exp)
 
-
-@pytest.mark.xfail
-def test_drop_duplicates_series():
-    # currently, geoseries with identical values are not recognized as
-    # duplicates
-    dups = GeoSeries([Point(0, 0), Point(0, 0)])
-    dropped = dups.drop_duplicates()
-    assert len(dropped) == 1
-
-
-@pytest.mark.xfail
-def test_drop_duplicates_frame():
-    # currently, dropping duplicates in a geodataframe produces a TypeError
-    # better behavior would be dropping the duplicated points
-    gdf_len = 3
-    dup_gdf = GeoDataFrame({'geometry': [Point(0, 0) for x in range(gdf_len)],
-                            'value1': [x for x in range(gdf_len)]})
-    dropped_geometry = dup_gdf.drop_duplicates(subset="geometry")
-    assert len(dropped_geometry) == 1
-    dropped_all = dup_gdf.drop_duplicates()
-    assert len(dropped_all) == gdf_len
-
 # Missing values
 
 
@@ -219,6 +197,7 @@ def test_unique():
     exp = np.array([Point(0, 0), Point(2, 2)])
     assert_array_equal(s.unique(), exp)
 
+
 @pytest.mark.xfail
 def test_value_counts():
     # each object is considered unique
@@ -226,6 +205,28 @@ def test_value_counts():
     res = s.value_counts()
     exp = pd.Series([2, 1], index=[Point(0, 0), Point(1, 1)])
     assert_series_equal(res, exp)
+
+
+@pytest.mark.xfail
+def test_drop_duplicates_series():
+    # currently, geoseries with identical values are not recognized as
+    # duplicates
+    dups = GeoSeries([Point(0, 0), Point(0, 0)])
+    dropped = dups.drop_duplicates()
+    assert len(dropped) == 1
+
+
+@pytest.mark.xfail
+def test_drop_duplicates_frame():
+    # currently, dropping duplicates in a geodataframe produces a TypeError
+    # better behavior would be dropping the duplicated points
+    gdf_len = 3
+    dup_gdf = GeoDataFrame({'geometry': [Point(0, 0) for x in range(gdf_len)],
+                            'value1': range(gdf_len)})
+    dropped_geometry = dup_gdf.drop_duplicates(subset="geometry")
+    assert len(dropped_geometry) == 1
+    dropped_all = dup_gdf.drop_duplicates()
+    assert len(dropped_all) == gdf_len
 
 
 def test_groupby(df):


### PR DESCRIPTION
This adds tests of desired behavior of drop_duplicates as applied to
geoseries and geodataframes, with currently failing tests for both.