### PR TITLE
colorbar same height as plot area

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -469,9 +469,14 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         from matplotlib.lines import Line2D
         from matplotlib.colors import Normalize
         from matplotlib import cm
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
 
         norm = Normalize(vmin=mn, vmax=mx)
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
+
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="5%", pad=0.1)
+
         if categorical:
             patches = []
             for value, cat in enumerate(categories):
@@ -486,7 +491,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
             ax.legend(patches, categories, **legend_kwds)
         else:
             n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap, ax=ax)
+            ax.get_figure().colorbar(n_cmap, cax=cax)
 
     plt.draw()
     return ax


### PR DESCRIPTION
This PR is related to https://github.com/geopandas/geopandas/issues/702. 

The PR changes the behavior of colobars in Geopandas. With this PR, the colorbars have the same height as the map area. 

The following example demonstrates the change. The used dataset can be downloaded from [https://opendata.swiss/en/dataset/swissboundaries3d-gemeindegrenzen](url).

Code:


    import geopandas as gpd
    import matplotlib.pyplot as plt
    df = gpd.read_file(r"swissBOUNDARIES3D_1_3_TLM_HOHEITSGEBIET.shp")
    print(df)

    df.plot(column='GEM_FLAECH',
            linewidth=0.1,
            edgecolor='face',
            legend=True)

    plt.tight_layout()

    plt.savefig('test.png')

With the master branch, the results looks like this:
![test_org](https://user-images.githubusercontent.com/259530/38356721-c2308680-38c0-11e8-9a49-bb67a33a7e0b.png)

With the PR like this:

![test_mod](https://user-images.githubusercontent.com/259530/38356732-cd3c4ed8-38c0-11e8-8b6e-a00fad862f4b.png)

The PR is not ready to be included.  Further changes might be necessary regarding the hardcoded "5%" size parameter.  For example the ones proposed in the answer from Matthias in https://stackoverflow.com/questions/18195758/set-matplotlib-colorbar-size-to-match-graph/33505522#33505522. 