### PR TITLE
ensure that the colorbar gets plotted to the right axis

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -470,7 +470,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
             ax.legend(patches, categories, numpoints=1, loc='best')
         else:
             n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap)
+            ax.get_figure().colorbar(n_cmap, ax=ax)
 
     plt.draw()
     return ax


### PR DESCRIPTION
This results in the colorbar getting drawn on `ax` referred to in the `ax.get_figure().colorbar` call. The axis doesn't propagate downwards after `get_figure`, so the current version will always plot the colorbar on the last axis in a figure with more than one axis. 

I did this locally and it behaves as I expect:
```python
test_data = gpd.read_file(ps.examples.get_path('columbus.shp'))
f,ax = plt.subplots(1,2,figsize=(5*2.1,5))
ax[0] = test_data.plot('CRIME', ax=ax[0], legend=True)
ax[1] = test_data.plot('INC', legend=False, ax=ax[1])
plt.show()
``` 
gives
![test_a](https://user-images.githubusercontent.com/2250995/29848437-66fda8e8-8cd5-11e7-86bd-d1904383abdc.png)
