### PR TITLE
Dropping geometry name produces normal dataframe

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -698,6 +698,14 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     # Implement pandas methods
     #
 
+    def drop(self, labels, axis=0, level=None, inplace=False, errors='raise'):
+        result = super(GeoDataFrame, self).drop(labels, axis=axis, level=level,
+                                                inplace=inplace, errors=errors)
+        if self._geometry_column_name not in result.columns:
+            return pd.DataFrame(result)
+        else:
+            return result
+
     def merge(self, *args, **kwargs):
         r"""Merge two ``GeoDataFrame`` objects with a database-style join.
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -880,3 +880,15 @@ def test_geodataframe_crs():
     gdf = GeoDataFrame()
     gdf.crs = "IGNF:ETRS89UTM28"
     assert gdf.crs.to_authority() == ("IGNF", "ETRS89UTM28")
+
+
+def test_drop():
+    geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
+    gdf = GeoDataFrame({"a": [1, 2, 3], "geometry": geoms})
+
+    assert type(gdf[["a"]]) == pd.DataFrame
+    assert type(gdf[["geometry"]]) == GeoDataFrame
+    assert isinstance(gdf.drop("a", axis=1), GeoDataFrame)
+    assert gdf.drop("a", axis=1).columns.tolist() == ["geometry"]
+    assert type(gdf.drop("geometry", axis=1)) == pd.DataFrame
+    assert gdf.drop("geometry", axis=1).columns.tolist() == ["a"]


### PR DESCRIPTION
There might be a better and more generic way of accomplishing this.