### PR TITLE
Improve API reference docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,8 @@ import sys, os
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['IPython.sphinxext.ipython_console_highlighting',
               'IPython.sphinxext.ipython_directive',
-              'sphinx.ext.autodoc']
+              'sphinx.ext.autodoc',
+              'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,6 +30,9 @@ extensions = ['IPython.sphinxext.ipython_console_highlighting',
               'sphinx.ext.autodoc',
               'numpydoc']
 
+# Fix issue with warnings from numpydoc (see discussion in PR #534)
+numpydoc_show_class_members = False
+
 # Add any paths that contain templates here, relative to this directory.
 
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,7 +26,8 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['IPython.sphinxext.ipython_console_highlighting',
-              'IPython.sphinxext.ipython_directive']
+              'IPython.sphinxext.ipython_directive',
+              'sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -37,10 +37,10 @@ We can now plot those GeoDataFrames:
 Note that in general, any options one can pass to `pyplot <http://matplotlib.org/api/pyplot_api.html>`_ in ``matplotlib`` (or `style options that work for lines <http://matplotlib.org/api/lines_api.html>`_) can be passed to the ``plot()`` method.
 
 
-Chloropleth Maps
+Choropleth Maps
 -----------------
 
-*geopandas* makes it easy to create Chloropleth maps (maps where the color of each shape is based on the value of an associated variable). Simply use the plot command with the ``column`` argument set to the column whose values you want used to assign colors.
+*geopandas* makes it easy to create Choropleth maps (maps where the color of each shape is based on the value of an associated variable). Simply use the plot command with the ``column`` argument set to the column whose values you want used to assign colors.
 
 .. ipython:: python
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -3,6 +3,9 @@
 Reference
 ===========================
 
+GeoSeries
+---------
+
 The following Shapely methods and attributes are available on
 ``GeoSeries`` objects:
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -6,243 +6,99 @@ Reference
 The following Shapely methods and attributes are available on
 ``GeoSeries`` objects:
 
-.. attribute:: GeoSeries.area
+.. autoattribute:: geopandas.GeoSeries.area
 
-  Returns a ``Series`` containing the area of each geometry in the ``GeoSeries``.
+.. autoattribute:: geopandas.GeoSeries.bounds
 
-.. attribute:: GeoSeries.bounds
+.. autoattribute:: geopandas.GeoSeries.length
 
-  Returns a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
-  ``maxy`` values containing the bounds for each geometry.
-  (see ``GeoSeries.total_bounds`` for the limits of the entire series).
+.. autoattribute:: geopandas.GeoSeries.geom_type
 
-.. attribute:: GeoSeries.length
+.. automethod:: geopandas.GeoSeries.distance
 
-  Returns a ``Series`` containing the length of each geometry.
+.. automethod:: geopandas.GeoSeries.representative_point
 
-.. attribute:: GeoSeries.geom_type
+.. autoattribute:: geopandas.GeoSeries.exterior
 
-  Returns a ``Series`` of strings specifying the `Geometry Type` of
-  each object.
-
-.. method:: GeoSeries.distance(other)
-
-  Returns a ``Series`` containing the minimum distance to the `other`
-  ``GeoSeries`` (elementwise) or geometric object.
-
-.. method:: GeoSeries.representative_point()
-
-  Returns a ``GeoSeries`` of (cheaply computed) points that are
-  guaranteed to be within each geometry.
-
-.. attribute:: GeoSeries.exterior
-
-  Returns a ``GeoSeries`` of LinearRings representing the outer
-  boundary of each polygon in the GeoSeries.  (Applies to GeoSeries
-  containing only Polygons).
-
-.. attribute:: GeoSeries.interiors
-
-  Returns a ``GeoSeries`` of InteriorRingSequences representing the
-  inner rings of each polygon in the GeoSeries.  (Applies to GeoSeries
-  containing only Polygons).
+.. autoattribute:: geopandas.GeoSeries.interiors
 
 `Unary Predicates`
 
-.. attribute:: GeoSeries.is_empty
+.. autoattribute:: geopandas.GeoSeries.is_empty
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-  empty geometries.
+.. autoattribute:: geopandas.GeoSeries.is_ring
 
-.. attribute:: GeoSeries.is_ring
+.. autoattribute:: geopandas.GeoSeries.is_simple
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-  features that are closed.
-
-.. attribute:: GeoSeries.is_simple
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-  geometries that do not cross themselves (meaningful only for
-  `LineStrings` and `LinearRings`).
-
-.. attribute:: GeoSeries.is_valid
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
-  geometries that are valid.
+.. autoattribute:: geopandas.GeoSeries.is_valid
 
 `Binary Predicates`
 
-.. method:: GeoSeries.almost_equals(other[, decimal=6])
+.. automethod:: geopandas.GeoSeries.geom_almost_equals
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  each object is approximately equal to the `other` at all
-  points to specified `decimal` place precision.  (See also :meth:`equals`)
+.. automethod:: geopandas.GeoSeries.contains
 
-.. method:: GeoSeries.contains(other)
+.. automethod:: geopandas.GeoSeries.crosses(other)
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  each object's `interior` contains the `boundary` and
-  `interior` of the other object and their boundaries do not touch at all.
+.. automethod:: geopandas.GeoSeries.disjoint(other)
 
