### PR TITLE
CLN: Consolidate pytest sections in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ parentdir_prefix = geopandas-
 
 [tools:pytest]
 xfail_strict=true
-
-[pytest]
 markers =
     web: web tests
     cython: geopandas-cython branch related failures


### PR DESCRIPTION
Put both under [tools:pytest] section to silence warnings.