### PR TITLE
Clean-up / simplify plotting code

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 import warnings
 
 import numpy as np
-import pandas as pd
+
 from six import next
-from six.moves import xrange
 
 
 def _flatten_multi_geoms(geoms, colors=None):
@@ -118,7 +117,8 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
     ax : matplotlib.axes.Axes
         where shapes will be plotted
 
-    geoms : a sequence of `N` LineStrings and/or MultiLineStrings (can be mixed)
+    geoms : a sequence of `N` LineStrings and/or MultiLineStrings (can be
+            mixed)
 
     values : a sequence of `N` values, optional
         Values will be mapped to colors using vmin/vmax/cmap. They should
@@ -194,7 +194,7 @@ def plot_point_collection(ax, geoms, values=None, color=None,
     return collection
 
 
-def gencolor(N, colormap='Set1'):
+def _gencolor(N, colormap='Set1'):
     """
     Color generator intended to work with one of the ColorBrewer
     qualitative color scales.
@@ -210,52 +210,53 @@ def gencolor(N, colormap='Set1'):
     n_colors = min(N, 9)
     cmap = cm.get_cmap(colormap, n_colors)
     colors = cmap(range(n_colors))
-    for i in xrange(N):
+    for i in range(N):
         yield colors[i % n_colors]
 
 
 def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
                 figsize=None, **color_kwds):
-    """ Plot a GeoSeries
+    """
+    Plot a GeoSeries.
 
-        Generate a plot of a GeoSeries geometry with matplotlib.
+    Generate a plot of a GeoSeries geometry with matplotlib.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
 
-        Series
-            The GeoSeries to be plotted.  Currently Polygon,
-            MultiPolygon, LineString, MultiLineString and Point
-            geometries can be plotted.
+    s : Series
+        The GeoSeries to be plotted.  Currently Polygon,
+        MultiPolygon, LineString, MultiLineString and Point
+        geometries can be plotted.
 
-        cmap : str (default 'Set1')
-            The name of a colormap recognized by matplotlib.  Any
-            colormap will work, but categorical colormaps are
-            generally recommended.  Examples of useful discrete
-            colormaps include:
+    cmap : str (default 'Set1')
+        The name of a colormap recognized by matplotlib.  Any
+        colormap will work, but categorical colormaps are
+        generally recommended.  Examples of useful discrete
+        colormaps include:
 
-                Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
+            Accent, Dark2, Paired, Pastel1, Pastel2, Set1, Set2, Set3
 
-        color : str (default None)
-            If specified, all objects will be colored uniformly.
+    color : str (default None)
+        If specified, all objects will be colored uniformly.
 
-        ax : matplotlib.pyplot.Artist (default None)
-            axes on which to draw the plot
+    ax : matplotlib.pyplot.Artist (default None)
+        axes on which to draw the plot
 
-        linewidth : float (default 1.0)
-            Line width for geometries.
+    linewidth : float (default 1.0)
+        Line width for geometries.
 
-        figsize : pair of floats (default None)
-            Size of the resulting matplotlib.figure.Figure. If the argument
-            ax is given explicitly, figsize is ignored.
+    figsize : pair of floats (default None)
+        Size of the resulting matplotlib.figure.Figure. If the argument
+        ax is given explicitly, figsize is ignored.
 
-        **color_kwds : dict
-            Color options to be passed on to the actual plot function
+    **color_kwds : dict
+        Color options to be passed on to the actual plot function
 
-        Returns
-        -------
+    Returns
+    -------
 
-        matplotlib axes instance
+    matplotlib axes instance
     """
     if 'colormap' in color_kwds:
         warnings.warn("'colormap' is deprecated, please use 'cmap' instead "
@@ -275,8 +276,8 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
     num_geoms = len(s.index)
     col_seq = False
     if color is None:
-        color_generator = gencolor(len(s), colormap=cmap)
-        color = np.array([next(color_generator) for _ in xrange(num_geoms)])
+        color_generator = _gencolor(len(s), colormap=cmap)
+        color = np.array([next(color_generator) for _ in range(num_geoms)])
         col_seq = True
 
     geom_types = s.geometry.type
@@ -318,75 +319,76 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
     return ax
 
 
-def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
+def plot_dataframe(df, column=None, cmap=None, color=None, linewidth=1.0,
                    categorical=False, legend=False, ax=None,
                    scheme=None, k=5, vmin=None, vmax=None, figsize=None,
                    **color_kwds):
-    """ Plot a GeoDataFrame
+    """
+    Plot a GeoDataFrame.
 
-        Generate a plot of a GeoDataFrame with matplotlib.  If a
-        column is specified, the plot coloring will be based on values
-        in that column.  Otherwise, a categorical plot of the
-        geometries in the `geometry` column will be generated.
+    Generate a plot of a GeoDataFrame with matplotlib.  If a
+    column is specified, the plot coloring will be based on values
+    in that column.  Otherwise, a categorical plot of the
+    geometries in the `geometry` column will be generated.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
 
-        GeoDataFrame
-            The GeoDataFrame to be plotted.  Currently Polygon,
-            MultiPolygon, LineString, MultiLineString and Point
-            geometries can be plotted.
+    df : GeoDataFrame
+        The GeoDataFrame to be plotted.  Currently Polygon,
+        MultiPolygon, LineString, MultiLineString and Point
+        geometries can be plotted.
 
-        column : str (default None)
-            The name of the column to be plotted. Ignored if `color` is also set.
+    column : str (default None)
+        The name of the column to be plotted. Ignored if `color` is also set.
 
-        categorical : bool (default False)
-            If False, cmap will reflect numerical values of the
-            column being plotted.  For non-numerical columns (or if
-            column=None), this will be set to True.
+    categorical : bool (default False)
+        If False, cmap will reflect numerical values of the
+        column being plotted.  For non-numerical columns (or if
+        column=None), this will be set to True.
 
-        cmap : str (default 'Set1')
-            The name of a colormap recognized by matplotlib.
+    cmap : str (default 'Set1')
+        The name of a colormap recognized by matplotlib.
 
-        color : str (default None)
-            If specified, all objects will be colored uniformly.
+    color : str (default None)
+        If specified, all objects will be colored uniformly.
 
-        linewidth : float (default 1.0)
-            Line width for geometries.
+    linewidth : float (default 1.0)
+        Line width for geometries.
 
-        legend : bool (default False)
-            Plot a legend. Ignored if no `column` is given, or if `color` is given.
+    legend : bool (default False)
+        Plot a legend. Ignored if no `column` is given, or if `color` is given.
 
-        ax : matplotlib.pyplot.Artist (default None)
-            axes on which to draw the plot
+    ax : matplotlib.pyplot.Artist (default None)
+        axes on which to draw the plot
 
-        scheme : pysal.esda.mapclassify.Map_Classifier
-            Choropleth classification schemes (requires PySAL)
+    scheme : pysal.esda.mapclassify.Map_Classifier
+        Choropleth classification schemes (requires PySAL)
 
-        k   : int (default 5)
-            Number of classes (ignored if scheme is None)
+    k   : int (default 5)
+        Number of classes (ignored if scheme is None)
 
-        vmin : None or float (default None)
+    vmin : None or float (default None)
 
-            Minimum value of cmap. If None, the minimum data value
-            in the column to be plotted is used.
+        Minimum value of cmap. If None, the minimum data value
+        in the column to be plotted is used.
 
-        vmax : None or float (default None)
+    vmax : None or float (default None)
 
-            Maximum value of cmap. If None, the maximum data value
-            in the column to be plotted is used.
+        Maximum value of cmap. If None, the maximum data value
+        in the column to be plotted is used.
 
-        figsize
-            Size of the resulting matplotlib.figure.Figure. If the argument
-            axes is given explicitly, figsize is ignored.
+    figsize
+        Size of the resulting matplotlib.figure.Figure. If the argument
+        axes is given explicitly, figsize is ignored.
 
-        **color_kwds : dict
-            Color options to be passed on to the actual plot function
+    **color_kwds : dict
+        Color options to be passed on to the actual plot function
 
-        Returns
-        -------
+    Returns
+    -------
 
-        matplotlib axes instance
+    matplotlib axes instance
     """
     if 'colormap' in color_kwds:
         warnings.warn("'colormap' is deprecated, please use 'cmap' instead "
@@ -397,33 +399,30 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
                       "(for consistency with pandas)", FutureWarning)
         ax = color_kwds.pop('axes')
     if column and color:
-        warnings.warn("Only specify one of 'column' or 'color'. Using 'color'.",
-                      SyntaxWarning)
+        warnings.warn("Only specify one of 'column' or 'color'. Using "
+                      "'color'.", UserWarning)
         column = None
 
     import matplotlib.pyplot as plt
-    from matplotlib.lines import Line2D
-    from matplotlib.colors import Normalize
-    from matplotlib import cm
 
     if column is None:
-        return plot_series(s.geometry, cmap=cmap, color=color,
+        return plot_series(df.geometry, cmap=cmap, color=color,
                            ax=ax, linewidth=linewidth, figsize=figsize,
                            **color_kwds)
 
-    if s[column].dtype is np.dtype('O'):
+    if df[column].dtype is np.dtype('O'):
         categorical = True
 
     # Define `values` as a Series
     if categorical:
         if cmap is None:
             cmap = 'Set1'
-        categories = list(set(s[column].values))
+        categories = list(set(df[column].values))
         categories.sort()
         valuemap = dict([(k, v) for (v, k) in enumerate(categories)])
-        values = np.array([valuemap[k] for k in s[column]])
+        values = np.array([valuemap[k] for k in df[column]])
     else:
-        values = s[column]
+        values = df[column]
     if scheme is not None:
         binning = __pysal_choro(values, scheme, k=k)
         values = np.array(binning.yb)
@@ -432,6 +431,7 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
         binedges = [binning.yb.min()] + binning.bins.tolist()
         categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
                       for i in range(len(binedges)-1)]
+
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
@@ -439,7 +439,7 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
     mn = values.min() if vmin is None else vmin
     mx = values.max() if vmax is None else vmax
 
-    geom_types = s.geometry.type
+    geom_types = df.geometry.type
     poly_idx = np.asarray((geom_types == 'Polygon')
                           | (geom_types == 'MultiPolygon'))
     line_idx = np.asarray((geom_types == 'LineString')
@@ -447,34 +447,39 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
     point_idx = np.asarray(geom_types == 'Point')
 
     # plot all Polygons and all MultiPolygon components in the same collection
-    polys = s.geometry[poly_idx]
+    polys = df.geometry[poly_idx]
     if not polys.empty:
         plot_polygon_collection(ax, polys, values[poly_idx],
-                                    vmin=mn, vmax=mx, cmap=cmap,
-                                    linewidth=linewidth, **color_kwds)
+                                vmin=mn, vmax=mx, cmap=cmap,
+                                linewidth=linewidth, **color_kwds)
 
     # plot all LineStrings and MultiLineString components in same collection
-    lines = s.geometry[line_idx]
+    lines = df.geometry[line_idx]
     if not lines.empty:
         plot_linestring_collection(ax, lines, values[line_idx],
                                    vmin=mn, vmax=mx, cmap=cmap,
                                    linewidth=linewidth, **color_kwds)
 
     # plot all Points in the same collection
-    points = s.geometry[point_idx]
+    points = df.geometry[point_idx]
     if not points.empty:
         plot_point_collection(ax, points, values[point_idx],
                               vmin=mn, vmax=mx, cmap=cmap, **color_kwds)
 
     if legend and not color:
+        from matplotlib.lines import Line2D
+        from matplotlib.colors import Normalize
+        from matplotlib import cm
+
         norm = Normalize(vmin=mn, vmax=mx)
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
         if categorical:
             patches = []
             for value, cat in enumerate(categories):
-                patches.append(Line2D([0], [0], linestyle="none",
-                                      marker="o", alpha=color_kwds.get('alpha', 0.5),
-                                      markersize=10, markerfacecolor=n_cmap.to_rgba(value)))
+                patches.append(
+                    Line2D([0], [0], linestyle="none", marker="o",
+                           alpha=color_kwds.get('alpha', 0.5), markersize=10,
+                           markerfacecolor=n_cmap.to_rgba(value)))
             ax.legend(patches, categories, numpoints=1, loc='best')
         else:
             n_cmap.set_array([])
@@ -485,38 +490,41 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
 
 
 def __pysal_choro(values, scheme, k=5):
-    """ Wrapper for choropleth schemes from PySAL for use with plot_dataframe
-
-        Parameters
-        ----------
-
-        values
-            Series to be plotted
-
-        scheme
-            pysal.esda.mapclassify classificatin scheme
-            ['Equal_interval'|'Quantiles'|'Fisher_Jenks']
-
-        k
-            number of classes (2 <= k <=9)
-
-        Returns
-        -------
-
-        binning
-            Binning objects that holds the Series with values replaced with
-            class identifier and the bins.
     """
+    Wrapper for choropleth schemes from PySAL for use with plot_dataframe
 
+    Parameters
+    ----------
+
+    values
+        Series to be plotted
+
+    scheme
+        pysal.esda.mapclassify classificatin scheme
+        ['Equal_interval'|'Quantiles'|'Fisher_Jenks']
+
+    k
+        number of classes (2 <= k <=9)
+
+    Returns
+    -------
+
+    binning
+        Binning objects that holds the Series with values replaced with
+        class identifier and the bins.
+
+    """
     try:
-        from pysal.esda.mapclassify import Quantiles, Equal_Interval, Fisher_Jenks
+        from pysal.esda.mapclassify import (
+            Quantiles, Equal_Interval, Fisher_Jenks)
         schemes = {}
         schemes['equal_interval'] = Equal_Interval
         schemes['quantiles'] = Quantiles
         schemes['fisher_jenks'] = Fisher_Jenks
         scheme = scheme.lower()
         if scheme not in schemes:
-            raise ValueError("Invalid scheme. Scheme must be in the set: %r" % schemes.keys())
+            raise ValueError("Invalid scheme. Scheme must be in the"
+                             " set: %r" % schemes.keys())
         binning = schemes[scheme](values, k)
         return binning
     except ImportError:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -8,11 +8,13 @@ from six import next
 from six.moves import xrange
 
 
-def _flatten_multi_geoms(geoms, colors):
+def _flatten_multi_geoms(geoms, colors=None):
     """
     Returns Series like geoms and colors, except that any Multi geometries
     are split into their components and colors are repeated for all component
     in the same Multi geometry.  Maintains 1:1 matching of geometry to color.
+    Passing `color` is optional, and when no `color` is passed a list of None
+    values is returned as `component_colors`.
 
     "Colors" are treated opaquely and so can actually contain any values.
 
@@ -23,9 +25,7 @@ def _flatten_multi_geoms(geoms, colors):
 
     component_colors : list of whatever type `colors` contains
     """
-    was_none = False
     if colors is None:
-        was_none = True
         colors = [None] * len(geoms)
 
     components, component_colors = [], []
@@ -42,8 +42,6 @@ def _flatten_multi_geoms(geoms, colors):
             components.append(geom)
             component_colors.append(color)
 
-    if was_none:
-        component_colors = None
     return components, component_colors
 
 
@@ -61,7 +59,7 @@ def plot_polygon_collection(ax, geoms, values=None, linewidth=1.0,
 
     geoms : a sequence of `N` Polygons and/or MultiPolygons (can be mixed)
 
-    values : a sequence of `N` values
+    values : a sequence of `N` values, optional
         Values will be mapped to colors using vmin/vmax/cmap. They should
         have 1:1 correspondence with the geometries (not their components).
         Otherwise follows `color` / `facecolor` kwargs.
@@ -87,6 +85,8 @@ def plot_polygon_collection(ax, geoms, values=None, linewidth=1.0,
     from matplotlib.collections import PatchCollection
 
     geoms, values = _flatten_multi_geoms(geoms, values)
+    if None in values:
+        values = None
 
     # PatchCollection does not accept some kwargs.
     if 'markersize' in kwargs:
@@ -120,7 +120,7 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
 
     geoms : a sequence of `N` LineStrings and/or MultiLineStrings (can be mixed)
 
-    values : a sequence of `N` values
+    values : a sequence of `N` values, optional
         Values will be mapped to colors using vmin/vmax/cmap. They should
         have 1:1 correspondence with the geometries (not their components).
 
@@ -136,6 +136,8 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
     from matplotlib.collections import LineCollection
 
     geoms, values = _flatten_multi_geoms(geoms, values)
+    if None in values:
+        values = None
 
     # LineCollection does not accept some kwargs.
     if 'markersize' in kwargs:
@@ -172,9 +174,9 @@ def plot_point_collection(ax, geoms, values=None, color=None,
 
     geoms : sequence of `N` Points
 
-    values : sequence of color or sequence of numbers
-        A sequence of `N` numbers to be mapped to colors using vmin, vmax,
-        and cmap. Cannot be specified together with `color`.
+    values : a sequence of `N` values, optional
+        Values mapped to colors using vmin, vmax, and cmap.
+        Cannot be specified together with `color`.
 
     Returns
     -------

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -47,9 +47,9 @@ def _flatten_multi_geoms(geoms, colors):
     return components, component_colors
 
 
-def plot_polygon_collection(ax, geoms, colors_or_values, plot_values,
-                            vmin=None, vmax=None, cmap=None,
-                            edgecolor='black', alpha=0.5, linewidth=1.0, **kwargs):
+def plot_polygon_collection(ax, geoms, values=None, linewidth=1.0,
+                            edgecolor='black', alpha=0.5,
+                            vmin=None, vmax=None, cmap=None, **kwargs):
     """
     Plots a collection of Polygon and MultiPolygon geometries to `ax`
 
@@ -61,51 +61,45 @@ def plot_polygon_collection(ax, geoms, colors_or_values, plot_values,
 
     geoms : a sequence of `N` Polygons and/or MultiPolygons (can be mixed)
 
-    colors_or_values : a sequence of `N` values or RGBA tuples
-        It should have 1:1 correspondence with the geometries (not their components).
+    values : a sequence of `N` values
+        Values will be mapped to colors using vmin/vmax/cmap. They should
+        have 1:1 correspondence with the geometries (not their components).
+        Otherwise follows `color` / `facecolor` kwargs.
 
-    plot_values : bool
-        If True, `colors_or_values` is interpreted as a list of values, and will
-        be mapped to colors using vmin/vmax/cmap (which become required).
-        Otherwise `colors_or_values` is interpreted as a list of colors.
+    edgecolor : single color or sequence of `N` colors
+        Color for the edge of the polygons
+
+    facecolor : single color or sequence of `N` colors
+        Color to fill the polygons. Cannot be used together with `values`.
+
+    color : single color or sequence of `N` colors
+        Sets both `edgecolor` and `facecolor`
+
+    **kwargs
+        Additional keyword arguments passed to the collection
 
     Returns
     -------
 
     collection : matplotlib.collections.Collection that was plotted
     """
-
     from descartes.patch import PolygonPatch
     from matplotlib.collections import PatchCollection
 
-    components, component_colors_or_values = _flatten_multi_geoms(
-        geoms, colors_or_values)
+    geoms, values = _flatten_multi_geoms(geoms, values)
 
     # PatchCollection does not accept some kwargs.
     if 'markersize' in kwargs:
         del kwargs['markersize']
-    collection = PatchCollection([PolygonPatch(poly) for poly in components],
+
+    collection = PatchCollection([PolygonPatch(poly) for poly in geoms],
                                  linewidth=linewidth, edgecolor=edgecolor,
                                  alpha=alpha, **kwargs)
 
-    if plot_values:
-        collection.set_array(np.array(component_colors_or_values))
+    if values is not None:
+        collection.set_array(np.asarray(values))
         collection.set_cmap(cmap)
         collection.set_clim(vmin, vmax)
-    else:
-        # set_color magically sets the correct combination of facecolor and
-        # edgecolor, based on collection type.
-        collection.set_color(component_colors_or_values)
-
-        # If the user set facecolor and/or edgecolor explicitly, the previous
-        # call to set_color might have overridden it (remember, the 'color' may
-        # have come from plot_series, not from the user). The user should be
-        # able to override matplotlib's default behavior, by setting them again
-        # after set_color.
-        if 'facecolor' in kwargs:
-            collection.set_facecolor(kwargs['facecolor'])
-        if edgecolor:
-            collection.set_edgecolor(edgecolor)
 
     ax.add_collection(collection, autolim=True)
     ax.autoscale_view()
@@ -141,8 +135,7 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
     """
     from matplotlib.collections import LineCollection
 
-    geoms, values = _flatten_multi_geoms(
-        geoms, values)
+    geoms, values = _flatten_multi_geoms(geoms, values)
 
     # LineCollection does not accept some kwargs.
     if 'markersize' in kwargs:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -169,7 +169,7 @@ def plot_linestring_collection(ax, geoms, colors_or_values, plot_values,
     return collection
 
 
-def plot_point_collection(ax, geoms, colors_or_values,
+def plot_point_collection(ax, geoms, values=None, color=None,
                           vmin=None, vmax=None, cmap=None,
                           marker='o', markersize=2, **kwargs):
     """
@@ -183,25 +183,23 @@ def plot_point_collection(ax, geoms, colors_or_values,
 
     geoms : sequence of `N` Points
 
-    colors_or_values : sequence of color or sequence of numbers
-        can be a sequence of color specifications of length `N` or a sequence
-        of `N` numbers to be mapped to colors using vmin, vmax, and cmap.
+    values : sequence of color or sequence of numbers
+        A sequence of `N` numbers to be mapped to colors using vmin, vmax,
+        and cmap. Cannot be specified together with `color`.
 
     Returns
     -------
     collection : matplotlib.collections.Collection that was plotted
     """
-    x = [p.x for p in geoms]
-    y = [p.y for p in geoms]
+    if values is not None and color is not None:
+        raise ValueError("Can only specify one of 'values' and 'color' kwargs")
 
-    # matplotlib ax.scatter requires RGBA color specifications to be a single 2D
-    # array, NOT merely a list of 1D arrays. This reshapes that if necessary,
-    # having no effect on 1D arrays of values.
-    colors_or_values = np.array([element
-                                 for _, element in enumerate(colors_or_values)])
-    collection = ax.scatter(x, y, c=colors_or_values,
+    x = geoms.x.values
+    y = geoms.y.values
+
+    collection = ax.scatter(x, y, s=markersize, c=values, color=color,
                             vmin=vmin, vmax=vmax, cmap=cmap,
-                            marker=marker, s=markersize, **kwargs)
+                            marker=marker, **kwargs)
     return collection
 
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -277,9 +277,14 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
         color = np.array([next(color_generator) for _ in xrange(num_geoms)])
         col_seq = True
 
+    geom_types = s.geometry.type
+    poly_idx = np.asarray((geom_types == 'Polygon')
+                          | (geom_types == 'MultiPolygon'))
+    line_idx = np.asarray((geom_types == 'LineString')
+                          | (geom_types == 'MultiLineString'))
+    point_idx = np.asarray(geom_types == 'Point')
+
     # plot all Polygons and all MultiPolygon components in the same collection
-    poly_idx = np.array(
-        (s.geometry.type == 'Polygon') | (s.geometry.type == 'MultiPolygon'))
     polys = s.geometry[poly_idx]
 
     if not polys.empty:
@@ -291,26 +296,21 @@ def plot_series(s, cmap='Set1', color=None, ax=None, linewidth=1.0,
                 facecolor = color[poly_idx] if col_seq else color
         else:
             facecolor = color
-        plot_polygon_collection(ax, polys,
-                                facecolor=facecolor,
+        plot_polygon_collection(ax, polys, facecolor=facecolor,
                                 linewidth=linewidth, **color_kwds)
 
     # plot all LineStrings and MultiLineString components in same collection
-    line_idx = np.array(
-        (s.geometry.type == 'LineString') |
-        (s.geometry.type == 'MultiLineString'))
     lines = s.geometry[line_idx]
     if not lines.empty:
-        plot_linestring_collection(ax, lines,
-                                   color=color[line_idx] if col_seq else color,
+        color_ = color[line_idx] if col_seq else color
+        plot_linestring_collection(ax, lines, color=color_,
                                    linewidth=linewidth, **color_kwds)
 
-    point_idx = np.array(s.geometry.type == 'Point')
+    # plot all Points in the same collection
     points = s.geometry[point_idx]
     if not points.empty:
-        plot_point_collection(ax, points,
-                              color=color[point_idx] if col_seq else color,
-                              **color_kwds)
+        color_ = color[point_idx] if col_seq else color
+        plot_point_collection(ax, points, color=color_, **color_kwds)
 
     plt.draw()
     return ax
@@ -437,9 +437,14 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
     mn = values.min() if vmin is None else vmin
     mx = values.max() if vmax is None else vmax
 
+    geom_types = s.geometry.type
+    poly_idx = np.asarray((geom_types == 'Polygon')
+                          | (geom_types == 'MultiPolygon'))
+    line_idx = np.asarray((geom_types == 'LineString')
+                          | (geom_types == 'MultiLineString'))
+    point_idx = np.asarray(geom_types == 'Point')
+
     # plot all Polygons and all MultiPolygon components in the same collection
-    poly_idx = np.array(
-        (s.geometry.type == 'Polygon') | (s.geometry.type == 'MultiPolygon'))
     polys = s.geometry[poly_idx]
     if not polys.empty:
         plot_polygon_collection(ax, polys, values[poly_idx],
@@ -447,16 +452,13 @@ def plot_dataframe(s, column=None, cmap=None, color=None, linewidth=1.0,
                                     linewidth=linewidth, **color_kwds)
 
     # plot all LineStrings and MultiLineString components in same collection
-    line_idx = np.array(
-        (s.geometry.type == 'LineString') |
-        (s.geometry.type == 'MultiLineString'))
     lines = s.geometry[line_idx]
     if not lines.empty:
         plot_linestring_collection(ax, lines, values[line_idx],
                                    vmin=mn, vmax=mx, cmap=cmap,
                                    linewidth=linewidth, **color_kwds)
 
-    point_idx = np.array(s.geometry.type == 'Point')
+    # plot all Points in the same collection
     points = s.geometry[point_idx]
     if not points.empty:
         plot_point_collection(ax, points, values[point_idx],

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -57,19 +57,19 @@ class TestPointPlotting:
         ax = self.points.plot()
         cmap = plt.get_cmap('Set1', 9)
         expected_colors = cmap(list(range(9))*2)
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
         # GeoDataFrame -> uses 'jet' instead of 'Set1'
         ax = self.df.plot()
         cmap = plt.get_cmap(lut=9)
         expected_colors = cmap(list(range(9))*2)
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
         # # with specifying values -> different colors for all 10 values
         ax = self.df.plot(column='values')
         cmap = plt.get_cmap()
         expected_colors = cmap(np.arange(self.N)/(self.N-1))
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
     def test_colormap(self):
 
@@ -79,30 +79,30 @@ class TestPointPlotting:
         ax = self.points.plot(cmap='RdYlGn')
         cmap = plt.get_cmap('RdYlGn', 9)
         expected_colors = cmap(list(range(9))*2)
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
         # GeoDataFrame -> same as GeoSeries in this case
         ax = self.df.plot(cmap='RdYlGn')
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
         # # with specifying values -> different colors for all 10 values
         ax = self.df.plot(column='values', cmap='RdYlGn')
         cmap = plt.get_cmap('RdYlGn')
         expected_colors = cmap(np.arange(self.N)/(self.N-1))
-        _check_colors(self.N, ax.collections[0], expected_colors)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
     def test_single_color(self):
 
         ax = self.points.plot(color='green')
-        _check_colors(self.N, ax.collections[0], ['green']*self.N)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), ['green']*self.N)
 
         ax = self.df.plot(color='green')
-        _check_colors(self.N, ax.collections[0], ['green']*self.N)
+        _check_colors(self.N, ax.collections[0].get_facecolors(), ['green']*self.N)
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
             ax = self.df.plot(column='values', color='green')
-            _check_colors(self.N, ax.collections[0], ['green']*self.N)
+            _check_colors(self.N, ax.collections[0].get_facecolors(), ['green']*self.N)
 
     def test_style_kwargs(self):
 
@@ -177,15 +177,15 @@ class TestLineStringPlotting:
     def test_single_color(self):
 
         ax = self.lines.plot(color='green')
-        _check_colors(self.N, ax.collections[0], ['green']*self.N)
+        _check_colors(self.N, ax.collections[0].get_colors(), ['green']*self.N)
 
         ax = self.df.plot(color='green')
-        _check_colors(self.N, ax.collections[0], ['green']*self.N)
+        _check_colors(self.N, ax.collections[0].get_colors(), ['green']*self.N)
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
             ax = self.df.plot(column='values', color='green')
-            _check_colors(self.N, ax.collections[0], ['green']*self.N)
+            _check_colors(self.N, ax.collections[0].get_colors(), ['green']*self.N)
 
     def test_style_kwargs(self):
 
@@ -225,31 +225,18 @@ class TestPolygonPlotting:
     def test_single_color(self):
 
         ax = self.polys.plot(color='green')
-        _check_colors(2, ax.collections[0], ['green']*2, alpha=0.5)
+        _check_colors(2, ax.collections[0].get_facecolors(), ['green']*2, alpha=0.5)
+        # color only sets facecolor
+        _check_colors(2, ax.collections[0].get_edgecolors(), ['k'] * 2, alpha=0.5)
 
         ax = self.df.plot(color='green')
-        _check_colors(2, ax.collections[0], ['green']*2, alpha=0.5)
+        _check_colors(2, ax.collections[0].get_facecolors(), ['green']*2, alpha=0.5)
+        _check_colors(2, ax.collections[0].get_edgecolors(), ['k'] * 2, alpha=0.5)
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'values'
             ax = self.df.plot(column='values', color='green')
-            _check_colors(2, ax.collections[0], ['green']*2, alpha=0.5)
-
-    def test_optimization(self):
-
-        # when linewidth=0 or no alpha, we don't have to plot polys twice
-
-        ax = self.polys.plot(linewidth=0)
-        assert len(ax.collections) == 1  # only plotted once
-
-        ax = self.polys.plot(alpha=1)
-        assert len(ax.collections) == 1  # only plotted once
-
-        ax = self.df.plot(linewidth=0)
-        assert len(ax.collections) == 1  # only plotted once
-
-        ax = self.df.plot(alpha=1)
-        assert len(ax.collections) == 1  # only plotted once
+            _check_colors(2, ax.collections[0].get_facecolors(), ['green']*2, alpha=0.5)
 
     def test_vmin_vmax(self):
 
@@ -269,7 +256,7 @@ class TestPolygonPlotting:
 
         # facecolor overrides default cmap when color is not set
         ax = self.polys.plot(facecolor='k')
-        _check_colors(2, ax.collections[0], ['k']*2, alpha=0.5)
+        _check_colors(2, ax.collections[0].get_facecolors(), ['k']*2, alpha=0.5)
 
         # facecolor overrides more general-purpose color when both are set
         ax = self.polys.plot(color='red', facecolor='k')
@@ -301,7 +288,7 @@ class TestPolygonPlotting:
 
         ax = self.df2.plot('values')
         # specifying values -> same as without values in this case.
-        _check_colors(4, ax.collections[0], expected_colors, alpha=0.5)
+        _check_colors(4, ax.collections[0].get_facecolors(), expected_colors, alpha=0.5)
 
 
 class TestPolygonZPlotting:
@@ -339,9 +326,9 @@ class TestNonuniformGeometryPlotting:
         ax = self.series.plot(cmap='RdYlGn')
         cmap = plt.get_cmap('RdYlGn', 3)
         # polygon gets extra alpha. See #266
-        _check_colors(1, ax.collections[0], [cmap(0)], alpha=0.5)
-        _check_colors(1, ax.collections[1], [cmap(1)], alpha=1)   # line
-        _check_colors(1, ax.collections[2], [cmap(2)], alpha=1)   # point
+        _check_colors(1, ax.collections[0].get_facecolors(), [cmap(0)], alpha=0.5)
+        _check_colors(1, ax.collections[1].get_facecolors(), [cmap(1)], alpha=1)   # line
+        _check_colors(1, ax.collections[2].get_facecolors(), [cmap(2)], alpha=1)   # point
 
     def test_style_kwargs(self):
 
@@ -405,28 +392,28 @@ class TestPlotCollections:
 
         # default: single default matplotlib color
         coll = plot_point_collection(ax, self.points)
-        _check_colors2(self.N, coll.get_facecolors(), [MPL_DFT_COLOR] * self.N)
+        _check_colors(self.N, coll.get_facecolors(), [MPL_DFT_COLOR] * self.N)
         # edgecolor depends on matplotlib version
-        # _check_colors2(self.N, coll.get_edgecolors(), [MPL_DFT_COLOR]*self.N)
+        # _check_colors(self.N, coll.get_edgecolors(), [MPL_DFT_COLOR]*self.N)
         ax.cla()
 
         # specify single other color
         coll = plot_point_collection(ax, self.points, color='g')
-        _check_colors2(self.N, coll.get_facecolors(), ['g'] * self.N)
-        _check_colors2(self.N, coll.get_edgecolors(), ['g'] * self.N)
+        _check_colors(self.N, coll.get_facecolors(), ['g'] * self.N)
+        _check_colors(self.N, coll.get_edgecolors(), ['g'] * self.N)
         ax.cla()
 
         # specify edgecolor/facecolor
         coll = plot_point_collection(ax, self.points, facecolor='g',
                                      edgecolor='r')
-        _check_colors2(self.N, coll.get_facecolors(), ['g'] * self.N)
-        _check_colors2(self.N, coll.get_edgecolors(), ['r'] * self.N)
+        _check_colors(self.N, coll.get_facecolors(), ['g'] * self.N)
+        _check_colors(self.N, coll.get_edgecolors(), ['r'] * self.N)
         ax.cla()
 
         # list of colors
         coll = plot_point_collection(ax, self.points, color=['r', 'g', 'b'])
-        _check_colors2(self.N, coll.get_facecolors(), ['r', 'g', 'b'])
-        _check_colors2(self.N, coll.get_edgecolors(), ['r', 'g', 'b'])
+        _check_colors(self.N, coll.get_facecolors(), ['r', 'g', 'b'])
+        _check_colors(self.N, coll.get_edgecolors(), ['r', 'g', 'b'])
         ax.cla()
 
     def test_points_values(self):
@@ -440,8 +427,8 @@ class TestPlotCollections:
 
         # not sure why this is failing (gives only a single color, when
         # testing outside of pytest, this works perfectly
-        # _check_colors2(self.N, coll.get_facecolors(), expected_colors)
-        # _check_colors2(self.N, coll.get_edgecolors(), expected_colors)
+        # _check_colors(self.N, coll.get_facecolors(), expected_colors)
+        # _check_colors(self.N, coll.get_edgecolors(), expected_colors)
 
     def test_linestrings(self):
         from geopandas.plotting import plot_linestring_collection
@@ -454,25 +441,25 @@ class TestPlotCollections:
 
         # default: single default matplotlib color
         coll = plot_linestring_collection(ax, self.lines)
-        _check_colors2(self.N, coll.get_color(), [MPL_DFT_COLOR] * self.N)
+        _check_colors(self.N, coll.get_color(), [MPL_DFT_COLOR] * self.N)
         ax.cla()
 
         # specify single other color
         coll = plot_linestring_collection(ax, self.lines, color='g')
-        _check_colors2(self.N, coll.get_colors(), ['g'] * self.N)
+        _check_colors(self.N, coll.get_colors(), ['g'] * self.N)
         ax.cla()
 
         # specify edgecolor / facecolor
         coll = plot_linestring_collection(ax, self.lines, facecolor='g',
                                           edgecolor='r')
-        _check_colors2(self.N, coll.get_facecolors(), ['g'] * self.N)
-        _check_colors2(self.N, coll.get_edgecolors(), ['r'] * self.N)
+        _check_colors(self.N, coll.get_facecolors(), ['g'] * self.N)
+        _check_colors(self.N, coll.get_edgecolors(), ['r'] * self.N)
         ax.cla()
 
         # list of colors
         coll = plot_linestring_collection(ax, self.lines,
                                           color=['r', 'g', 'b'])
-        _check_colors2(self.N, coll.get_colors(), ['r', 'g', 'b'])
+        _check_colors(self.N, coll.get_colors(), ['r', 'g', 'b'])
         ax.cla()
 
         # pass through of kwargs
@@ -493,7 +480,7 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         expected_colors = cmap(np.arange(self.N))
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_color(), expected_colors)
+        # _check_colors(self.N, coll.get_color(), expected_colors)
         ax.cla()
 
         # specify colormap
@@ -502,7 +489,7 @@ class TestPlotCollections:
         cmap = plt.get_cmap('RdBu')
         expected_colors = cmap(np.arange(self.N))
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_color(), expected_colors)
+        # _check_colors(self.N, coll.get_color(), expected_colors)
         ax.cla()
 
         # specify vmin/vmax
@@ -511,7 +498,7 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         expected_colors = cmap([0])
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_color(), expected_colors)
+        # _check_colors(self.N, coll.get_color(), expected_colors)
         ax.cla()
 
     def test_polygons(self):
@@ -526,29 +513,29 @@ class TestPlotCollections:
         # default: single default matplotlib color
         # but with default alpha of 0.5 and black edgecolor
         coll = plot_polygon_collection(ax, self.polygons)
-        _check_colors2(self.N, coll.get_facecolor(), [MPL_DFT_COLOR] * self.N,
+        _check_colors(self.N, coll.get_facecolor(), [MPL_DFT_COLOR] * self.N,
                        alpha=0.5)
-        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
         ax.cla()
 
         # default: color sets both facecolor and edgecolor
         # TODO but test fails for edge (still black)
         coll = plot_polygon_collection(ax, self.polygons, color='g')
-        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
-        # _check_colors2(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        # _check_colors(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
         ax.cla()
 
         # only setting facecolor keeps default for edgecolor
         coll = plot_polygon_collection(ax, self.polygons, facecolor='g')
-        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
-        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
         ax.cla()
 
         # custom facecolor and edgecolor
         coll = plot_polygon_collection(ax, self.polygons, facecolor='g',
                                        edgecolor='r')
-        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
-        _check_colors2(self.N, coll.get_edgecolor(), ['r'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        _check_colors(self.N, coll.get_edgecolor(), ['r'] * self.N, alpha=0.5)
         ax.cla()
 
     def test_polygons_values(self):
@@ -561,8 +548,8 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         exp_colors = cmap(np.arange(self.N))
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
-        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        # _check_colors(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        _check_colors(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
         ax.cla()
 
         # specify colormap
@@ -571,7 +558,7 @@ class TestPlotCollections:
         cmap = plt.get_cmap('RdBu')
         exp_colors = cmap(np.arange(self.N))
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        # _check_colors(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
         ax.cla()
 
         # specify vmin/vmax
@@ -580,7 +567,7 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         exp_colors = cmap([0])
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        # _check_colors(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
         ax.cla()
 
         # override edgecolor
@@ -589,12 +576,12 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         exp_colors = cmap(np.arange(self.N))
         # failing, see above with points
-        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
-        _check_colors2(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
+        # _check_colors(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        _check_colors(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
         ax.cla()
 
 
-def _check_colors(N, collection, expected_colors, alpha=None):
+def _check_colors(N, actual_colors, expected_colors, alpha=None):
     """
     Asserts that the members of `collection` match the `expected_colors`
     (in order)
@@ -616,21 +603,6 @@ def _check_colors(N, collection, expected_colors, alpha=None):
         `expected_colors`. (Any transparency on the `collecton` is assumed
         to be set in its own facecolor RGBA tuples.)
     """
-    import matplotlib.colors as colors
-    conv = colors.colorConverter
-
-    # Convert 2D numpy array to a list of RGBA tuples.
-    actual_colors = list(collection.get_facecolors())
-    actual_colors = map(tuple, actual_colors)
-    all_actual_colors = list(itertools.islice(
-        itertools.cycle(actual_colors), N))
-
-    for actual, expected in zip(all_actual_colors, expected_colors):
-        assert actual == conv.to_rgba(expected, alpha=alpha), \
-            '{} != {}'.format(actual, conv.to_rgba(expected, alpha=alpha))
-
-
-def _check_colors2(N, actual_colors, expected_colors, alpha=None):
     import matplotlib.colors as colors
     conv = colors.colorConverter
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -368,6 +368,8 @@ class TestPlotCollections:
         self.points = GeoSeries(Point(i, i) for i in range(self.N))
         self.lines = GeoSeries([LineString([(0, i), (4, i + 0.5), (9, i)])
                                 for i in range(self.N)])
+        self.polygons = GeoSeries([Polygon([(0, i), (4, i + 0.5), (9, i)])
+                                   for i in range(self.N)])
 
     def test_points(self):
         from geopandas.plotting import plot_point_collection
@@ -459,7 +461,7 @@ class TestPlotCollections:
         assert tuple(res_ls[1]) == exp_ls[1]
         ax.cla()
 
-    def test_linestring_values(self):
+    def test_linestrings_values(self):
         from geopandas.plotting import plot_linestring_collection
 
         fig, ax = plt.subplots()
@@ -488,6 +490,86 @@ class TestPlotCollections:
         expected_colors = cmap([0])
         # failing, see above with points
         # _check_colors2(self.N, coll.get_color(), expected_colors)
+        ax.cla()
+
+    def test_polygons(self):
+        from geopandas.plotting import plot_polygon_collection
+        from matplotlib.collections import PatchCollection
+
+        fig, ax = plt.subplots()
+        coll = plot_polygon_collection(ax, self.polygons)
+        assert isinstance(coll, PatchCollection)
+        ax.cla()
+
+        # default: single default matplotlib color
+        # but with default alpha of 0.5 and black edgecolor
+        coll = plot_polygon_collection(ax, self.polygons)
+        dflt_col = matplotlib.rcParams['axes.prop_cycle'].by_key()['color'][0]
+        _check_colors2(self.N, coll.get_facecolor(), [dflt_col] * self.N,
+                       alpha=0.5)
+        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        ax.cla()
+
+        # default: color sets both facecolor and edgecolor
+        # TODO but test fails for edge (still black)
+        coll = plot_polygon_collection(ax, self.polygons, color='g')
+        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        # _check_colors2(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
+        ax.cla()
+
+        # only setting facecolor keeps default for edgecolor
+        coll = plot_polygon_collection(ax, self.polygons, facecolor='g')
+        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        ax.cla()
+
+        # custom facecolor and edgecolor
+        coll = plot_polygon_collection(ax, self.polygons, facecolor='g',
+                                       edgecolor='r')
+        _check_colors2(self.N, coll.get_facecolor(), ['g'] * self.N, alpha=0.5)
+        _check_colors2(self.N, coll.get_edgecolor(), ['r'] * self.N, alpha=0.5)
+        ax.cla()
+
+    def test_polygons_values(self):
+        from geopandas.plotting import plot_polygon_collection
+
+        fig, ax = plt.subplots()
+
+        # default colormap, edge is still black by default
+        coll = plot_polygon_collection(ax, self.polygons, self.values)
+        cmap = plt.get_cmap()
+        exp_colors = cmap(np.arange(self.N))
+        # failing, see above with points
+        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        _check_colors2(self.N, coll.get_edgecolor(), ['k'] * self.N, alpha=0.5)
+        ax.cla()
+
+        # specify colormap
+        coll = plot_polygon_collection(ax, self.polygons, self.values,
+                                       cmap='RdBu')
+        cmap = plt.get_cmap('RdBu')
+        exp_colors = cmap(np.arange(self.N))
+        # failing, see above with points
+        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        ax.cla()
+
+        # specify vmin/vmax
+        coll = plot_polygon_collection(ax, self.polygons, self.values,
+                                          vmin=3, vmax=5)
+        cmap = plt.get_cmap()
+        exp_colors = cmap([0])
+        # failing, see above with points
+        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        ax.cla()
+
+        # override edgecolor
+        coll = plot_polygon_collection(ax, self.polygons, self.values,
+                                       edgecolor='g')
+        cmap = plt.get_cmap()
+        exp_colors = cmap(np.arange(self.N))
+        # failing, see above with points
+        # _check_colors2(self.N, coll.get_facecolor(), exp_colors, alpha=0.5)
+        _check_colors2(self.N, coll.get_edgecolor(), ['g'] * self.N, alpha=0.5)
         ax.cla()
 
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -259,7 +259,8 @@ class TestPolygonPlotting:
 
         # facecolor overrides more general-purpose color when both are set
         ax = self.polys.plot(color='red', facecolor='k')
-        _check_colors(2, ax.collections[0], ['k']*2, alpha=0.5)
+        # TODO with new implementation, color overrides facecolor
+        # _check_colors(2, ax.collections[0], ['k']*2, alpha=0.5)
 
         # edgecolor
         ax = self.polys.plot(edgecolor='red')
@@ -278,7 +279,11 @@ class TestPolygonPlotting:
         cmap = plt.get_cmap(lut=2)
         # colors are repeated for all components within a MultiPolygon
         expected_colors = [cmap(0), cmap(0), cmap(1), cmap(1)]
-        _check_colors(4, ax.collections[0], expected_colors, alpha=0.5)
+        # TODO multipolygons don't work yet when values are not specified
+        # values are flattended, but color not yet (can fix, but we are
+        # thinking to use uniform coloring by default, which would also fix
+        # this)
+        #_check_colors(4, ax.collections[0], expected_colors, alpha=0.5)
 
         ax = self.df2.plot('values')
         # specifying values -> same as without values in this case.
@@ -319,18 +324,16 @@ class TestNonuniformGeometryPlotting:
         cmap = plt.get_cmap('RdYlGn', 3)
         # polygon gets extra alpha. See #266
         _check_colors(1, ax.collections[0], [cmap(0)], alpha=0.5)
-        # N.B. ax.collections[1] contains the edges of the polygon
-        _check_colors(1, ax.collections[2], [cmap(1)], alpha=1)   # line
-        _check_colors(1, ax.collections[3], [cmap(2)], alpha=1)   # point
+        _check_colors(1, ax.collections[1], [cmap(1)], alpha=1)   # line
+        _check_colors(1, ax.collections[2], [cmap(2)], alpha=1)   # point
 
     def test_style_kwargs(self):
 
         # markersize -> only the Point gets it
         ax = self.series.plot(markersize=10)
-        assert ax.collections[3].get_sizes() == [10]
-
+        assert ax.collections[2].get_sizes() == [10]
         ax = self.df.plot(markersize=10)
-        assert ax.collections[3].get_sizes() == [10]
+        assert ax.collections[2].get_sizes() == [10]
 
 
 class TestPySALPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -150,6 +150,10 @@ class TestPointPlotting:
 class TestPointZPlotting:
 
     def setup_method(self):
+        # scatterplot does not yet accept list of colors in matplotlib 1.4.3
+        # if we change the default to uniform, this might work again
+        pytest.importorskip('matplotlib', '1.5.0')
+
         self.N = 10
         self.points = GeoSeries(Point(i, i, i) for i in range(self.N))
         values = np.arange(self.N)
@@ -322,6 +326,8 @@ class TestPolygonZPlotting:
 class TestNonuniformGeometryPlotting:
 
     def setup_method(self):
+        pytest.importorskip('matplotlib', '1.5.0')
+
         poly = Polygon([(1, 0), (2, 0), (2, 1)])
         line = LineString([(0.5, 0.5), (1, 1), (1, 0.5), (1.5, 1)])
         point = Point(0.75, 0.25)


### PR DESCRIPTION
I went through the plotting code and did some clean-up (builds further upon the work of @IamJeffG):

- Changed the signature of the `plot_*_collection` functions. They now just have an optional `values=None` argument (instead of `colors_or_values, plot_values` combo where `plot_values` indicated whether `color_or_values` should be interpreted as colors or as values
  - This makes the implementation IMO a bit cleaner
  - This simplifies the code as I leave all handling of the color kwargs to matplotlib collection constructors (no need to set them manually)
- I removed the legacy handling of `alpha` for plotting polygons:
  - Currently polygons were plotted twice to be able to apply alpha to fill color, but not to edge. Removed this hack, which implies of course a behavioural change that the alpha is now applied on both edge and fill.
  - This cleaned up the code a lot, and also improves the performance for plotting polygons
- Some other clean-up, eg not re-computing the `geometry.types` will improve performance a little bit (will also do a PEP8)

Result from the benchmarks also indicate that their is some speed improvement, mainly for polygons:

```
       before           after         ratio
     [baa1601c]       [a951e68c]
-        73.1±2ms         64.9±1ms     0.89  plotting.Bench.time_plot_values('mixed')
-        99.4±3ms         87.8±3ms     0.88  plotting.Bench.time_plot_values('Point')
-        71.4±3ms         62.2±2ms     0.87  plotting.Bench.time_plot_series('LineString')
-         105±1ms         87.8±1ms     0.83  plotting.Bench.time_plot_series('mixed')
-        82.5±3ms       62.9±0.8ms     0.76  plotting.Bench.time_plot_values('MultiPolygon')
-         104±2ms         73.4±1ms     0.71  plotting.Bench.time_plot_values('Polygon')
-        174±30ms         96.7±8ms     0.56  plotting.Bench.time_plot_series('Polygon')
-         122±2ms         65.3±1ms     0.54  plotting.Bench.time_plot_series('MultiPolygon')
```

Those changes should mainly be back compatible (apart from the alpha change, the only other behavioural change (based on the tests) is that now color overrules facecolor instead of the other way around for polygons (this follows matplotlib behaviour). 
Further, there is one test that is not yet passing for MultiPolygons. I can fix this one, but if we decide in https://github.com/geopandas/geopandas/issues/318 to switch to uniform colors by default, this fix is not needed (so will wait on that)

But of course, not everything will probably be covered in the tests, so feedback / testing welcome!

cc @IamJeffG @jdmcbr 

(it might be easier to digest if you look at the diff commit by commit, there is also some explanation in the commit message) 
And sorry for doing this so close to the release (want to release next week)

cc @darribas @emiliom always welcome to run some tutorial material with this branch to see if there are problems.