-.. method:: GeoSeries.crosses(other)
+.. automethod:: geopandas.GeoSeries.geom_equals(other)
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  the `interior` of each object intersects the `interior` of
-  the other but does not contain it, and the dimension of the intersection is
-  less than the dimension of the one or the other.
+.. automethod:: geopandas.GeoSeries.intersects(other)
 
-.. method:: GeoSeries.disjoint(other)
+.. automethod:: geopandas.GeoSeries.touches
 
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  the `boundary` and `interior` of each object does not
-  intersect at all with those of the other.
-
-.. method:: GeoSeries.equals(other)
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  if the set-theoretic `boundary`, `interior`, and `exterior`
-  of each object coincides with those of the other.
-
-.. method:: GeoSeries.intersects(other)
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  if the `boundary` and `interior` of each object intersects in
-  any way with those of the other.
-
-.. method:: GeoSeries.touches(other)
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  the objects have at least one point in common and their
-  interiors do not intersect with any part of the other.
-
-.. method:: GeoSeries.within(other)
-
-  Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-  each object's `boundary` and `interior` intersect only
-  with the `interior` of the other (not its `boundary` or `exterior`).
-  (Inverse of :meth:`contains`)
+.. automethod:: geopandas.GeoSeries.within
 
 `Set-theoretic Methods`
 
-.. method:: GeoSeries.difference(other)
+.. automethod:: geopandas.GeoSeries.difference
 
-  Returns a ``GeoSeries`` of the points in each geometry that
-  are not in the *other* object.
+.. automethod:: geopandas.GeoSeries.intersection
 
-.. method:: GeoSeries.intersection(other)
+.. automethod:: geopandas.GeoSeries.symmetric_difference
 
-  Returns a ``GeoSeries`` of the intersection of each object with the `other`
-  geometric object.
-
-.. method:: GeoSeries.symmetric_difference(other)
-
-  Returns a ``GeoSeries`` of the points in each object not in the `other`
-  geometric object, and the points in the `other` not in this object.
-
-.. method:: GeoSeries.union(other)
-
-  Returns a ``GeoSeries`` of the union of points from each object and the
-  `other` geometric object.
+.. automethod:: geopandas.GeoSeries.union
 
 `Constructive Methods`
 
-.. method:: GeoSeries.buffer(distance, resolution=16)
+.. automethod:: geopandas.GeoSeries.buffer
 
-  Returns a ``GeoSeries`` of geometries representing all points within a given `distance`
-  of each geometric object.
+.. autoattribute:: geopandas.GeoSeries.boundary
 
-.. attribute:: GeoSeries.boundary
+.. autoattribute:: geopandas.GeoSeries.centroid
 
-  Returns a ``GeoSeries`` of lower dimensional objects representing
-  each geometries's set-theoretic `boundary`.
+.. autoattribute:: geopandas.GeoSeries.convex_hull
 
-.. attribute:: GeoSeries.centroid
+.. autoattribute:: geopandas.GeoSeries.envelope
 
-  Returns a ``GeoSeries`` of points for each geometric centroid.
-
-.. attribute:: GeoSeries.convex_hull
-
-  Returns a ``GeoSeries`` of geometries representing the smallest
-  convex `Polygon` containing all the points in each object unless the
-  number of points in the object is less than three. For two points,
-  the convex hull collapses to a `LineString`; for 1, a `Point`.
-
-.. attribute:: GeoSeries.envelope
-
-  Returns a ``GeoSeries`` of geometries representing the point or
-  smallest rectangular polygon (with sides parallel to the coordinate
-  axes) that contains each object.
-
-.. method:: GeoSeries.simplify(tolerance, preserve_topology=True)
-
-  Returns a ``GeoSeries`` containing a simplified representation of
-  each object.
+.. automethod:: geopandas.GeoSeries.simplify(tolerance, preserve_topology=True)
 
 `Affine transformations`
 
-.. method:: GeoSeries.rotate(self, angle, origin='center', use_radians=False)
+.. automethod:: geopandas.GeoSeries.rotate
 
-  Rotate the coordinates of the GeoSeries.
+.. automethod:: geopandas.GeoSeries.scale
 
-.. method:: GeoSeries.scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin='center')
+.. automethod:: geopandas.GeoSeries.skew
 
- Scale the geometries of the GeoSeries along each (x, y, z) dimensio.
-
-.. method:: GeoSeries.skew(self, angle, origin='center', use_radians=False)
-
-  Shear/Skew the geometries of the GeoSeries by angles along x and y dimensions.
-
-.. method:: GeoSeries.translate(self, angle, origin='center', use_radians=False)
-
-  Shift the coordinates of the GeoSeries.
+.. automethod:: geopandas.GeoSeries.translate
 
 `Aggregating methods`
 
-.. attribute:: GeoSeries.unary_union
-
-  Return a geometry containing the union of all geometries in the ``GeoSeries``.
+.. autoattribute:: geopandas.GeoSeries.unary_union
 
 Additionally, the following methods are implemented:
 
-.. method:: GeoSeries.from_file()
+.. automethod:: geopandas.GeoSeries.from_file
 
