### PR TITLE
TST: Add case sensitivity flag to validate_boro_df

### DIFF
--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -396,8 +396,7 @@ class TestDataFrame:
             crs = f.crs
 
         df = GeoDataFrame.from_features(features, crs=crs)
-        df.rename(columns=lambda x: x.lower(), inplace=True)
-        validate_boro_df(df)
+        validate_boro_df(df, case_sensitive=True)
         assert df.crs == crs
 
     def test_from_features_unaligned_properties(self):
@@ -458,7 +457,7 @@ class TestDataFrame:
         finally:
             con.close()
 
-        validate_boro_df(df)
+        validate_boro_df(df, case_sensitive=False)
 
     def test_from_postgis_custom_geom_col(self):
         con = connect('test_geopandas')
@@ -474,7 +473,7 @@ class TestDataFrame:
         finally:
             con.close()
 
-        validate_boro_df(df)
+        validate_boro_df(df, case_sensitive=False)
 
     def test_dataframe_to_geodataframe(self):
         df = pd.DataFrame({"A": range(len(self.df)), "location":

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -20,15 +20,19 @@ except ImportError:
     import mock
 
 
-def validate_boro_df(df):
+def validate_boro_df(df, case_sensitive=False):
     """ Tests a GeoDataFrame that has been read in from the nybb dataset."""
     assert isinstance(df, GeoDataFrame)
     # Make sure all the columns are there and the geometries
     # were properly loaded as MultiPolygons
     assert len(df) == 5
-    columns = ('borocode', 'boroname', 'shape_leng', 'shape_area')
-    for col in columns:
-        assert col in df.columns
+    columns = ('BoroCode', 'BoroName', 'Shape_Leng', 'Shape_Area')
+    if case_sensitive:
+        for col in columns:
+            assert col in df.columns
+    else:
+        for col in columns:
+            assert col.lower() in (dfcol.lower() for dfcol in df.columns)
     assert all(df.geometry.type == 'MultiPolygon')
 
 


### PR DESCRIPTION
`validate_boro_df` had been used primarily for testing reads from a postgis database, and so was checking against lower case column names. In the one other place that `validate_boro_df` was used, it was changing column names prior to testing in order to use the existing functionality. I think this is a little more transparent functionality for any future situations in which `validate_boro_df` might be used.