### PR TITLE
COMPAT: Alias isnull -> isna, following pandas

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -176,12 +176,12 @@ class GeoSeries(GeoPandasBase, Series):
 
         Returns
         -------
-        A boolean array of the same size as the series,
+        A boolean pandas Series of the same size as the GeoSeries,
         True where a value is N/A.
 
         See Also
         --------
-        notna : inverse of isna
+        GeoSereies.notna : inverse of isna
         """
         non_geo_null = super(GeoSeries, self).isnull()
         val = self.apply(_is_empty)
@@ -199,12 +199,12 @@ class GeoSeries(GeoPandasBase, Series):
 
         Returns
         -------
-        A boolean array of the same size as the series,
+        A boolean pandas Series of the same size as the GeoSeries,
         False where a value is N/A.
 
         See Also
         --------
-        isna : inverse of notna
+        GeoSeries.isna : inverse of notna
         """
         return ~self.isna()
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -182,16 +182,20 @@ class GeoSeries(GeoPandasBase, Series):
         val = self.apply(_is_empty)
         return np.logical_or(non_geo_null, val)
 
-    isnull = isna
-    isnull.__doc__ = "Alias for `isna` method. See `isna` for more detail."
+    def isnull(self):
+        """Alias for `isna` method. See `isna` for more detail."""
+        return self.isna()
 
     def notna(self):
         """Inverse of `isna`. See `isna` for more detail."""
         return ~self.isna()
 
-    notnull = notna
-    notnull.__doc__ = ("Alias for `notna` method, inverse of `isna`. " +
-                       "See `isna` for more details.")
+    def notnull(self):
+        """
+        Alias for `notna` method, inverse of `isna`.
+        See `isna` for more details.
+        """
+        return self.notna()
 
     def fillna(self, value=None, method=None, inplace=False,
                **kwargs):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -176,7 +176,12 @@ class GeoSeries(GeoPandasBase, Series):
 
         Returns
         -------
-        A boolean array, True where a value is N/A.
+        A boolean array of the same size as the series,
+        True where a value is N/A.
+
+        See Also
+        --------
+        notna : inverse of isna
         """
         non_geo_null = super(GeoSeries, self).isnull()
         val = self.apply(_is_empty)
@@ -187,14 +192,24 @@ class GeoSeries(GeoPandasBase, Series):
         return self.isna()
 
     def notna(self):
-        """Inverse of `isna`. See `isna` for more detail."""
+        """
+        N/A values in a GeoSeries can be represented by empty geometric
+        objects, in addition to standard representations such as None and
+        np.nan.
+
+        Returns
+        -------
+        A boolean array of the same size as the series,
+        False where a value is N/A.
+
+        See Also
+        --------
+        isna : inverse of notna
+        """
         return ~self.isna()
 
     def notnull(self):
-        """
-        Alias for `notna` method, inverse of `isna`.
-        See `isna` for more details.
-        """
+        """Alias for `notna` method. See `notna` for more detail."""
         return self.notna()
 
     def fillna(self, value=None, method=None, inplace=False,

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -168,11 +168,30 @@ class GeoSeries(GeoPandasBase, Series):
         return GeoSeries(self.values.copy(order), index=self.index,
                       name=self.name).__finalize__(self)
 
-    def isnull(self):
-        """Null values in a GeoSeries are represented by empty geometric objects"""
+    def isna(self):
+        """
+        N/A values in a GeoSeries can be represented by empty geometric
+        objects, in addition to standard representations such as None and
+        np.nan.
+
+        Returns
+        -------
+        A boolean array, True where a value is N/A.
+        """
         non_geo_null = super(GeoSeries, self).isnull()
         val = self.apply(_is_empty)
         return np.logical_or(non_geo_null, val)
+
+    isnull = isna
+    isnull.__doc__ = "Alias for `isna` method. See `isna` for more detail."
+
+    def notna(self):
+        """Inverse of `isna`. See `isna` for more detail."""
+        return ~self.isna()
+
+    notnull = notna
+    notnull.__doc__ = ("Alias for `notna` method, inverse of `isna`. " +
+                       "See `isna` for more details.")
 
     def fillna(self, value=None, method=None, inplace=False,
                **kwargs):

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -7,7 +7,7 @@ from six import PY3
 import numpy as np
 import pandas as pd
 import shapely
-from shapely.geometry import Point
+from shapely.geometry import Point, Polygon
 
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.tests.util import assert_geoseries_equal
@@ -176,14 +176,18 @@ def test_dropna():
     assert_geoseries_equal(res, exp)
 
 
-def test_isnull():
-    for NA in [None, np.nan]:
-        s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)])
-        res = s2.isnull()
-        exp = pd.Series([False, True, False])
-        assert_series_equal(res, exp)
-        res = s2.notnull()
-        assert_series_equal(res, ~exp)
+@pytest.mark.parametrize("NA", [None, np.nan, Point(), Polygon()])
+def test_isna(NA):
+    s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)])
+    exp = pd.Series([False, True, False])
+    res = s2.isnull()
+    assert_series_equal(res, exp)
+    res = s2.isna()
+    assert_series_equal(res, exp)
+    res = s2.notnull()
+    assert_series_equal(res, ~exp)
+    res = s2.notna()
+    assert_series_equal(res, ~exp)
 
 
 # Groupby / algos


### PR DESCRIPTION
Add same alias for notnull -> notna, and add tests of empty geometries
to ensure that the check is working for the case it is supposed to
catch.

Questions: 
- Are the docs sufficient? 
- I don't think what I've added is incompatible with changes in #512, but maybe I've missed something?
- This doesn't cover `isna` or `notna` on `GeoDataFrames`, which is consistent with existing behavior of `isnull`, where the override only occurs for `GeoSeries`. Should that change? 