-  Load a ``GeoSeries`` from a file from any format recognized by
-  `fiona`_.
+.. automethod:: geopandas.GeoSeries.to_crs
 
-.. method:: GeoSeries.to_crs(crs=None, epsg=None)
+.. automethod:: geopandas.GeoSeries.plot
 
-  Transform all geometries in a GeoSeries to a different coordinate
-  reference system.  The ``crs`` attribute on the current GeoSeries
-  must be set.  Either ``crs`` in dictionary form or an EPSG code may
-  be specified for output.
+.. autoattribute:: geopandas.GeoSeries.total_bounds
 
-  This method will transform all points in all objects.  It has no
-  notion or projecting entire geometries.  All segments joining points
-  are assumed to be lines in the current projection, not geodesics.
-  Objects crossing the dateline (or other projection boundary) will
-  have undesirable behavior.
-
-.. method:: GeoSeries.plot(colormap='Set1', alpha=0.5, axes=None)
-
-  Generate a plot of the geometries in the ``GeoSeries``.
-  ``colormap`` can be any recognized by matplotlib, but discrete
-  colormaps such as ``Accent``, ``Dark2``, ``Paired``, ``Pastel1``,
-  ``Pastel2``, ``Set1``, ``Set2``, or ``Set3`` are recommended.
-  Wraps the ``plot_series()`` function.
-
-.. attribute:: GeoSeries.total_bounds
-
-  Returns a tuple containing ``minx``, ``miny``, ``maxx``,
-  ``maxy`` values for the bounds of the series as a whole.
-  See ``GeoSeries.bounds`` for the bounds of the geometries contained
-  in the series.
-
-.. attribute:: GeoSeries.__geo_interface__
-
-  Implements the `geo_interface`_. Returns a python data structure
-  to represent the ``GeoSeries`` as a GeoJSON-like ``FeatureCollection``. 
-  Note that the features will have an empty ``properties`` dict as they don't
-  have associated attributes (geometry only).
+.. autoattribute:: geopandas.GeoSeries.__geo_interface__
 
 Methods of pandas ``Series`` objects are also available, although not
 all are applicable to geometric objects and some may return a
