### PR TITLE
BUG: retain index names of input frames to sjoin

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -54,10 +54,8 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
     # index in geopandas may be any arbitrary dtype. so reset both indices now
     # and store references to the original indices, to be reaffixed later.
     # GH 352
-    left_df.index.name = index_left
-    right_df.index.name = index_right
-    left_df = left_df.reset_index()
-    right_df = right_df.reset_index()
+    left_df = left_df.rename_axis(index_left,copy=False).reset_index()
+    right_df = right_df.rename_axis(index_right,copy=False).reset_index()
 
     if op == "within":
         # within implemented as the inverse of contains; swap names

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -54,8 +54,12 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
     # index in geopandas may be any arbitrary dtype. so reset both indices now
     # and store references to the original indices, to be reaffixed later.
     # GH 352
-    left_df = left_df.rename_axis(index_left,copy=False).reset_index()
-    right_df = right_df.rename_axis(index_right,copy=False).reset_index()
+    left_df = left_df.copy(deep=True)
+    left_df.index = left_df.index.rename(index_left)
+    left_df = left_df.reset_index()
+    right_df = right_df.copy(deep=True)
+    right_df.index = right_df.index.rename(index_right)
+    right_df = right_df.reset_index()
 
     if op == "within":
         # within implemented as the inverse of contains; swap names

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -75,8 +75,6 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='inner', op=op)
-        assert df1.index.name == None
-        assert df2.index.name == None
         
         exp = expected[op].dropna().copy()
         exp = exp.drop('geometry_y', axis=1).rename(
@@ -97,8 +95,6 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='left', op=op)
-        assert df1.index.name == None
-        assert df2.index.name == None
 
         exp = expected[op].dropna(subset=['index_left']).copy()
         exp = exp.drop('geometry_y', axis=1).rename(
@@ -120,8 +116,6 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='right', op=op)
-        assert df1.index.name == None
-        assert df2.index.name == None
 
         exp = expected[op].dropna(subset=['index_right']).copy()
         exp = exp.drop('geometry_x', axis=1).rename(
@@ -163,8 +157,6 @@ class TestSpatialJoinNYBB:
 
     def test_sjoin_left(self):
         df = sjoin(self.pointdf, self.polydf, how='left')
-        assert self.polydf.index.name is None
-        assert self.pointdf.index.name is None
         assert df.shape == (21, 8)
         for i, row in df.iterrows():
             assert row.geometry.type == 'Point'
@@ -175,8 +167,6 @@ class TestSpatialJoinNYBB:
         # the inverse of left
         df = sjoin(self.pointdf, self.polydf, how="right")
         df2 = sjoin(self.polydf, self.pointdf, how="left")
-        assert self.polydf.index.name is None
-        assert self.pointdf.index.name is None
         assert df.shape == (12, 8)
         assert df.shape == df2.shape
         for i, row in df.iterrows():
@@ -186,8 +176,6 @@ class TestSpatialJoinNYBB:
 
     def test_sjoin_inner(self):
         df = sjoin(self.pointdf, self.polydf, how="inner")
-        assert self.polydf.index.name is None
-        assert self.pointdf.index.name is None
         assert df.shape == (11, 8)
 
     def test_sjoin_op(self):
@@ -212,7 +200,7 @@ class TestSpatialJoinNYBB:
         assert 'Shape_Area_left' in df.columns
         assert 'Shape_Area_right' in df.columns
 
-    @pytest.mark.parametrize('how', ['left','right','inner'])
+    @pytest.mark.parametrize('how', ['left', 'right', 'inner'])
     def test_sjoin_named_index(self,how):
         #original index names should be unchanged
         pointdf2 = self.pointdf.copy()
@@ -220,8 +208,6 @@ class TestSpatialJoinNYBB:
         df = sjoin(pointdf2, self.polydf, how=how)
         assert pointdf2.index.name == 'pointid'
         assert self.polydf.index.name == None
-        #output index should be unamed since it is a new index?
-        #assert that extra index is called index_lhs or index_rhs?
 
     def test_sjoin_values(self):
         # GH190

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -75,7 +75,9 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='inner', op=op)
-
+        assert df1.index.name == None
+        assert df2.index.name == None
+        
         exp = expected[op].dropna().copy()
         exp = exp.drop('geometry_y', axis=1).rename(
             columns={'geometry_x': 'geometry'})
