### PR TITLE
Fix error on plot empty GeoDataFrame

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -255,15 +255,15 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
                       "(for consistency with pandas)", FutureWarning)
         ax = style_kwds.pop('axes')
 
-    if not s.shape[0]:
-        warnings.warn("The GeoDataFrame you are attempting to plot is "
-                "empty. Nothing has been displayed.", UserWarning)
-        return ax
-
     import matplotlib.pyplot as plt
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
+
+    if not s.shape[0]:
+        warnings.warn("The GeoDataFrame you are attempting to plot is "
+                "empty. Nothing has been displayed.", UserWarning)
+        return ax
 
     # if cmap is specified, create range of colors based on cmap
     values = None
@@ -401,6 +401,10 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
     import matplotlib
     import matplotlib.pyplot as plt
 
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.set_aspect('equal')
+
     if not df.shape[0]:
         warnings.warn("The GeoDataFrame you are attempting to plot is "
                 "empty. Nothing has been displayed.", UserWarning)
@@ -436,10 +440,6 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
                       for i in range(len(binedges)-1)]
         values = np.array(binning.yb)
-
-    if ax is None:
-        fig, ax = plt.subplots(figsize=figsize)
-        ax.set_aspect('equal')
 
     mn = values.min() if vmin is None else vmin
     mx = values.max() if vmax is None else vmax

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -260,9 +260,9 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
 
-    if not s.shape[0]:
-        warnings.warn("The GeoDataFrame you are attempting to plot is "
-                "empty. Nothing has been displayed.", UserWarning)
+    if s.empty:
+        warnings.warn("The GeoSeries you are attempting to plot is "
+                      "empty. Nothing has been displayed.", UserWarning)
         return ax
 
     # if cmap is specified, create range of colors based on cmap
@@ -405,10 +405,11 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         fig, ax = plt.subplots(figsize=figsize)
         ax.set_aspect('equal')
 
-    if not df.shape[0]:
+    if df.empty:
         warnings.warn("The GeoDataFrame you are attempting to plot is "
-                "empty. Nothing has been displayed.", UserWarning)
+                      "empty. Nothing has been displayed.", UserWarning)
         return ax
+
     if column is None:
         return plot_series(df.geometry, cmap=cmap, color=color, ax=ax,
                            figsize=figsize, **style_kwds)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -396,94 +396,98 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
     import matplotlib
     import matplotlib.pyplot as plt
 
-    if column is None:
-        return plot_series(df.geometry, cmap=cmap, color=color, ax=ax,
-                           figsize=figsize, **style_kwds)
+    if df.shape[0] > 0:
+        if column is None:
+            return plot_series(df.geometry, cmap=cmap, color=color, ax=ax,
+                               figsize=figsize, **style_kwds)
 
-    if df[column].dtype is np.dtype('O'):
-        categorical = True
+        if df[column].dtype is np.dtype('O'):
+            categorical = True
 
