### PR TITLE
CLN: Remove unused internal function

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -711,14 +711,3 @@ class _CoordinateIndexer(_NDFrameIndexer):
                    ys.stop if ys.stop is not None else ymax)
         idx = obj.intersects(bbox)
         return obj[idx]
-
-
-def _array_input(arr):
-    if isinstance(arr, (MultiPoint, MultiLineString, MultiPolygon)):
-        # Prevent against improper length detection when input is a
-        # Multi*
-        geom = arr
-        arr = np.empty(1, dtype=object)
-        arr[0] = geom
-
-    return arr


### PR DESCRIPTION
`_array_input` was not used anywhere, and has been sitting around unused
for ~4 years, so far as I can tell.

If this has a clear purpose I'm missing, I'm happy to close this. I just noticed it, tried to figure out what it was used for, couldn't discern any function it was currently serving, and making a PR to remove it was as easy as creating an issue to ask about it. 