### PR TITLE
Override __eq__ with geom_equals for GeoSeries

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -326,7 +326,12 @@ class GeoPandasBase(object):
             The GeoSeries (elementwise) or geometric object to test for
             equality.
         """
-        return binary_predicate('equals', self, other)
+        try:
+            return binary_predicate('equals', self, other)
+        except TypeError:
+            raise TypeError("GeoSeries equality checks are only supported " +
+                            "with shapely geometries or other GeoSeries, " +
+                            "not type {}".format(type(other)))
 
     def geom_almost_equals(self, other, decimal=6):
         """

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -329,8 +329,8 @@ class GeoPandasBase(object):
         try:
             return binary_predicate('equals', self, other)
         except TypeError:
-            raise TypeError("GeoSeries equality checks are only supported " +
-                            "with shapely geometries or other GeoSeries, " +
+            raise TypeError("GeoSeries equality checks are only supported "
+                            "with shapely geometries or other GeoSeries, "
                             "not type {}".format(type(other)))
 
     def geom_almost_equals(self, other, decimal=6):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -433,6 +433,9 @@ class GeoSeries(GeoPandasBase, Series):
     def __eq__(self, other):
         return self.geom_equals(other)
 
+    def __ne__(self, other):
+        return ~self.geom_equals(other)
+
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
         return self.symmetric_difference(other)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -430,6 +430,9 @@ class GeoSeries(GeoPandasBase, Series):
     # Implement standard operators for GeoSeries
     #
 
+    def __eq__(self, other):
+        return self.geom_equals(other)
+
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
         return self.symmetric_difference(other)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -133,6 +133,12 @@ class TestSeries:
         exp = pd.Series([False, True, False])
         assert_series_equal(res, exp)
 
+    def test_not_equal_comp_op(self):
+        s = GeoSeries([Point(x, x) for x in range(3)])
+        res = s != Point(1, 1)
+        exp = pd.Series([True, False, True])
+        assert_series_equal(res, exp)
+
     def test_to_file(self):
         """ Test to_file and from_file """
         tempfilename = os.path.join(self.tempdir, 'test.shp')

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -132,12 +132,27 @@ class TestSeries:
         res = s == Point(1, 1)
         exp = pd.Series([False, True, False])
         assert_series_equal(res, exp)
+        assert (s == s).all()
+        # non-geometry non-equality will raise a TypeError
+        with pytest.raises(TypeError):
+            res = s == 1
+        with pytest.raises(TypeError):
+            res = s == pd.Series([1, 2, 3])
 
     def test_not_equal_comp_op(self):
         s = GeoSeries([Point(x, x) for x in range(3)])
+        s2 = GeoSeries([Point(-x, -x) for x in range(3)])
         res = s != Point(1, 1)
         exp = pd.Series([True, False, True])
         assert_series_equal(res, exp)
+        res = s != s2
+        exp = pd.Series([False, True, True])
+        assert_series_equal(res, exp)
+        # non-geometry non-equality will raise a TypeError
+        with pytest.raises(TypeError):
+            res = s != 1
+        with pytest.raises(TypeError):
+            res = s != pd.Series([1, 2, 3])
 
     def test_to_file(self):
         """ Test to_file and from_file """


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/598

As this PR stands, it at least addresses the individual specific issue raised in #598; `geom_equals` already avoids densifying, so just need to override `__eq__` on a `GeoSeries` to use `geom_equals`. That said, it is not clear to me if there was any particular reason why this behavior was not already in place on master. I would have assumed it was, so the fact that it was not makes me wonder if I'm missing something.

If this is the right way to go, I at least need to add `__ne__` as well. I'm not sure if there's anything else of that sort that makes sense to add.