### PR TITLE
CLN: Remove try/except for old GEOS bug

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -101,14 +101,7 @@ def overlay(df1, df2, how, use_sindex=True):
     mls2 = MultiLineString(rings2)
 
     # Union and polygonize
-    try:
-        # calculating union (try the fast unary_union)
-        mm = unary_union([mls1, mls2])
-    except:
-        # unary_union FAILED
-        # see https://github.com/Toblerity/Shapely/issues/47#issuecomment-18506767
-        # calculating union again (using the slow a.union(b))
-        mm = mls1.union(mls2)
+    mm = unary_union([mls1, mls2])
     newpolys = polygonize(mm)
 
     # determine spatial relationship


### PR DESCRIPTION
Handling for a bug discussed in
https://github.com/Toblerity/Shapely/issues/47#issuecomment-18506767
seems no likely necessary, given the issue was fixed 4 years ago.

Of course, not a big deal to leave this in place if there's concern about removal, I've just been looking around the code and seeing some references to fixes required for old versions of libraries geopandas depends upon. 