### PR TITLE
Adding geoalchemy2 WKBElement handling in from_postgis

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -2,6 +2,7 @@ import binascii
 
 from pandas import read_sql
 import shapely.wkb
+from geoalchemy2.elements import WKBElement
 
 from geopandas import GeoSeries, GeoDataFrame
 
@@ -39,7 +40,13 @@ def read_postgis(sql, con, geom_col='geom', crs=None, index_col=None,
 
     wkb_geoms = df[geom_col]
 
-    s = wkb_geoms.apply(lambda x: shapely.wkb.loads(binascii.unhexlify(x.encode())))
+    if wkb_geoms.apply(lambda x: isinstance(x, WKBElement)).all():
+        get_wkb_str = lambda x: str(x)
+    else:
+        get_wkb_str = lambda x: x.encode()
+
+    s = wkb_geoms.apply(
+        lambda x: shapely.wkb.loads(binascii.unhexlify(get_wkb_str(x))))
 
     df[geom_col] = GeoSeries(s)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ shapely>=1.2.18
 fiona>=1.0.1
 pyproj>=1.9.3
 six>=1.3.0
+geoalchemy2>=0.4.0


### PR DESCRIPTION
When using geoalchemy2 accessing postgis for tables with geography type, the returned geometries are WKBElement objects. The object does not have `x.encode()` but rather a `desc` property for stringifying the underlying wkt data. This PR is trying to make it easy to work with such scenario.