### PR TITLE
TST: Fix test of LineString style in mpl>=2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,6 @@ matrix:
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
-  # matplotlib 2.x (development version) causes a few tests to fail
-  allow_failures:
-    - env: PANDAS=master  MATPLOTLIB=master
-
-
 before_install:
   - pip install -U pip
 


### PR DESCRIPTION
I reversed the way the test was applied for simpler handling between matplotlib versions, but I think the basic logic is the same.

Closes #278