@@ -95,6 +97,8 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='left', op=op)
+        assert df1.index.name == None
+        assert df2.index.name == None
 
         exp = expected[op].dropna(subset=['index_left']).copy()
         exp = exp.drop('geometry_y', axis=1).rename(
@@ -116,6 +120,8 @@ class TestSpatialJoin:
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how='right', op=op)
+        assert df1.index.name == None
+        assert df2.index.name == None
 
         exp = expected[op].dropna(subset=['index_right']).copy()
         exp = exp.drop('geometry_x', axis=1).rename(
@@ -157,6 +163,8 @@ class TestSpatialJoinNYBB:
 
     def test_sjoin_left(self):
         df = sjoin(self.pointdf, self.polydf, how='left')
+        assert self.polydf.index.name is None
+        assert self.pointdf.index.name is None
         assert df.shape == (21, 8)
         for i, row in df.iterrows():
             assert row.geometry.type == 'Point'
@@ -167,6 +175,8 @@ class TestSpatialJoinNYBB:
         # the inverse of left
         df = sjoin(self.pointdf, self.polydf, how="right")
         df2 = sjoin(self.polydf, self.pointdf, how="left")
+        assert self.polydf.index.name is None
+        assert self.pointdf.index.name is None
         assert df.shape == (12, 8)
         assert df.shape == df2.shape
         for i, row in df.iterrows():
@@ -176,6 +186,8 @@ class TestSpatialJoinNYBB:
 
     def test_sjoin_inner(self):
         df = sjoin(self.pointdf, self.polydf, how="inner")
+        assert self.polydf.index.name is None
+        assert self.pointdf.index.name is None
         assert df.shape == (11, 8)
 
     def test_sjoin_op(self):
@@ -199,6 +211,17 @@ class TestSpatialJoinNYBB:
         df = sjoin(pointdf2, self.polydf, how="left")
         assert 'Shape_Area_left' in df.columns
         assert 'Shape_Area_right' in df.columns
+
+    @pytest.mark.parametrize('how', ['left','right','inner'])
+    def test_sjoin_named_index(self,how):
+        #original index names should be unchanged
+        pointdf2 = self.pointdf.copy()
+        pointdf2.index.name = 'pointid'
+        df = sjoin(pointdf2, self.polydf, how=how)
+        assert pointdf2.index.name == 'pointid'
+        assert self.polydf.index.name == None
+        #output index should be unamed since it is a new index?
+        #assert that extra index is called index_lhs or index_rhs?
 
     def test_sjoin_values(self):
         # GH190


### PR DESCRIPTION
a fix and some unit tests for issue #525. Original panda dataframe's index names are no longer changed by sjoin() call.

This pull request follows on from request #538 (I reorganised my github fork and broke things)

My original code didn't work for pandas 0.16.2 and so I've found the following way to make the code work across pandas version 0.16.0 - 0.20.0

    left_df = left_df.copy(deep=True)
    left_df.index = left_df.index.rename(index_left)
    left_df = left_df.reset_index()

I wanted to do copy(deep=False) in order to save a copy but the geopandas code for the copy method is different from the pandas method code and so it didn't work (but works for a pandas dataframe). Is there a reason for that?
pandas code is

    data = self._data.copy(deep=deep)
    return self._constructor(data).__finalize__(self)

geopandas code is

    data = self._data
    if deep:
        data = data.copy()
    return GeoDataFrame(data).__finalize__(self)
