### PR TITLE
ENH: get explicit CRS from EPSG code

### DIFF
--- a/geopandas/tools/__init__.py
+++ b/geopandas/tools/__init__.py
@@ -4,6 +4,7 @@ from .geocoding import geocode, reverse_geocode
 from .overlay import overlay
 from .sjoin import sjoin
 from .util import collect
+from .crs import explicit_crs_from_epsg
 
 __all__ = [
     'overlay',

--- a/geopandas/tools/crs.py
+++ b/geopandas/tools/crs.py
@@ -1,0 +1,38 @@
+import pyproj
+import re
+import os
+import fiona.crs
+
+
+def explicit_crs_from_epsg(crs=None, epsg=None):
+    """
+    Gets full/explicit CRS from EPSG code provided.
+
+    Parameters
+    ----------
+     crs : dict or string, default None
+         An existing crs dict or string with the 'init' key specifying an EPSG code
+     epsg : string or int, default None
+        The EPSG code to lookup
+    """
+
+    if epsg is None:
+        if crs is not None:
+            if isinstance(crs, str):
+                crs = fiona.crs.from_string(crs)
+            if 'init' in crs and crs['init'].lower().startswith('epsg:'):
+                epsg = crs['init'].split(':')[1]
+
+    if epsg is None:
+        raise ValueError('No epsg code provided.')
+
+    with open(os.path.join(pyproj.pyproj_datadir, 'epsg')) as f:
+        data = f.read()
+
+    _crs = re.search('\n<{}>\s*(.+?)\s*<>'.format(epsg), data)
+    if _crs is None:
+        raise ValueError('EPSG code "{}" not found.'.format(epsg))
+    _crs = fiona.crs.from_string(_crs.group(1))
+    # preserve the epsg code for future reference
+    _crs['init'] = 'epsg:{}'.format(epsg)
+    return _crs

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -54,7 +54,8 @@ class TestTools:
             collect([self.mpc, self.mp1])
 
     def test_explicit_crs_from_epsg(self):
-        assert explicit_crs_from_epsg(epsg=4326) == {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}
-
-    def test_explicit_crs_from_crs(self):
-        assert explicit_crs_from_epsg(crs={'init': 'epsg:4326'}) == {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}
+        expected = {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}
+        assert explicit_crs_from_epsg(epsg=4326) == expected
+        assert explicit_crs_from_epsg(epsg='4326') == expected
+        assert explicit_crs_from_epsg(crs={'init': 'epsg:4326'}) == expected
+        assert explicit_crs_from_epsg(crs="{'init': 'epsg:4326'}") == expected

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -4,7 +4,7 @@ from shapely.geometry import Point, MultiPoint, LineString
 
 from geopandas import GeoSeries
 from geopandas.tools import collect
-from geopandas.tools.crs import explicit_crs_from_epsg
+from geopandas.tools.crs import explicit_crs_from_epsg, epsg_from_crs
 
 import pytest
 
@@ -52,6 +52,11 @@ class TestTools:
     def test_collect_mixed_multi(self):
         with pytest.raises(ValueError):
             collect([self.mpc, self.mp1])
+
+    def test_epsg_from_crs(self):
+        assert epsg_from_crs({'init': 'epsg:4326'}) == 4326
+        assert epsg_from_crs({'init': 'EPSG:4326'}) == 4326
+        assert epsg_from_crs('+init=epsg:4326') == 4326
 
     def test_explicit_crs_from_epsg(self):
         expected = {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -4,6 +4,7 @@ from shapely.geometry import Point, MultiPoint, LineString
 
 from geopandas import GeoSeries
 from geopandas.tools import collect
+from geopandas.tools.crs import explicit_crs_from_epsg
 
 import pytest
 
@@ -51,3 +52,9 @@ class TestTools:
     def test_collect_mixed_multi(self):
         with pytest.raises(ValueError):
             collect([self.mpc, self.mp1])
+
+    def test_explicit_crs_from_epsg(self):
+        assert explicit_crs_from_epsg(epsg=4326) == {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}
+
+    def test_explicit_crs_from_crs(self):
+        assert explicit_crs_from_epsg(crs={'init': 'epsg:4326'}) == {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -58,4 +58,4 @@ class TestTools:
         assert explicit_crs_from_epsg(epsg=4326) == expected
         assert explicit_crs_from_epsg(epsg='4326') == expected
         assert explicit_crs_from_epsg(crs={'init': 'epsg:4326'}) == expected
-        assert explicit_crs_from_epsg(crs="{'init': 'epsg:4326'}") == expected
+        assert explicit_crs_from_epsg(crs="+init=epsg:4326") == expected


### PR DESCRIPTION
Gets full/explicit CRS from EPSG code provided. This provides useful logic for #245 when used like `gdf.to_crs(crs=explicit_crs_from_epsg(other_gdf.crs))`. Additionally this could provide a 90% solution for not performing `to_crs` unnecessarily by checking `if explicit_crs_from_epsg(gdf.crs) == explicit_crs_from_epsg(other_gdf.crs)` prior to running `to_crs` could then be used as part of a resolving #65.

Note, I didn't know where this should go (in code or in the docs) so I created the file you see, however I leave it at the discretion of the maintainers as to where it best fits and what documentation it needs (and I'm happy to revise once given direction).