### PR TITLE
Add asv benchmark for to_crs

### DIFF
--- a/benchmarks/transform.py
+++ b/benchmarks/transform.py
@@ -1,13 +1,25 @@
-from geopandas import GeoDataFrame, read_file, datasets
+from geopandas import GeoDataFrame, GeoSeries, read_file, datasets
+import numpy as np
 import pandas as pd
+from shapely.geometry import Point
 
 
-class Boroughs:
+class CRS:
 
     def setup(self):
         nybb = read_file(datasets.get_path('nybb'))
         self.long_nybb = GeoDataFrame(pd.concat(10 * [nybb]),
                                       crs=nybb.crs)
 
+        num_points = 20000
+        longitudes = np.random.rand(num_points) - 120
+        latitudes = np.random.rand(num_points) + 38
+        self.point_df = GeoSeries([Point(x, y) for (x, y)
+                                  in zip(longitudes, latitudes)])
+        self.point_df.crs = {"init": "epsg:4326"}
+
     def time_transform_wgs84(self):
         self.long_nybb.to_crs({"init": "epsg:4326"})
+
+    def time_transform_many_points(self):
+        self.point_df.to_crs({"init": "epsg:32610"})

--- a/benchmarks/transform.py
+++ b/benchmarks/transform.py
@@ -1,0 +1,13 @@
+from geopandas import GeoDataFrame, read_file, datasets
+import pandas as pd
+
+
+class Boroughs:
+
+    def setup(self):
+        nybb = read_file(datasets.get_path('nybb'))
+        self.long_nybb = GeoDataFrame(pd.concat(10 * [nybb]),
+                                      crs=nybb.crs)
+
+    def time_transform_wgs84(self):
+        self.long_nybb.to_crs({"init": "epsg:4326"})


### PR DESCRIPTION
Inspired by possibility of switch to `fiona` as basis of transform, rather than `pyproj` (#564). I just replicated the NYBB dataset by 10x since ~1 second runtime seemed like a good baseline amount of time for the test. 