### PR TITLE
BUG: let geometry kwarg override geometry in data in GeoDataFrame constructor

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -101,8 +101,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             else:
                 gs['geometry'] = geometry
                 geometry = 'geometry'
+            if geometry in arg.columns:
+                arg.drop(geometry, axis=1, inplace=True)
 
-        if geometry in arg.columns:
+        elif geometry in arg.columns:
             arg = arg.copy()
             geom = arg.pop(geometry)
             geom = coerce_to_geoseries(geom, name=geometry)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -745,6 +745,14 @@ class TestConstructor:
         assert gdf._geometry_column_name == 'my_geom'
         assert gdf.geometry.name == 'my_geom'
 
+    def test_overwrite_geometry(self):
+        # GH602
+        data = pd.DataFrame({'geometry': [1, 2, 3], 'col1': [4, 5, 6]})
+        geoms = pd.Series([Point(i, i) for i in range(3)])
+        # passed geometry kwarg should overwrite geometry column in data
+        res = GeoDataFrame(data, geometry=geoms)
+        assert_geoseries_equal(res.geometry, GeoSeries(geoms))
+
 
 def test_set_geometry_null():
     polys = [Polygon([(random.random(), random.random())


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/602

Logic: if we specify a `geometry` keyword that is not a string, drop any columns in the passed data that have the same name (the default 'geometry' or the derived geometry name if a Series is passed to `geometry`)