### PR TITLE
Fix align to preserve metadata

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -250,8 +250,7 @@ class GeoSeries(GeoPandasBase, Series):
         """ propagate metadata from other to self """
         # NOTE: backported from pandas master (upcoming v0.13)
         for name in self._metadata:
-            if not hasattr(self, name):
-                object.__setattr__(self, name, getattr(other, name, None))
+            object.__setattr__(self, name, getattr(other, name, None))
         return self
 
     def copy(self, order='C'):
@@ -345,15 +344,7 @@ class GeoSeries(GeoPandasBase, Series):
                                                    level=level, copy=copy,
                                                    fill_value=fill_value,
                                                    **kwargs)
-        # left = left.astype(np.uintp)  # TODO: maybe avoid this in pandas
-        # right = right.astype(np.uintp)
-        # left2 = GeoSeries(left)  # TODO: why do we do this?
-        left2 = left
-        if isinstance(other, GeoSeries):
-            right2 = GeoSeries(right)
-            return left2, right2
-        else:  # It is probably a Series, let's keep it that way
-            return left2, right
+        return left, right
 
     def __contains__(self, other):
         """Allow tests of the form "geom in s"

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -106,6 +106,16 @@ class TestSeries:
         assert a1['B'].equals(a2['B'])
         assert a1['C'].is_empty
 
+    def test_align_crs(self):
+        a1 = self.a1
+        a1.crs = {'init': 'epsg:4326', 'no_defs': True}
+        a2 = self.a2
+        a2.crs = {'init': 'epsg:31370', 'no_defs': True}
+
+        res1, res2 = a1.align(a2)
+        assert res1.crs == {'init': 'epsg:4326', 'no_defs': True}
+        assert res2.crs == {'init': 'epsg:31370', 'no_defs': True}
+
     def test_geom_almost_equals(self):
         # TODO: test decimal parameter
         assert np.all(self.g1.geom_almost_equals(self.g1))


### PR DESCRIPTION
Related to https://github.com/geopandas/geopandas/pull/587#issuecomment-337393467 (but this only fixes align to preserve the metadata, does not yet add the warning to `binary_geo`)