### PR TITLE
Raise ValueError using to_file with bool column

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -120,8 +120,9 @@ def infer_schema(df):
         if out_type == 'long':
             out_type = 'int'
         if out_type == 'bool':
-            raise ValueError("column {} is boolean type, ".format(column) +
-                             "which is unsupported in file writing.")
+            raise ValueError('column "{}" is boolean type, '.format(column) +
+                             'which is unsupported in file writing. '
+                             'Consider casting the column to int type.')
         return out_type
 
     properties = OrderedDict([

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -113,16 +113,19 @@ def infer_schema(df):
     except ImportError:
         from ordereddict import OrderedDict
 
-    def convert_type(in_type):
+    def convert_type(column, in_type):
         if in_type == object:
             return 'str'
         out_type = type(np.asscalar(np.zeros(1, in_type))).__name__
         if out_type == 'long':
             out_type = 'int'
+        if out_type == 'bool':
+            raise ValueError("column {} is boolean type, ".format(column) +
+                             "which is unsupported in file writing.")
         return out_type
 
     properties = OrderedDict([
-        (col, convert_type(_type)) for col, _type in
+        (col, convert_type(col, _type)) for col, _type in
         zip(df.columns, df.dtypes) if col != df._geometry_column_name
     ])
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -311,7 +311,7 @@ class TestDataFrame:
         assert np.alltrue(df3['Name'].values == self.line_paths)
 
     def test_to_file_bool(self):
-        """Test error raise when writing with a boolean column."""
+        """Test error raise when writing with a boolean column (GH #437)."""
 
         # still want a temp dir in case this test passes
         tempfilename = os.path.join(self.tempdir, 'boros.shp')

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -310,6 +310,16 @@ class TestDataFrame:
         assert len(df3) == 2
         assert np.alltrue(df3['Name'].values == self.line_paths)
 
+    def test_to_file_bool(self):
+        """Test error raise when writing with a boolean column."""
+
+        # still want a temp dir in case this test passes
+        tempfilename = os.path.join(self.tempdir, 'boros.shp')
+        df_with_bool = self.df.copy()
+        df_with_bool['bool_column'] = True
+        with pytest.raises(ValueError):
+            df_with_bool.to_file(tempfilename)
+
     def test_to_file_types(self):
         """ Test various integer type columns (GH#93) """
         tempfilename = os.path.join(self.tempdir, 'int.shp')


### PR DESCRIPTION
Fiona doesn't support writing to files with boolean type. There was some
discussion of converting to int and writing to file anyway, but at a
minimum seems useful to raise a clearer message about the problem.

Closes #437.