### PR TITLE
DOC: Add minimal geocoding example for docs

### DIFF
--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -6,7 +6,6 @@
    import geopandas as gpd
 
 
-
 Geocoding
 ==========
 
@@ -24,18 +23,19 @@ with the detailed borough boundary file included within ``geopandas``.
     boros = gpd.read_file(gpd.datasets.get_path("nybb"))
     print(boros.BoroName)
     boro_locations = gpd.tools.geocode(boros.BoroName, provider="google")
+    print(boro_locations)
 
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots()
 
     boros.to_crs({"init": "epsg:4326"}).plot(ax=ax, color="white", edgecolor="black");
-    boro_locations.plot(ax=ax, color="red");
     @savefig boro_centers_over_bounds.png
-    plt.show();
+    boro_locations.plot(ax=ax, color="red");
 
 
-Available ``provider`` arguments include ``'google'``, ``'bing'``,
-``'yahoo'``, and ``'openmapquest'``. See
+The argument to ``provider`` can either be a string referencing geocoding
+services, such as ``'google'``, ``'bing'``, ``'yahoo'``, and
+``'openmapquest'``, or an instance of a ``Geocoder`` from ``geopy``. See
 ``geopy.geocoders.SERVICE_TO_GEOCODER`` for the full list.
 For many providers, parameters such as API keys need to be passed as
 ``**kwargs`` in the ``geocode`` call.

--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -21,9 +21,9 @@ with the detailed borough boundary file included within ``geopandas``.
 .. ipython:: python
 
     boros = gpd.read_file(gpd.datasets.get_path("nybb"))
-    print(boros.BoroName)
+    boros.BoroName
     boro_locations = gpd.tools.geocode(boros.BoroName, provider="google")
-    print(boro_locations)
+    boro_locations
 
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots()

--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -1,17 +1,41 @@
+.. currentmodule:: geopandas
+
+.. ipython:: python
+   :suppress:
+
+   import geopandas as gpd
+
+
 
 Geocoding
 ==========
 
-[TO BE COMPLETED]
+``geopandas`` supports geocoding (i.e., converting place names to
+location on Earth) through `geopy`_, an optional dependency.
+The following example shows how to use the Google geocoding API to get the
+locations of boroughs in New York City, and plots those centers along
+with the detailed borough boundary file included within ``geopandas``.
 
+.. _geopy: http://geopy.readthedocs.io/
 
-.. function:: geopandas.tools.geocode(strings, provider='googlev3', **kwargs)
+.. ipython:: python
 
-  Geocode a list of strings and return a GeoDataFrame containing the
-  resulting points in its ``geometry`` column.  Available
-  ``provider``s include ``googlev3``, ``bing``, ``google``, ``yahoo``,
-  ``mapquest``, and ``openmapquest``.  ``**kwargs`` will be passed as
-  parameters to the appropriate geocoder.
+    boros = gpd.read_file(gpd.datasets.get_path("nybb"))
+    print(boros.BoroName)
+    boro_centers = gpd.tools.geocode(boros.BoroName, provider="google")
 
-  Requires `geopy`_.  Please consult the Terms of Service for the
-  chosen provider.
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+
+    boros.to_crs({"init": "epsg:4326"}).plot(ax=ax, color="white", edgecolor="black");
+    boro_centers.plot(ax=ax, color="red");
+    @savefig boro_centers_over_bounds.png
+    plt.show();
+
+Available ``provider`` arguments include ``'google'``, ``'bing'``,
+``'yahoo'``, and ``'openmapquest'``. See
+``geopy.geocoders.SERVICE_TO_GEOCODER`` for the full list.
+For many providers, parameters such as API keys need to be passed as
+**kwargs in the ``geocode`` call.
+
+Please consult the Terms of Service for the chosen provider.

--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -11,9 +11,10 @@ Geocoding
 ==========
 
 ``geopandas`` supports geocoding (i.e., converting place names to
-location on Earth) through `geopy`_, an optional dependency.
-The following example shows how to use the Google geocoding API to get the
-locations of boroughs in New York City, and plots those centers along
+location on Earth) through `geopy`_, an optional dependency of ``geopandas``.
+The following example shows how to use the `Google geocoding API
+<https://developers.google.com/maps/documentation/geocoding/start>`_ to get the
+locations of boroughs in New York City, and plots those locations along
 with the detailed borough boundary file included within ``geopandas``.
 
 .. _geopy: http://geopy.readthedocs.io/
@@ -22,20 +23,21 @@ with the detailed borough boundary file included within ``geopandas``.
 
     boros = gpd.read_file(gpd.datasets.get_path("nybb"))
     print(boros.BoroName)
-    boro_centers = gpd.tools.geocode(boros.BoroName, provider="google")
+    boro_locations = gpd.tools.geocode(boros.BoroName, provider="google")
 
     import matplotlib.pyplot as plt
     fig, ax = plt.subplots()
 
     boros.to_crs({"init": "epsg:4326"}).plot(ax=ax, color="white", edgecolor="black");
-    boro_centers.plot(ax=ax, color="red");
+    boro_locations.plot(ax=ax, color="red");
     @savefig boro_centers_over_bounds.png
     plt.show();
+
 
 Available ``provider`` arguments include ``'google'``, ``'bing'``,
 ``'yahoo'``, and ``'openmapquest'``. See
 ``geopy.geocoders.SERVICE_TO_GEOCODER`` for the full list.
 For many providers, parameters such as API keys need to be passed as
-**kwargs in the ``geocode`` call.
+``**kwargs`` in the ``geocode`` call.
 
 Please consult the Terms of Service for the chosen provider.


### PR DESCRIPTION
Shows the location of borough centers accessed through Google geocoding
API, along with the boundaries in the shapefile included in geopandas.