### PR TITLE
Compatible setup.py for pip install geopandas-cython branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ dependency. ``rtree`` requires the C library [``libspatialindex``](https://githu
 Then, installation works as normal: ``pip install geopandas``
 
 
+**Advanced**
+
+For development purposes, you can install directly from github using: ``pip install --upgrade git+git://github.com/geopandas/geopandas.git@geopandas-cython``
+
+
 Examples
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ except ImportError:
     has_cython = False
 
 use_cython = False
+print('Print msg for PR#896, sys.argv:', sys.argv)
 if '--without-cython' in sys.argv:
     sys.argv.remove('--without-cython')
 
@@ -68,6 +69,18 @@ if '--with-cython' in sys.argv:
     if use_cython and not has_cython:
         raise RuntimeError('ERROR: Cython not found.  Exiting.\n       '
                            'Install Cython or don\'t use "--with-cython"')
+
+if 'pip-' in sys.argv[3] and (sys.argv[1] in ['egg_info', 'install']):
+    #catching pip install geopandas, see if can build cython extensions
+    #pip install .    --> sys.argv = ['-c', 'egg_info', '--egg-base', 'pip-egg-info']
+    #pip install git+ --> sys.argv = ['-c', 'install', '--record', '/tmp/pip-i_hrsvpw-record/install-record.txt', '--single-version-externally-managed', '--compile']
+    use_cython = True
+    if use_cython and not has_cython:
+        #do auto `pip install Cython`?
+        raise RuntimeError('ERROR: Cython not found.  Exiting.\n       '
+                           'Install Cython first with `pip install Cython`')
+
+print('Print msg for PR#896, use_cython:{}, has_cython:{}'.format(use_cython, has_cython))
 
 suffix = '.pyx' if use_cython else '.c'
 ext_modules = []


### PR DESCRIPTION
Work in progress to allow for an easy pip based install directly from git (with or without pre-installing Cython?).

``pip install --upgrade git+https://github.com/geopandas/geopandas.git@geopandas-cython``

Makes it easier for people wanting to develop/try-out geopandas-cython branch!

TODO ensure 'test cases' below work (and find a proper place to put those test cases):

- [x] `pip install git+https://github.com/weiji14/geopandas.git@geopandas.cython`
- [ ] `git clone https://github.com/weiji14/geopandas.git && git checkout geopandas-cython && pip install .`
- [ ] `git clone https://github.com/weiji14/geopandas.git && git checkout geopandas-cython && python setup.py build_ext --inplace --with-cython`


Some references:
- https://stackoverflow.com/questions/24923003/organizing-a-package-with-cython
- https://github.com/pandas-dev/pandas/blob/f18378dc5af59c137e3579ff83806296c2222321/setup.py#L79
- https://github.com/h5py/h5py/blob/28e1e2bb68df60a3f3a42177dd2e7b3a0edfcc6e/setup.py#L35
- https://groups.google.com/forum/?_escaped_fragment_=topic/cython-users/n5UpJmWUzag#!topic/cython-users/n5UpJmWUzag
- https://docs.cython.org/en/latest/src/reference/compilation.html#compiling-with-distutils