@@ -259,52 +115,19 @@ called ``geometry`` which contains a `GeoSeries``.
 
 Currently, the following methods are implemented for a ``GeoDataFrame``:
 
-.. classmethod:: GeoDataFrame.from_file(filename, **kwargs)
+.. automethod:: geopandas.GeoDataFrame.from_file
 
-  Load a ``GeoDataFrame`` from a file from any format recognized by
-  `fiona`_.  See ``read_file()``.
+.. automethod:: geopandas.GeoDataFrame.from_postgis
 
-.. classmethod:: GeoDataFrame.from_postgis(sql, con, geom_col='geom', crs=None, index_col=None, coerce_float=True, params=None)
+.. automethod:: geopandas.GeoDataFrame.to_crs
 
-  Load a ``GeoDataFrame`` from a file from a PostGIS database.
-  See ``read_postgis()``.
+.. automethod:: geopandas.GeoDataFrame.to_file
 
-.. method:: GeoSeries.to_crs(crs=None, epsg=None, inplace=False)
+.. automethod:: geopandas.GeoDataFrame.to_json
 
-  Transform all geometries in the ``geometry`` column of a
-  GeoDataFrame to a different coordinate reference system.  The
-  ``crs`` attribute on the current GeoSeries must be set.  Either
-  ``crs`` in dictionary form or an EPSG code may be specified for
-  output.  If ``inplace=True`` the geometry column will be replaced in
-  the current dataframe, otherwise a new GeoDataFrame will be returned.
+.. automethod:: geopandas.GeoDataFrame.plot(column=None, colormap=None, alpha=0.5, categorical=False, legend=False, axes=None)
 
-  This method will transform all points in all objects.  It has no
-  notion or projecting entire geometries.  All segments joining points
-  are assumed to be lines in the current projection, not geodesics.
-  Objects crossing the dateline (or other projection boundary) will
-  have undesirable behavior.
-
-.. method:: GeoSeries.to_file(filename, driver="ESRI Shapefile", **kwargs)
-
-  Write the ``GeoDataFrame`` to a file.  By default, an ESRI shapefile
-  is written, but any OGR data source supported by Fiona can be
-  written.  ``**kwargs`` are passed to the Fiona driver.
-
-.. method:: GeoSeries.to_json(**kwargs)
-
-  Returns a GeoJSON representation of the ``GeoDataFrame`` as a string.
-
-.. method:: GeoDataFrame.plot(column=None, colormap=None, alpha=0.5, categorical=False, legend=False, axes=None)
-
-  Generate a plot of the geometries in the ``GeoDataFrame``.  If the
-  ``column`` parameter is given, colors plot according to values in
-  that column, otherwise calls ``GeoSeries.plot()`` on the
-  ``geometry`` column.  Wraps the ``plot_dataframe()`` function.
-
-.. attribute:: GeoDataFrame.__geo_interface__
-
-  Implements the `geo_interface`_. Returns a python data structure
-  to represent the ``GeoDataFrame`` as a GeoJSON-like ``FeatureCollection``.
+.. autoattribute:: geopandas.GeoDataFrame.__geo_interface__
 
 All pandas ``DataFrame`` methods are also available, although they may
 not operate in a meaningful way on the ``geometry`` column and may not

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -75,7 +75,7 @@ The following Shapely methods and attributes are available on
 
 .. autoattribute:: geopandas.GeoSeries.envelope
 
-.. automethod:: geopandas.GeoSeries.simplify(tolerance, preserve_topology=True)
+.. automethod:: geopandas.GeoSeries.simplify
 
 `Affine transformations`
 
@@ -97,7 +97,7 @@ Additionally, the following methods are implemented:
 
 .. automethod:: geopandas.GeoSeries.to_crs
 
-.. automethod:: geopandas.GeoSeries.plot(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds)
+.. automethod:: geopandas.GeoSeries.plot
 
 .. autoattribute:: geopandas.GeoSeries.total_bounds
 
@@ -128,7 +128,7 @@ Currently, the following methods are implemented for a ``GeoDataFrame``:
 
 .. automethod:: geopandas.GeoDataFrame.to_json
 
-.. automethod:: geopandas.GeoDataFrame.plot(column=None, colormap=None, alpha=0.5, categorical=False, legend=False, axes=None)
+.. automethod:: geopandas.GeoDataFrame.plot
 
 .. autoattribute:: geopandas.GeoDataFrame.__geo_interface__
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -41,13 +41,13 @@ The following Shapely methods and attributes are available on
 
 .. automethod:: geopandas.GeoSeries.contains
 
-.. automethod:: geopandas.GeoSeries.crosses(other)
+.. automethod:: geopandas.GeoSeries.crosses
 
-.. automethod:: geopandas.GeoSeries.disjoint(other)
+.. automethod:: geopandas.GeoSeries.disjoint
 
-.. automethod:: geopandas.GeoSeries.geom_equals(other)
+.. automethod:: geopandas.GeoSeries.geom_equals
 
-.. automethod:: geopandas.GeoSeries.intersects(other)
+.. automethod:: geopandas.GeoSeries.intersects
 
 .. automethod:: geopandas.GeoSeries.touches
 
@@ -97,7 +97,7 @@ Additionally, the following methods are implemented:
 
 .. automethod:: geopandas.GeoSeries.to_crs
 
-.. automethod:: geopandas.GeoSeries.plot
+.. automethod:: geopandas.GeoSeries.plot(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds)
 
 .. autoattribute:: geopandas.GeoSeries.total_bounds
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -98,12 +98,14 @@ class GeoPandasBase(object):
 
     @property
     def area(self):
-        """Return the area of each geometry in the GeoSeries"""
+        """Returns a ``Series`` containing the area of each geometry in the
+        ``GeoSeries``."""
         return _series_unary_op(self, 'area', null_value=np.nan)
 
     @property
     def geom_type(self):
-        """Return the geometry type of each geometry in the GeoSeries"""
+        """Returns a ``Series`` of strings specifying the `Geometry Type` of each
+        object."""
         return _series_unary_op(self, 'geom_type', null_value=None)
 
     @property
@@ -113,27 +115,35 @@ class GeoPandasBase(object):
 
     @property
     def length(self):
-        """Return the length of each geometry in the GeoSeries"""
+        """Returns a ``Series`` containing the length of each geometry."""
         return _series_unary_op(self, 'length', null_value=np.nan)
 
     @property
     def is_valid(self):
-        """Return True for each valid geometry, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        geometries that are valid."""
         return _series_unary_op(self, 'is_valid', null_value=False)
 
     @property
     def is_empty(self):
-        """Return True for each empty geometry, False for non-empty"""
+
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for empty
+        geometries."""
         return _series_unary_op(self, 'is_empty', null_value=False)
 
     @property
     def is_simple(self):
-        """Return True for each simple geometry, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        geometries that do not cross themselves.
+
+        This is meaningful only for `LineStrings` and `LinearRings`.
+        """
         return _series_unary_op(self, 'is_simple', null_value=False)
 
     @property
     def is_ring(self):
-        """Return True for each geometry that is a closed ring, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        features that are closed."""
         # operates on the exterior, so can't use _series_unary_op()
         return Series([geom.exterior.is_ring for geom in self.geometry],
                       index=self.index)
@@ -144,38 +154,61 @@ class GeoPandasBase(object):
 
     @property
     def boundary(self):
-        """Return the bounding geometry for each geometry"""
+        """Returns a ``GeoSeries`` of lower dimensional objects representing
+        each geometries's set-theoretic `boundary`."""
         return _geo_unary_op(self, 'boundary')
 
     @property
     def centroid(self):
-        """Return the centroid of each geometry in the GeoSeries"""
+        """Returns a ``GeoSeries`` of points representing the centroid of each
+        geometry."""
         return _geo_unary_op(self, 'centroid')
 
     @property
     def convex_hull(self):
-        """Return the convex hull of each geometry"""
+        """Returns a ``GeoSeries`` of geometries representing the convex hull
+        of each geometry.
+
+        The convex hull of a geometry is the smallest convex `Polygon`
+        containing all the points in each geometry, unless the number of points
+        in the geometric object is less than three. For two points, the convex
+        hull collapses to a `LineString`; for 1, a `Point`."""
         return _geo_unary_op(self, 'convex_hull')
 
     @property
     def envelope(self):
-        """Return a bounding rectangle for each geometry"""
+        """Returns a ``GeoSeries`` of geometries representing the envelope of
+        each geometry.
+
+        The envelope of a geometry is the bounding rectangle. That is, the
+        point or smallest rectangular polygon (with sides parallel to the
+        coordinate axes) that contains the geometry."""
         return _geo_unary_op(self, 'envelope')
 
     @property
     def exterior(self):
-        """Return the outer boundary of each polygon"""
+        """Returns a ``GeoSeries`` of LinearRings representing the outer boundary of
+        each polygon in the GeoSeries.
+
+        Applies to GeoSeries containing only Polygons.
+        """
         # TODO: return empty geometry for non-polygons
         return _geo_unary_op(self, 'exterior')
 
     @property
     def interiors(self):
-        """Return the interior rings of each polygon"""
+        """Returns a ``GeoSeries`` of InteriorRingSequences representing the inner
+        rings of each polygon in the GeoSeries.
+
+        Applies to GeoSeries containing only Polygons.
+        """
         # TODO: return empty list or None for non-polygons
         return _series_unary_op(self, 'interiors', null_value=False)
 
     def representative_point(self):
-        """Return a GeoSeries of points guaranteed to be in each geometry"""
+        """Returns a ``GeoSeries`` of (cheaply computed) points that are
+        guaranteed to be within each geometry.
+        """
         return gpd.GeoSeries([geom.representative_point()
                              for geom in self.geometry],
                          index=self.index)
@@ -191,7 +224,8 @@ class GeoPandasBase(object):
 
     @property
     def unary_union(self):
-        """Return the union of all geometries"""
+        """Returns a geometry containing the union of all geometries in the
+        ``GeoSeries``."""
         return unary_union(self.geometry.values)
 
     #
@@ -199,15 +233,53 @@ class GeoPandasBase(object):
     #
 
     def contains(self, other):
-        """Return True for all geometries that contain *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry that contains `other`.
+
+        An object is said to contain `other` if its `interior` contains the
+        `boundary` and `interior` of the other object and their boundaries do
+        not touch at all.
+
+        This is the inverse of :meth:`within`.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            contained.
+        """
         return _series_op(self, other, 'contains')
 
     def geom_equals(self, other):
-        """Return True for all geometries that equal *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry equal to `other`.
+
+        An object is said to be equal to `other` if its set-theoretic
+        `boundary`, `interior`, and `exterior` coincides with those of the
+        other.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test for
+            equality.
+        """
         return _series_op(self, other, 'equals')
 
     def geom_almost_equals(self, other, decimal=6):
-        """Return True for all geometries that is approximately equal to *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
+        each geometry is approximately equal to `other`.
+
+        Approximate equality is tested at all points to the specified `decimal`
+        place precision.  See also :meth:`equals`.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to compare to.
+        decimal : int
+            Decimal place presion used when testing for approximate equality.
+        """
         # TODO: pass precision argument
         return _series_op(self, other, 'almost_equals', decimal=decimal)
 
@@ -217,15 +289,49 @@ class GeoPandasBase(object):
         return _series_op(self, other, 'equals_exact', tolerance=tolerance)
 
     def crosses(self, other):
-        """Return True for all geometries that cross *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry that cross `other`.
+
+        An object is said to cross `other` if its `interior` intersects the
+        `interior` of the other but does not contain it, and the dimension of
+        the intersection is less than the dimension of the one or the other.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            crossed.
+        """
         return _series_op(self, other, 'crosses')
 
     def disjoint(self, other):
-        """Return True for all geometries that are disjoint with *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry disjoint to `other`.
+
+        An object is said to be disjoint to `other` if its `boundary` and
+        `interior` does not intersect at all with those of the other.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            disjoint.
+        """
         return _series_op(self, other, 'disjoint')
 
     def intersects(self, other):
-        """Return True for all geometries that intersect *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry that intersects `other`.
+
+        An object is said to intersect `other` if its `boundary` and `interior`
+        intersects in any way with those of the other.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            intersected.
+        """
         return _series_op(self, other, 'intersects')
 
     def overlaps(self, other):
@@ -233,15 +339,48 @@ class GeoPandasBase(object):
         return _series_op(self, other, 'overlaps')
 
     def touches(self, other):
-        """Return True for all geometries that touch *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry that touches `other`.
+
+        An object is said to touch `other` if it has at least one point in
+        common with `other` and its interior does not intersect with any part
+        of the other.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if is
+            touched.
+        """
         return _series_op(self, other, 'touches')
 
     def within(self, other):
-        """Return True for all geometries that are within *other*, else False"""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        each geometry that is within `other`.
+
+        An object is said to be within `other` if its `boundary` and `interior`
+        intersects only with the `interior` of the other (not its `boundary` or
+        `exterior`).
+
+        This is the inverse of :meth:`contains`.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if each
+            geometry is within.
+        """
         return _series_op(self, other, 'within')
 
     def distance(self, other):
-        """Return distance of each geometry to *other*"""
+        """Returns a ``Series`` containing the minimum distance to `other`.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the minimum
+            distance to.
+        """
         return _series_op(self, other, 'distance')
 
     #
@@ -249,19 +388,54 @@ class GeoPandasBase(object):
     #
 
     def difference(self, other):
-        """Return the set-theoretic difference of each geometry with *other*"""
+        """Returns a ``GeoSeries`` of the points in each geometry that
+        are not in `other`.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            difference to.
+        """
         return _geo_op(self, other, 'difference')
 
     def symmetric_difference(self, other):
-        """Return the symmetric difference of each geometry with *other*"""
+        """Returns a ``GeoSeries`` of the symmetric difference of points in each
+        geometry with `other`.
+
+        For each geometry, the symmetric difference consists of points in the
+        geometry not in `other`, and points in `other` not in the geometry.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            symmetric difference to.
+        """
         return _geo_op(self, other, 'symmetric_difference')
 
     def union(self, other):
-        """Return the set-theoretic union of each geometry with *other*"""
+        """Returns a ``GeoSeries`` of the union of points in each geometry with
+        `other`.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the union
+            with.
+        """
         return _geo_op(self, other, 'union')
 
     def intersection(self, other):
-        """Return the set-theoretic intersection of each geometry with *other*"""
+        """Returns a ``GeoSeries`` of the intersection of points in each
+        geometry with `other`.
+
+        Parameters
+        ----------
+        other : Geoseries or geometric object
+            The Geoseries (elementwise) or geometric object to find the
+            intersection with.
+        """
         return _geo_op(self, other, 'intersection')
 
     #
@@ -270,7 +444,11 @@ class GeoPandasBase(object):
 
     @property
     def bounds(self):
-        """Return a DataFrame of minx, miny, maxx, maxy values of geometry objects"""
+        """Returns a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
+        ``maxy`` values containing the bounds for each geometry.
+
+        See ``GeoSeries.total_bounds`` for the limits of the entire series.
+        """
         bounds = np.array([geom.bounds for geom in self.geometry])
         return DataFrame(bounds,
                          columns=['minx', 'miny', 'maxx', 'maxy'],
@@ -278,11 +456,12 @@ class GeoPandasBase(object):
 
     @property
     def total_bounds(self):
-        """Return a single bounding box (minx, miny, maxx, maxy) for all geometries
+        """Returns a tuple containing ``minx``, ``miny``, ``maxx``, ``maxy``
+        values for the bounds of the series as a whole.
 
-        This is a shortcut for calculating the min/max x and y bounds individually.
+        See ``GeoSeries.bounds`` for the bounds of the geometries contained in
+        the series.
         """
-
         b = self.bounds
         return np.array((b['minx'].min(),
                          b['miny'].min(),
@@ -296,11 +475,39 @@ class GeoPandasBase(object):
         return self._sindex
 
     def buffer(self, distance, resolution=16, **kwargs):
+        """Returns a ``GeoSeries`` of geometries representing all points within
+        a given `distance` of each geometric object.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#object.buffer
+        for details.
+
+        Parameters
+        ----------
+        distance : float
+            The radius of the buffer.
+        resolution: float
+            Optional, the resolution of the buffer around each vertex.
+        """
         return gpd.GeoSeries([geom.buffer(distance, resolution, **kwargs)
                              for geom in self.geometry],
                          index=self.index, crs=self.crs)
 
     def simplify(self, *args, **kwargs):
+        """Returns a ``GeoSeries`` containing a simplified representation of
+        each geometry.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#object.simplify
+        for details
+
+        Parameters
+        ----------
+        tolerance : float
+            All points in a simplified geometry will be no more than
+            `tolerance` distance from the original.
+        preserve_topology: bool
+            False uses a quicker algorithm, but may produce self-intersecting
+            or otherwise invalid geometries.
+        """
         return gpd.GeoSeries([geom.simplify(*args, **kwargs)
                              for geom in self.geometry],
                       index=self.index, crs=self.crs)
@@ -343,8 +550,10 @@ class GeoPandasBase(object):
             index=self.index, crs=self.crs)
 
     def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
-        """
-        Shift the coordinates of the GeoSeries.
+        """Returns a ``GeoSeries`` with translated geometries.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.translate
+        for details.
 
         Parameters
         ----------
@@ -352,18 +561,16 @@ class GeoPandasBase(object):
             Amount of offset along each dimension.
             xoff, yoff, and zoff for translation along the x, y, and z
             dimensions respectively.
-
-        See shapely manual for more information:
-        http://toblerity.org/shapely/manual.html#affine-transformations
         """
-
         return gpd.GeoSeries([affinity.translate(s, xoff, yoff, zoff)
                              for s in self.geometry],
             index=self.index, crs=self.crs)
 
     def rotate(self, angle, origin='center', use_radians=False):
-        """
-        Rotate the coordinates of the GeoSeries.
+        """Returns a ``GeoSeries`` with rotated geometries.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.rotate
+        for details.
 
         Parameters
         ----------
@@ -377,18 +584,19 @@ class GeoPandasBase(object):
             object or a coordinate tuple (x, y).
         use_radians : boolean
             Whether to interpret the angle of rotation as degrees or radians
-
-        See shapely manual for more information:
-        http://toblerity.org/shapely/manual.html#affine-transformations
         """
-
         return gpd.GeoSeries([affinity.rotate(s, angle, origin=origin,
             use_radians=use_radians) for s in self.geometry],
             index=self.index, crs=self.crs)
 
     def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin='center'):
-        """
-        Scale the geometries of the GeoSeries along each (x, y, z) dimension.
+        """Returns a ``GeoSeries`` with scaled geometries.
+
+        The geometries can be scaled by different factors along each
+        dimension. Negative scale factors will mirror or reflect coordinates.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.scale
+        for details.
 
         Parameters
         ----------
@@ -398,20 +606,18 @@ class GeoPandasBase(object):
             The point of origin can be a keyword 'center' for the 2D bounding
             box center (default), 'centroid' for the geometry's 2D centroid, a
             Point object or a coordinate tuple (x, y, z).
-
-        Note: Negative scale factors will mirror or reflect coordinates.
-
-        See shapely manual for more information:
-        http://toblerity.org/shapely/manual.html#affine-transformations
         """
-
         return gpd.GeoSeries([affinity.scale(s, xfact, yfact, zfact,
             origin=origin) for s in self.geometry], index=self.index,
             crs=self.crs)
 
     def skew(self, xs=0.0, ys=0.0, origin='center', use_radians=False):
-        """
-        Shear/Skew the geometries of the GeoSeries by angles along x and y dimensions.
+        """Returns a ``GeoSeries`` with skewed geometries.
+
+        The geometries are sheared by angles along the x and y dimensions.
+
+        See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.skew
+        for details.
 
         Parameters
         ----------
@@ -425,11 +631,7 @@ class GeoPandasBase(object):
             object or a coordinate tuple (x, y).
         use_radians : boolean
             Whether to interpret the shear angle(s) as degrees or radians
-
-        See shapely manual for more information:
-        http://toblerity.org/shapely/manual.html#affine-transformations
         """
-
         return gpd.GeoSeries([affinity.skew(s, xs, ys, origin=origin,
             use_radians=use_radians) for s in self.geometry],
             index=self.index, crs=self.crs)

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -295,8 +295,8 @@ class GeoPandasBase(object):
             self._generate_sindex()
         return self._sindex
 
-    def buffer(self, distance, resolution=16):
-        return gpd.GeoSeries([geom.buffer(distance, resolution)
+    def buffer(self, distance, resolution=16, **kwargs):
+        return gpd.GeoSeries([geom.buffer(distance, resolution, **kwargs)
                              for geom in self.geometry],
                          index=self.index, crs=self.crs)
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -126,9 +126,8 @@ class GeoPandasBase(object):
 
     @property
     def is_empty(self):
-
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for empty
-        geometries."""
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        empty geometries."""
         return _series_unary_op(self, 'is_empty', null_value=False)
 
     @property
@@ -187,8 +186,8 @@ class GeoPandasBase(object):
 
     @property
     def exterior(self):
-        """Returns a ``GeoSeries`` of LinearRings representing the outer boundary of
-        each polygon in the GeoSeries.
+        """Returns a ``GeoSeries`` of LinearRings representing the outer
+        boundary of each polygon in the GeoSeries.
 
         Applies to GeoSeries containing only Polygons.
         """
@@ -197,8 +196,8 @@ class GeoPandasBase(object):
 
     @property
     def interiors(self):
-        """Returns a ``GeoSeries`` of InteriorRingSequences representing the inner
-        rings of each polygon in the GeoSeries.
+        """Returns a ``GeoSeries`` of InteriorRingSequences representing the
+        inner rings of each polygon in the GeoSeries.
 
         Applies to GeoSeries containing only Polygons.
         """
@@ -240,7 +239,8 @@ class GeoPandasBase(object):
         `boundary` and `interior` of the other object and their boundaries do
         not touch at all.
 
-        This is the inverse of :meth:`within`.
+        This is the inverse of :meth:`within` in the sense that the expression
+        ``a.contains(b) == b.within(a)`` always evaluates to ``True``.
 
         Parameters
         ----------
@@ -284,7 +284,8 @@ class GeoPandasBase(object):
         return _series_op(self, other, 'almost_equals', decimal=decimal)
 
     def geom_equals_exact(self, other, tolerance):
-        """Return True for all geometries that equal *other* to a given tolerance, else False"""
+        """Return True for all geometries that equal *other* to a given
+        tolerance, else False"""
         # TODO: pass tolerance argument.
         return _series_op(self, other, 'equals_exact', tolerance=tolerance)
 
@@ -362,13 +363,16 @@ class GeoPandasBase(object):
         intersects only with the `interior` of the other (not its `boundary` or
         `exterior`).
 
-        This is the inverse of :meth:`contains`.
+        This is the inverse of :meth:`contains` in the sense that the
+        expression ``a.within(b) == b.contains(a)`` always evaluates to
+        ``True``.
 
         Parameters
         ----------
         other : GeoSeries or geometric object
             The GeoSeries (elementwise) or geometric object to test if each
             geometry is within.
+
         """
         return _series_op(self, other, 'within')
 
@@ -400,8 +404,8 @@ class GeoPandasBase(object):
         return _geo_op(self, other, 'difference')
 
     def symmetric_difference(self, other):
-        """Returns a ``GeoSeries`` of the symmetric difference of points in each
-        geometry with `other`.
+        """Returns a ``GeoSeries`` of the symmetric difference of points in
+        each geometry with `other`.
 
         For each geometry, the symmetric difference consists of points in the
         geometry not in `other`, and points in `other` not in the geometry.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -69,22 +69,22 @@ class GeoSeries(GeoPandasBase, Series):
 
     @classmethod
     def from_file(cls, filename, **kwargs):
-        """
-        Alternate constructor to create a GeoSeries from a file
+        """Alternate constructor to create a ``GeoSeries`` from a file.
+
+        Can load a ``GeoSeries`` from a file from any format recognized by
+        `fiona`. See http://toblerity.org/fiona/manual.html for details.
 
         Parameters
         ----------
 
         filename : str
             File path or file handle to read from. Depending on which kwargs
-            are included, the content of filename may vary, see:
-            http://toblerity.github.io/fiona/README.html#usage
-            for usage details.
+            are included, the content of filename may vary. See
+            http://toblerity.org/fiona/README.html#usage for usage details.
         kwargs : key-word arguments
             These arguments are passed to fiona.open, and can be used to
             access multi-layer data, data stored within archives (zip files),
             etc.
-
         """
         import fiona
         geoms = []
@@ -98,7 +98,12 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def __geo_interface__(self):
-        """Returns a GeoSeries as a python feature collection
+        """Returns a ``GeoSeries`` as a python feature collection.
+
+        Implements the `geo_interface`. The returned python data structure
+        represents the ``GeoSeries`` as a GeoJSON-like ``FeatureCollection``.
+        Note that the features will have an empty ``properties`` dict as they
+        don't have associated attributes (geometry only).
         """
         from geopandas import GeoDataFrame
         return GeoDataFrame({'geometry': self}).__geo_interface__
@@ -250,6 +255,11 @@ class GeoSeries(GeoPandasBase, Series):
             return False
 
     def plot(self, *args, **kwargs):
+        """Generate a plot of the geometries in the ``GeoSeries``.
+
+        Wraps the ``plot_series()`` function, and documentation is copied from
+        there.
+        """
         return plot_series(self, *args, **kwargs)
 
     plot.__doc__ = plot_series.__doc__
@@ -259,19 +269,26 @@ class GeoSeries(GeoPandasBase, Series):
     #
 
     def to_crs(self, crs=None, epsg=None):
-        """Transform geometries to a new coordinate reference system
+        """Returns a ``GeoSeries`` with all geometries transformed to a new
+        coordinate reference system.
 
-        This method will transform all points in all objects.  It has
-        no notion or projecting entire geometries.  All segments
-        joining points are assumed to be lines in the current
-        projection, not geodesics.  Objects crossing the dateline (or
-        other projection boundary) will have undesirable behavior.
+        Transform all geometries in a GeoSeries to a different coordinate
+        reference system.  The ``crs`` attribute on the current GeoSeries must
+        be set.  Either ``crs`` in string or dictionary form or an EPSG code
+        may be specified for output.
 
-        `to_crs` passes the `crs` argument to the `Proj` function from the
-        `pyproj` library (with the option `preserve_units=True`). It can
-        therefore accept proj4 projections in any format
-        supported by `Proj`, including dictionaries, or proj4 strings.
+        This method will transform all points in all objects.  It has no notion
+        or projecting entire geometries.  All segments joining points are
+        assumed to be lines in the current projection, not geodesics.  Objects
+        crossing the dateline (or other projection boundary) will have
+        undesirable behavior.
 
+        Parameters
+        ----------
+        crs : dict or str
+            Output projection parameters as string or in dictionary form.
+        epsg : int
+            EPSG code specifying output projection.
         """
         from fiona.crs import from_epsg
         if self.crs is None:

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -423,6 +423,20 @@ class TestGeomMethods:
         res = res.skew(ys=-skew, origin=o)
         assert geom_almost_equals(expected, res)
 
+    def test_buffer(self):
+        original = GeoSeries([Point(0, 0)])
+        expected = GeoSeries([Polygon(((5, 0), (0, -5), (-5, 0), (0, 5),
+                                       (5, 0)))])
+        calculated = original.buffer(5, resolution=1)
+        assert geom_almost_equals(expected, calculated)
+
+    def test_buffer_args(self):
+        args = dict(cap_style=3, join_style=2, mitre_limit=2.5)
+        calculated_series = self.g0.buffer(10, **args)
+        for original, calculated in zip(self.g0, calculated_series):
+            expected = original.buffer(10, **args)
+            assert calculated.equals(expected)
+
     def test_envelope(self):
         e = self.g3.envelope
         assert np.all(e.geom_equals(self.sq))


### PR DESCRIPTION
Fixes #530 

Uses sphinx autodoc for the reference documentation to pick out the docstrings of the corresponding attributes and methods.

The documentation originally in `reference.rst` has been merged with the docstrings inside the `.py`-files. An attempt has been made to make the documentation more consistent.