### PR TITLE
BUG: Save z dimension in file writes

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -147,6 +147,13 @@ class GeoPandasBase(object):
         return Series([geom.exterior.is_ring for geom in self.geometry],
                       index=self.index)
 
+    @property
+    def has_z(self):
+        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        features that have a z-component."""
+        # operates on the exterior, so can't use _series_unary_op()
+        return _series_unary_op(self, 'has_z', null_value=False)
+
     #
     # Unary operations that return a GeoSeries
     #

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -146,9 +146,14 @@ def _common_geom_type(df):
     # Point, LineString, or Polygon
     geom_types = df.geometry.geom_type.unique()
 
-    from os.path import commonprefix   # To find longest common prefix
-    geom_type = commonprefix([g[::-1] for g in geom_types if g])[::-1]  # Reverse
+    from os.path import commonprefix
+    # use reversed geom types and commonprefix to find the common suffix,
+    # then reverse the result to get back to a geom type
+    geom_type = commonprefix([g[::-1] for g in geom_types if g])[::-1]
     if not geom_type:
-        geom_type = None
+        return None
+
+    if df.geometry.has_z.any():
+        geom_type = "3D " + geom_type
 
     return geom_type

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -320,6 +320,17 @@ class TestDataFrame:
         with pytest.raises(ValueError):
             df_with_bool.to_file(tempfilename)
 
+    def test_to_file_with_z(self):
+        """Test that 3D geometries are retained in writes (GH #612)."""
+
+        tempfilename = os.path.join(self.tempdir, 'test3D.shp')
+        point = Point(0, 0, 500)
+        df = GeoDataFrame({'a': [1]}, geometry=[point], crs={})
+        df.to_file(tempfilename)
+        df_read = GeoDataFrame.from_file(tempfilename)
+        assert_frame_equal(df, df_read)
+        assert_geoseries_equal(df.geometry, df_read.geometry)
+
     def test_to_file_types(self):
         """ Test various integer type columns (GH#93) """
         tempfilename = os.path.join(self.tempdir, 'int.shp')

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -320,12 +320,23 @@ class TestDataFrame:
         with pytest.raises(ValueError):
             df_with_bool.to_file(tempfilename)
 
-    def test_to_file_with_z(self):
+    def test_to_file_with_point_z(self):
         """Test that 3D geometries are retained in writes (GH #612)."""
 
-        tempfilename = os.path.join(self.tempdir, 'test3D.shp')
+        tempfilename = os.path.join(self.tempdir, 'test3Dpoint.shp')
         point = Point(0, 0, 500)
         df = GeoDataFrame({'a': [1]}, geometry=[point], crs={})
+        df.to_file(tempfilename)
+        df_read = GeoDataFrame.from_file(tempfilename)
+        assert_frame_equal(df, df_read)
+        assert_geoseries_equal(df.geometry, df_read.geometry)
+
+    def test_to_file_with_poly_z(self):
+        """Test that 3D geometries are retained in writes (GH #612)."""
+
+        tempfilename = os.path.join(self.tempdir, 'test_3Dpoly.shp')
+        poly = Polygon([[0, 0, 5], [0, 1, 5], [1, 1, 5], [1, 0, 5]])
+        df = GeoDataFrame({'a': [1]}, geometry=[poly], crs={})
         df.to_file(tempfilename)
         df_read = GeoDataFrame.from_file(tempfilename)
         assert_frame_equal(df, df_read)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -323,23 +323,23 @@ class TestDataFrame:
     def test_to_file_with_point_z(self):
         """Test that 3D geometries are retained in writes (GH #612)."""
 
-        tempfilename = os.path.join(self.tempdir, 'test3Dpoint.shp')
-        point = Point(0, 0, 500)
-        df = GeoDataFrame({'a': [1]}, geometry=[point], crs={})
+        tempfilename = os.path.join(self.tempdir, 'test_3Dpoint.shp')
+        point3d = Point(0, 0, 500)
+        point2d = Point(1, 1)
+        df = GeoDataFrame({'a': [1, 2]}, geometry=[point3d, point2d], crs={})
         df.to_file(tempfilename)
         df_read = GeoDataFrame.from_file(tempfilename)
-        assert_frame_equal(df, df_read)
         assert_geoseries_equal(df.geometry, df_read.geometry)
 
     def test_to_file_with_poly_z(self):
         """Test that 3D geometries are retained in writes (GH #612)."""
 
         tempfilename = os.path.join(self.tempdir, 'test_3Dpoly.shp')
-        poly = Polygon([[0, 0, 5], [0, 1, 5], [1, 1, 5], [1, 0, 5]])
-        df = GeoDataFrame({'a': [1]}, geometry=[poly], crs={})
+        poly3d = Polygon([[0, 0, 5], [0, 1, 5], [1, 1, 5], [1, 0, 5]])
+        poly2d = Polygon([[0, 0], [0, 1], [1, 1], [1, 0]])
+        df = GeoDataFrame({'a': [1, 2]}, geometry=[poly3d, poly2d], crs={})
         df.to_file(tempfilename)
         df_read = GeoDataFrame.from_file(tempfilename)
-        assert_frame_equal(df, df_read)
         assert_geoseries_equal(df.geometry, df_read.geometry)
 
     def test_to_file_types(self):

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -32,6 +32,7 @@ class TestGeomMethods:
         self.nested_squares = Polygon(self.sq.boundary,
                                       [self.inner_sq.boundary])
         self.p0 = Point(5, 5)
+        self.p3d = Point(5, 5, 5)
         self.g0 = GeoSeries([self.t1, self.t2, self.sq, self.inner_sq,
                              self.nested_squares, self.p0])
         self.g1 = GeoSeries([self.t1, self.sq])
@@ -40,6 +41,7 @@ class TestGeomMethods:
         self.g3.crs = {'init': 'epsg:4326', 'no_defs': True}
         self.g4 = GeoSeries([self.t2, self.t1])
         self.g4.crs = {'init': 'epsg:4326', 'no_defs': True}
+        self.g_3d = GeoSeries([self.p0, self.p3d])
         self.na = GeoSeries([self.t1, self.t2, Polygon()])
         self.na_none = GeoSeries([self.t1, None])
         self.a1 = self.g1.copy()
@@ -333,6 +335,10 @@ class TestGeomMethods:
     def test_is_simple(self):
         expected = Series(np.array([True] * len(self.g1)), self.g1.index)
         self._test_unary_real('is_simple', expected, self.g1)
+
+    def test_has_z(self):
+        expected = Series([False, True], self.g_3d.index)
+        self._test_unary_real('has_z', expected, self.g_3d)
 
     def test_xy_points(self):
         expected_x = [-73.9847, -74.0446]


### PR DESCRIPTION
In so doing, add the has_z attribute to series. The check in determining
the geometry type is pretty simplistic. Given how fiona is thinking
about geometry types now (https://github.com/Toblerity/Fiona/issues/465)
I didn't see a clearly better way.

Closes #612.