### PR TITLE
TST: mark geopandas-cython failures and update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest tstreamz ndas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython
+  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest pandas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython
   - source activate test-geopandas
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then pip install shapely==$SHAPELY; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,28 +25,16 @@ matrix:
 
     # Python 2.7 and 3.6 test all supported Pandas versions
     - python: 2.7
-      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 2.7
-      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 2.7
-      env: PANDAS=0.18.1  MATPLOTLIB=1.5.3
-    - python: 2.7
       env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
     - python: 2.7
-      env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
+      env: PANDAS=0.20.3  MATPLOTLIB=2.0.2 SHAPELY=1.5.17
     - python: 2.7
       env: PANDAS=master  MATPLOTLIB=master
 
     - python: 3.6
-      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 3.6
-      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 3.6
-      env: PANDAS=0.18.1  MATPLOTLIB=1.5.3
-    - python: 3.6
       env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
     - python: 3.6
-      env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
+      env: PANDAS=0.20.2  MATPLOTLIB=2.0.2 SHAPELY=1.5.17
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     - libspatialindex-dev
     - libgeos-dev
     - build-essential
-    - python-dev
 
 matrix:
   include:
@@ -38,18 +37,20 @@ matrix:
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
-before_install:
-  - pip install -U pip
-
 install:
-  - pip install numpy
-  - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; else pip install matplotlib==$MATPLOTLIB; fi
+  # Install conda
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+
+  # Install dependencies
+  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest tstreamz ndas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython
+  - source activate test-geopandas
+  - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then pip install shapely==$SHAPELY; fi
-
-  - pip install -r requirements.txt
-  - pip install -r requirements.test.txt
-
-  - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; else pip install pandas==$PANDAS; fi
+  - if [[ $PANDAS == 'master' ]]; then pip install git+https://github.com/pydata/pandas.git; fi
 
   - make inplace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest pandas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython
+  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest pandas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython codecov pytest-cov
   - source activate test-geopandas
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then pip install shapely==$SHAPELY; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest pandas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython codecov pytest-cov
+  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest pandas pyproj shapely fiona six rtree descartes matplotlib psycopg2 sqlalchemy pysal cython codecov pytest-cov mock
   - source activate test-geopandas
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then pip install shapely==$SHAPELY; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,24 +17,25 @@ addons:
 matrix:
   include:
     # Only one test for these Python versions
-    - python: 3.4
-      env: PANDAS=0.18.1 MATPLOTLIB=1.4.3 SHAPELY=1.5.17
     - python: 3.5
-      env: PANDAS=0.19.2 MATPLOTLIB=1.5.3
+      env: PANDAS=0.19.2 MATPLOTLIB=1.5.3 SHAPELY=1.5.17
 
     # Python 2.7 and 3.6 test all supported Pandas versions
-    - python: 2.7
-      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
     - python: 2.7
       env: PANDAS=0.20.3  MATPLOTLIB=2.0.2 SHAPELY=1.5.17
     - python: 2.7
       env: PANDAS=master  MATPLOTLIB=master
 
     - python: 3.6
-      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
-    - python: 3.6
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2 SHAPELY=1.5.17
     - python: 3.6
+      env: PANDAS=master  MATPLOTLIB=master
+  allow_failures:
+    - python: 3.5
+      env: PANDAS=0.19.2 MATPLOTLIB=1.5.3 SHAPELY=1.5.17
+    - python: 2.7
+      env: PANDAS=0.20.3  MATPLOTLIB=2.0.2 SHAPELY=1.5.17
+    - python: 2.7
       env: PANDAS=master  MATPLOTLIB=master
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,6 @@ language: python
 
 sudo: false
 
-cache: pip
-
-addons:
-  apt:
-    packages:
-    - libgdal1h
-    - gdal-bin
-    - libgdal-dev
-    - libspatialindex-dev
-    - libgeos-dev
-    - build-essential
-
 matrix:
   include:
     # Only one test for these Python versions

--- a/geopandas/tests/test_block.py
+++ b/geopandas/tests/test_block.py
@@ -1,5 +1,5 @@
+from distutils.version import LooseVersion
 
-import pytest
 import numpy as np
 import pandas as pd
 
@@ -8,6 +8,8 @@ from shapely.geometry.base import BaseGeometry
 
 from geopandas.vectorized import GeometryArray, from_shapely
 from geopandas._block import GeometryBlock
+
+import pytest
 
 
 def test_block():
