### PR TITLE
COMPAT: Remove deprecated usage of ix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Improvements:
 * Addition of the ``sindex`` attribute, a Spatial Index using the optional
   dependency ``rtree`` (``libspatialindex``) that can be used to speed up
   certain operations such as overlays (#140, #141).
-* Addition of the ``GeoSeries.ix`` coordinate indexer to slice a GeoSeries based
+* Addition of the ``GeoSeries.cx`` coordinate indexer to slice a GeoSeries based
   on a bounding box of the coordinates (#55).
 * Improvements to plotting: ability to specify edge colors (#173), support for
   the ``vmin``, ``vmax``, ``figsize``, ``linewidth`` keywords (#207), legends

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -495,9 +495,9 @@ class TestDataFrame:
         assert 'location' in df
 
         # should be a copy
-        df.ix[0, "A"] = 100
-        assert gf.ix[0, "A"] == 0
-        assert gf2.ix[0, "A"] == 0
+        df.loc[0, "A"] = 100
+        assert gf.loc[0, "A"] == 0
+        assert gf2.loc[0, "A"] == 0
 
         with pytest.raises(ValueError):
             df.set_geometry('location', inplace=True)

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -97,21 +97,21 @@ class TestJoinSindex:
         # First check that we gets hits from the boros frame.
         tree = self.boros.sindex
         hits = tree.intersection((1012821.80, 229228.26), objects=True)
-        res = [self.boros.ix[hit.object]['BoroName'] for hit in hits]
+        res = [self.boros.loc[hit.object]['BoroName'] for hit in hits]
         assert res == ['Bronx', 'Queens']
 
         # Check that we only get the Bronx from this view.
         first = self.boros[self.boros['BoroCode'] < 3]
         tree = first.sindex
         hits = tree.intersection((1012821.80, 229228.26), objects=True)
-        res = [first.ix[hit.object]['BoroName'] for hit in hits]
+        res = [first.loc[hit.object]['BoroName'] for hit in hits]
         assert res == ['Bronx']
 
         # Check that we only get Queens from this view.
         second = self.boros[self.boros['BoroCode'] >= 3]
         tree = second.sindex
         hits = tree.intersection((1012821.80, 229228.26), objects=True)
-        res = [second.ix[hit.object]['BoroName'] for hit in hits],
+        res = [second.loc[hit.object]['BoroName'] for hit in hits],
         assert res == ['Queens']
 
         # Get both the Bronx and Queens again.
@@ -120,5 +120,5 @@ class TestJoinSindex:
         assert merged.sindex.size == 5
         tree = merged.sindex
         hits = tree.intersection((1012821.80, 229228.26), objects=True)
-        res = [merged.ix[hit.object]['BoroName'] for hit in hits]
+        res = [merged.loc[hit.object]['BoroName'] for hit in hits]
         assert res == ['Bronx', 'Queens']

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -55,6 +55,7 @@ def _extract_rings(df):
 
     return rings
 
+
 def overlay(df1, df2, how, use_sindex=True):
     """Perform spatial overlay between two polygons.
 
@@ -136,13 +137,13 @@ def overlay(df1, df2, how, use_sindex=True):
         prop1 = None
         prop2 = None
         for cand_id in candidates1:
-            cand = df1.ix[cand_id]
+            cand = df1.loc[cand_id]
             if cent.intersects(cand[df1.geometry.name]):
                 df1_hit = True
                 prop1 = cand
                 break  # Take the first hit
         for cand_id in candidates2:
-            cand = df2.ix[cand_id]
+            cand = df2.loc[cand_id]
             if cent.intersects(cand[df2.geometry.name]):
                 df2_hit = True
                 prop2 = cand

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -182,12 +182,12 @@ class TestSpatialJoinNYBB:
         # points within polygons
         df = sjoin(self.pointdf, self.polydf, how="left", op="within")
         assert df.shape == (21, 8)
-        assert df.ix[1]['BoroName'] == 'Staten Island'
+        assert df.loc[1]['BoroName'] == 'Staten Island'
 
         # points contain polygons? never happens so we should have nulls
         df = sjoin(self.pointdf, self.polydf, how="left", op="contains")
         assert df.shape == (21, 8)
-        assert np.isnan(df.ix[1]['Shape_Area'])
+        assert np.isnan(df.loc[1]['Shape_Area'])
 
     def test_sjoin_bad_op(self):
         # AttributeError: 'Point' object has no attribute 'spandex'


### PR DESCRIPTION
As of 0.20.0, pandas .ix is deprecated (http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated). This switches all such instances
to the label based .loc indexer. (In searching for usage, I also noticed
the CHANGELOG contained an error in describing the introduction of the
.cx indexer.)