### PR TITLE
Open output file in a GDAL error-handling context

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -61,10 +61,11 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None,
     if schema is None:
         schema = infer_schema(df)
     filename = os.path.abspath(os.path.expanduser(filename))
-    with fiona.open(filename, 'w', driver=driver, crs=df.crs,
-                    schema=schema, **kwargs) as c:
-        for feature in df.iterfeatures():
-            c.write(feature)
+    with fiona.drivers():
+        with fiona.open(filename, 'w', driver=driver, crs=df.crs,
+                        schema=schema, **kwargs) as colxn:
+            for feature in df.iterfeatures():
+                colxn.write(feature)
 
 
 def infer_schema(df):


### PR DESCRIPTION
This intercepts GDAL error and warnings so that they go to the Python logger instead of directly to stderr, solving confusing error messages like the one reported at https://github.com/Toblerity/Fiona/issues/468.