### PR TITLE
Remove descartes from install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ For the installation of GeoPandas, the following packages are required:
 - ``pandas``
 - ``shapely``
 - ``fiona``
-- ``descartes``
 - ``pyproj``
 
-Further, [``rtree``](https://github.com/Toblerity/rtree) is an optional
-dependency. ``rtree`` requires the C library [``libspatialindex``](https://github.com/libspatialindex/libspatialindex). If using brew, you can install using ``brew install Spatialindex``.
+Further, ``descartes`` and ``matplotlib`` are optional dependencies, required
+for plotting, and [``rtree``](https://github.com/Toblerity/rtree) is an optional
+dependency, required for spatial joins. ``rtree`` requires the C library [``libspatialindex``](https://github.com/libspatialindex/libspatialindex). If using brew, you can install using ``brew install Spatialindex``.
 
 
 **Install**

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ such as PostGIS.
 if os.environ.get('READTHEDOCS', False) == 'True':
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'descartes', 'pyproj']
+    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'pyproj']
 
 # get all data dirs in the datasets module
 data_files = []


### PR DESCRIPTION
The descartes import in plotting is hidden, so it is not a hard
dependency, and should not be required for installation.

Closes #647.