### PR TITLE
TST: Set test gdf crs to silence crs warning

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -39,6 +39,7 @@ class TestGeomMethods:
         self.g3 = GeoSeries([self.t1, self.t2])
         self.g3.crs = {'init': 'epsg:4326', 'no_defs': True}
         self.g4 = GeoSeries([self.t2, self.t1])
+        self.g4.crs = {'init': 'epsg:4326', 'no_defs': True}
         self.na = GeoSeries([self.t1, self.t2, Polygon()])
         self.na_none = GeoSeries([self.t1, None])
         self.a1 = self.g1.copy()

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -187,6 +187,14 @@ class TestGeomMethods:
         result = getattr(gdf, op)
         fcmp(result, expected)
 
+    def test_crs_warning(self):
+        # operations on geometries should warn for different CRS
+        no_crs_g3 = self.g3.copy()
+        no_crs_g3.crs = None
+        with pytest.warns(UserWarning):
+            self._test_binary_topological('intersection', self.g3,
+                                          self.g3, no_crs_g3)
+
     def test_intersection(self):
         self._test_binary_topological('intersection', self.t1,
                                       self.g1, self.g2)


### PR DESCRIPTION
The symmetric difference test compared a frame with a crs to one
without. It didn't seem that this was intentional, so set the second
frame crs to the first so that the tests run without warnings.

Warning below:
```
geopandas/tests/test_geom_methods.py::TestGeomMethods::()::test_symmetric_difference_series
  /home/james/python/geopandas/geopandas/base.py:29: UserWarning: GeoSeries crs mismatch: {'init': 'epsg:4326', 'no_defs': True} and None
    other.crs))

geopandas/tests/test_geom_methods.py::TestGeomMethods::()::test_symmetric_difference_operator
  /home/james/python/geopandas/geopandas/base.py:29: UserWarning: GeoSeries crs mismatch: {'init': 'epsg:4326', 'no_defs': True} and None
    other.crs))
```