### PR TITLE
BLD: remove pandas/matplotlib master from 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
     - python: 2.7
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
+    - python: 2.7
+      env: PANDAS=master  MATPLOTLIB=2.1.2
 
     - python: 3.6
       env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
       env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
     - python: 2.7
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
-    - python: 2.7
-      env: PANDAS=master  MATPLOTLIB=master
 
     - python: 3.6
       env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17


### PR DESCRIPTION
As of https://github.com/matplotlib/matplotlib/commit/c36902c19622aae8102e12d6ffb4b65f84211465#diff-2eeaed663bd0d25b7e608891384b7298, matplotlib master no longer supports python 2.7. Given the impending deprecation plans for 2.7 across the scientific python stack, it seems reasonable to drop the python2.7 build check for pandas/matplotlib master. Currently, the travis build check is failing everywhere because matplotlib master cannot install with python 2.7.