@@ -32,11 +34,16 @@ def df():
     return pd.DataFrame(blk_mgr)
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(str(pd.__version__) < LooseVersion('0.21'),
+                   reason="GEOPANDAS-CYTHON")
 def test_repr(df):
     assert 'POINT' in repr(df)
     assert 'POINT' in repr(df['geometry'])
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
 def test_repr_truncated(df):
     with pd.option_context('display.max_rows', 4):
         repr(df)

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -91,6 +91,8 @@ class TestGeocode:
         assert coords[0] == pytest.approx(test[1])
         assert coords[1] == pytest.approx(test[0])
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_prepare_result_none(self):
         p0 = Point(12.3, -45.6)  # Treat these as lat/lon
         d = {'a': ('address0', p0.coords[0]),

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -303,8 +303,9 @@ class TestDataFrame:
         assert type(df2) is GeoDataFrame
         assert self.df.crs == df2.crs
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_to_file(self):
-        """ Test to_file and from_file """
         tempfilename = os.path.join(self.tempdir, 'boros.shp')
         self.df.to_file(tempfilename)
         # Read layer back in
@@ -488,6 +489,8 @@ class TestDataFrame:
 
         validate_boro_df(df, case_sensitive=False)
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_dataframe_to_geodataframe(self):
         df = pd.DataFrame({"A": range(len(self.df)), "location":
                            list(self.df.geometry)}, index=self.df.index)
@@ -576,6 +579,8 @@ class TestConstructor:
         assert_index_equal(df.columns, pd.Index(['A', 'geometry']))
         assert_series_equal(df['A'], pd.Series(range(3), name='A'))
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_dict_of_series(self):
 
         data = {"A": pd.Series(range(3)), "B": pd.Series(np.arange(3.0)),
@@ -595,6 +600,8 @@ class TestConstructor:
         with pytest.raises(ValueError):
             GeoDataFrame(data, index=[1, 2])
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_dict_specified_geometry(self):
 
         data = {"A": range(3), "B": np.arange(3.0),
@@ -641,6 +648,8 @@ class TestConstructor:
                           geometry='other_geom')
         check_geodataframe(df, 'other_geom')
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_from_frame(self):
         data = {"A": range(3), "B": np.arange(3.0),
                 "geometry": [Point(x, x) for x in range(3)]}
@@ -666,6 +675,8 @@ class TestConstructor:
             with pytest.raises(ValueError):
                 GeoDataFrame(df, geometry='other_geom')
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_from_frame_specified_geometry(self):
         data = {"A": range(3), "B": np.arange(3.0),
                 "other_geom": [Point(x, x) for x in range(3)]}
@@ -684,6 +695,8 @@ class TestConstructor:
         with pytest.raises(AttributeError):
             df.geometry
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_only_geometry(self):
         df = GeoDataFrame(geometry=[Point(x, x) for x in range(3)])
         check_geodataframe(df)
@@ -704,6 +717,8 @@ class TestConstructor:
         gdf = GeoDataFrame({'x': [1]})
         assert list(gdf.x) == [1]
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_empty(self):
         df = GeoDataFrame()
         assert type(df) == GeoDataFrame

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -675,8 +675,6 @@ class TestConstructor:
             with pytest.raises(ValueError):
                 GeoDataFrame(df, geometry='other_geom')
 
-    @pytest.mark.cython
-    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_from_frame_specified_geometry(self):
         data = {"A": range(3), "B": np.arange(3.0),
                 "other_geom": [Point(x, x) for x in range(3)]}

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -320,6 +320,8 @@ class TestGeomMethods:
         expected = Series(np.array([False] * len(self.g1)), self.g1.index)
         self._test_unary_real('is_empty', expected, self.g1)
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_is_ring(self):
         expected = Series(np.array([True] * len(self.g1)), self.g1.index)
         self._test_unary_real('is_ring', expected, self.g1)

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -5,6 +5,8 @@ from shapely.geometry import Point
 
 from geopandas import GeoDataFrame, GeoSeries
 
+import pytest
+
 
 class TestMerging:
 
@@ -42,6 +44,8 @@ class TestMerging:
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res, 'points', self.gdf.crs)
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_concat_axis0(self):
 
         res = pd.concat([self.gdf, self.gdf])
@@ -51,6 +55,8 @@ class TestMerging:
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res)
 
+    @pytest.mark.cython
+    @pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
     def test_concat_axis1(self):
 
         res = pd.concat([self.gdf, self.df], axis=1)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -29,6 +29,9 @@ def df():
                          'value2': np.array([1, 2, 1], dtype='int64')})
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(str(pd.__version__) < LooseVersion('0.21'),
+                   reason="GEOPANDAS-CYTHON")
 def test_repr(s, df):
     assert 'POINT' in repr(s)
     assert 'POINT' in repr(df)
@@ -64,6 +67,8 @@ def test_indexing(s, df):
     assert_geoseries_equal(df.loc[mask, 'geometry'], exp)
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(reason="GEOPANDAS-CYTHON not supported")
 def test_assignment(s, df):
     exp = GeoSeries([Point(10, 10), Point(1, 1), Point(2, 2)])
 
@@ -96,6 +101,8 @@ def test_assign(df):
     assert_frame_equal(res, exp, )
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
 def test_astype(s):
 
     with pytest.raises(TypeError):
@@ -110,8 +117,8 @@ def test_to_csv(df):
     assert df.to_csv(index=False) == exp
 
 
-@pytest.mark.skipif(str(pd.__version__) < LooseVersion('0.17'),
-                    reason="s.max() does not raise on 0.16")
+@pytest.mark.cython
+@pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
 def test_numerical_operations(s, df):
 
     # df methods ignore the geometry column
@@ -143,6 +150,8 @@ def test_numerical_operations(s, df):
     assert_frame_equal(res, exp)
 
 
+@pytest.mark.cython
+@pytest.mark.xfail(reason="GEOPANDAS-CYTHON")
 def test_where(s):
     res = s.where(np.array([True, False, True]))
     exp = s.copy()

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,11 @@ versionfile_source = geopandas/_version.py
 versionfile_build = geopandas/_version.py
 tag_prefix = v
 parentdir_prefix = geopandas-
+
+[tools:pytest]
+xfail_strict=true
+
+[pytest]
+markers =
+    web: web tests
+    cython: geopandas-cython branch related failures


### PR DESCRIPTION
Marking the remaining failures as `xfail`, so we can start relying on travis for further developing of the geopandas-cython branch.

I also marked the same tests with a cython mark, so you can do:

```
pytest geopandas -v --runxfail -m cython
```

to run all those tests in no-xfail mode to see the actual remaining failures.

Further trimmed down the travis build matrix (trying 0.19 for now)