### PR TITLE
BUG: fix points_from_xy for non-float data

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -49,6 +49,8 @@ def from_wkt(L):
 
 def points_from_xy(x, y):
     """ Convert numpy arrays of x and y values to a GeometryArray of points """
+    x = np.asarray(x, dtype='float64')
+    y = np.asarray(y, dtype='float64')
     out = vectorized.points_from_xy(x, y)
     return GeometryArray(out)
 

--- a/geopandas/tests/test_vectorized.py
+++ b/geopandas/tests/test_vectorized.py
@@ -43,6 +43,11 @@ def test_points():
 
     assert isinstance(points[0], shapely.geometry.Point)
 
+    # non-float
+    points = points_from_xy(np.array([1]), np.array([1]))
+    points[0].equals(Point(1., 1.))
+    points = points_from_xy([1], [1])
+    points[0].equals(Point(1., 1.))
 
 def test_from_shapely():
     assert isinstance(T, GeometryArray)

--- a/geopandas/vectorized.pyx
+++ b/geopandas/vectorized.pyx
@@ -184,8 +184,8 @@ cpdef from_wkt(object L):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef points_from_xy(np.ndarray[double, ndim=1, cast=True] x,
-                     np.ndarray[double, ndim=1, cast=True] y):
+cpdef points_from_xy(np.ndarray[double, ndim=1] x,
+                     np.ndarray[double, ndim=1] y):
     """ Convert numpy arrays of x and y values to a GeometryArray of points """
     cdef Py_ssize_t idx
     cdef GEOSCoordSequence *sequence


### PR DESCRIPTION
Currently the `cast=True` in cython leads to silently wrong data (`points_from_xy` requires float64 data):

```
In [12]: a = geopandas.array.points_from_xy(np.array([0, 1]), np.array([0, 1]))

In [13]: [p.wkt for p in a]
Out[13]: ['POINT (0 0)', 'POINT (4.940656458412465e-324 4.940656458412465e-324)']

In [14]: a = geopandas.array.points_from_xy(np.array([0, 1], dtype='float64'), np.array([0, 1], dtype='float64'))

In [16]: [p.wkt for p in a]
Out[16]: ['POINT (0 0)', 'POINT (1 1)']
```