### PR TITLE
TST: temporary pin shapely to < 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
 matrix:
   include:
     # Only one test for these Python versions
-    # Pandas >= 0.18.0, is not Python 2.6 compatible
     - python: 3.4
       env: PANDAS=0.18.1 MATPLOTLIB=1.4.3
     - python: 3.5
@@ -49,6 +48,9 @@ matrix:
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
+allow_failures:
+    - env: PANDAS=master  MATPLOTLIB=master
+
 before_install:
   - pip install -U pip
 
@@ -60,6 +62,7 @@ install:
   - pip install -r requirements.test.txt
 
   - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; else pip install pandas==$PANDAS; fi
+  - if [[ $PANDAS == 'master' ]]; then pip install -U shapely; fi
 
 script:
   - py.test geopandas --cov geopandas -v --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
-allow_failures:
+  allow_failures:
     - env: PANDAS=master  MATPLOTLIB=master
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION%"
   - activate test-environment
-  - conda install pandas shapely fiona pyproj rtree matplotlib==1.5.3 descartes
+  - conda install pandas shapely<1.6 fiona pyproj rtree matplotlib==1.5.3 descartes
   - conda install pytest mock
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - conda info -a
   - "conda create -q -n test-environment python=%PYTHON_VERSION%"
   - activate test-environment
-  - conda install pandas shapely<1.6 fiona pyproj rtree matplotlib==1.5.3 descartes
+  - conda install pandas shapely=1.5 fiona pyproj rtree matplotlib==1.5.3 descartes
   - conda install pytest mock
 
 test_script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.16
-shapely>=1.2.18
+shapely>=1.2.18,<1.6
 fiona>=1.0.1
 pyproj>=1.9.3
 six>=1.3.0


### PR DESCRIPTION
Some tests are failing since shapely 1.6 is used on CI (see eg https://travis-ci.org/geopandas/geopandas/jobs/267360623)
(reported to shapely: https://github.com/Toblerity/Shapely/issues/510)