-    # Define `values` as a Series
-    if categorical:
-        if cmap is None:
-            if LooseVersion(matplotlib.__version__) >= '2.0.1':
-                cmap = 'tab10'
-            elif LooseVersion(matplotlib.__version__) >= '2.0.0':
-                # Erroneous name.
-                cmap = 'Vega10'
-            else:
-                cmap = 'Set1'
-        categories = list(set(df[column].values))
-        categories.sort()
-        valuemap = dict([(k, v) for (v, k) in enumerate(categories)])
-        values = np.array([valuemap[k] for k in df[column]])
-    else:
-        values = df[column]
-    if scheme is not None:
-        binning = __pysal_choro(values, scheme, k=k)
-        # set categorical to True for creating the legend
-        categorical = True
-        binedges = [values.min()] + binning.bins.tolist()
-        categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
-                      for i in range(len(binedges)-1)]
-        values = np.array(binning.yb)
-
-    if ax is None:
-        fig, ax = plt.subplots(figsize=figsize)
-        ax.set_aspect('equal')
-
-    mn = values.min() if vmin is None else vmin
-    mx = values.max() if vmax is None else vmax
-
-    geom_types = df.geometry.type
-    poly_idx = np.asarray((geom_types == 'Polygon')
-                          | (geom_types == 'MultiPolygon'))
-    line_idx = np.asarray((geom_types == 'LineString')
-                          | (geom_types == 'MultiLineString'))
-    point_idx = np.asarray(geom_types == 'Point')
-
-    # plot all Polygons and all MultiPolygon components in the same collection
-    polys = df.geometry[poly_idx]
-    if not polys.empty:
-        plot_polygon_collection(ax, polys, values[poly_idx],
-                                vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
-
-    # plot all LineStrings and MultiLineString components in same collection
-    lines = df.geometry[line_idx]
-    if not lines.empty:
-        plot_linestring_collection(ax, lines, values[line_idx],
-                                   vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
-
-    # plot all Points in the same collection
-    points = df.geometry[point_idx]
-    if not points.empty:
-        plot_point_collection(ax, points, values[point_idx],
-                              vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
-
-    if legend and not color:
-        from matplotlib.lines import Line2D
-        from matplotlib.colors import Normalize
-        from matplotlib import cm
-
-        norm = Normalize(vmin=mn, vmax=mx)
-        n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
+        # Define `values` as a Series
         if categorical:
-            patches = []
-            for value, cat in enumerate(categories):
-                patches.append(
-                    Line2D([0], [0], linestyle="none", marker="o",
-                           alpha=style_kwds.get('alpha', 1), markersize=10,
-                           markerfacecolor=n_cmap.to_rgba(value)))
-            if legend_kwds is None:
-                legend_kwds = {}
-            legend_kwds.setdefault('numpoints', 1)
-            legend_kwds.setdefault('loc', 'best')
-            ax.legend(patches, categories, **legend_kwds)
+            if cmap is None:
+                if LooseVersion(matplotlib.__version__) >= '2.0.1':
+                    cmap = 'tab10'
+                elif LooseVersion(matplotlib.__version__) >= '2.0.0':
+                    # Erroneous name.
+                    cmap = 'Vega10'
+                else:
+                    cmap = 'Set1'
+            categories = list(set(df[column].values))
+            categories.sort()
+            valuemap = dict([(k, v) for (v, k) in enumerate(categories)])
+            values = np.array([valuemap[k] for k in df[column]])
         else:
-            n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap, ax=ax)
+            values = df[column]
+        if scheme is not None:
+            binning = __pysal_choro(values, scheme, k=k)
+            # set categorical to True for creating the legend
+            categorical = True
+            binedges = [values.min()] + binning.bins.tolist()
+            categories = ['{0:.2f} - {1:.2f}'.format(binedges[i], binedges[i+1])
+                          for i in range(len(binedges)-1)]
+            values = np.array(binning.yb)
 
-    plt.draw()
+        if ax is None:
+            fig, ax = plt.subplots(figsize=figsize)
+            ax.set_aspect('equal')
+
+        mn = values.min() if vmin is None else vmin
+        mx = values.max() if vmax is None else vmax
+
+        geom_types = df.geometry.type
+        poly_idx = np.asarray((geom_types == 'Polygon')
+                              | (geom_types == 'MultiPolygon'))
+        line_idx = np.asarray((geom_types == 'LineString')
+                              | (geom_types == 'MultiLineString'))
+        point_idx = np.asarray(geom_types == 'Point')
+
+        # plot all Polygons and all MultiPolygon components in the same collection
+        polys = df.geometry[poly_idx]
+        if not polys.empty:
+            plot_polygon_collection(ax, polys, values[poly_idx],
+                                    vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
+
+        # plot all LineStrings and MultiLineString components in same collection
+        lines = df.geometry[line_idx]
+        if not lines.empty:
+            plot_linestring_collection(ax, lines, values[line_idx],
+                                       vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
+
+        # plot all Points in the same collection
+        points = df.geometry[point_idx]
+        if not points.empty:
+            plot_point_collection(ax, points, values[point_idx],
+                                  vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
+
+        if legend and not color:
+            from matplotlib.lines import Line2D
+            from matplotlib.colors import Normalize
+            from matplotlib import cm
+
+            norm = Normalize(vmin=mn, vmax=mx)
+            n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
+            if categorical:
+                patches = []
+                for value, cat in enumerate(categories):
+                    patches.append(
+                        Line2D([0], [0], linestyle="none", marker="o",
+                               alpha=style_kwds.get('alpha', 1), markersize=10,
+                               markerfacecolor=n_cmap.to_rgba(value)))
+                if legend_kwds is None:
+                    legend_kwds = {}
+                legend_kwds.setdefault('numpoints', 1)
+                legend_kwds.setdefault('loc', 'best')
+                ax.legend(patches, categories, **legend_kwds)
+            else:
+                n_cmap.set_array([])
+                ax.get_figure().colorbar(n_cmap, ax=ax)
+
+        plt.draw()
+    else:
+        warnings.warn("The GeoDataFrame you are attempting to plot is "
+                "empty. Nothing has been displayed.", UserWarning)
     return ax
 
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -146,6 +146,15 @@ class TestPointPlotting:
         # last point == top of colorbar
         np.testing.assert_array_equal(point_colors[-1], cbar_colors[-1])
 
+    def test_empty_plot(self):
+        s = GeoSeries([])
+        with pytest.warns(UserWarning):
+            ax = s.plot()
+        assert len(ax.collections) == 0
+        df = GeoDataFrame([])
+        with pytest.warns(UserWarning):
+            ax = df.plot()
+        assert len(ax.collections) == 0
 
 class TestPointZPlotting:
 


### PR DESCRIPTION
This PR fixes #565 by introducing a check in `plot_dataframe`  to make sure the table is not empty. If `df.shape[0] > 0`, it proceeds; otherwise, it issues a warning and returns the original `ax` (if nothing's passed, the `None` is returned).