### PR TITLE
TST/DEP: remove support for pandas <0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,34 +16,26 @@ matrix:
   include:
     # Only one test for these Python versions
     - python: 3.4
-      env: PANDAS=0.18.1 MATPLOTLIB=1.4.3 SHAPELY=1.5.17
+      env: PANDAS=0.19.2 MATPLOTLIB=1.4.3 SHAPELY=1.5.17
     - python: 3.5
-      env: PANDAS=0.19.2 MATPLOTLIB=1.5.3
+      env: PANDAS=0.20.2 MATPLOTLIB=1.5.3
 
     # Python 2.7 and 3.6 test all supported Pandas versions
     - python: 2.7
-      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 2.7
-      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 2.7
-      env: PANDAS=0.18.1  MATPLOTLIB=1.5.3
-    - python: 2.7
-      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
+      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3 SHAPELY=1.5.17
     - python: 2.7
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
     - python: 2.7
-      env: PANDAS=master  MATPLOTLIB=2.1.2
+      env: PANDAS=0.22.0  MATPLOTLIB=2.1.2
+    - python: 2.7
+      env: PANDAS=master  MATPLOTLIB=2.2.2
 
     - python: 3.6
-      env: PANDAS=0.16.2  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 3.6
-      env: PANDAS=0.17.1  MATPLOTLIB=1.4.3 SHAPELY=1.5.17
-    - python: 3.6
-      env: PANDAS=0.18.1  MATPLOTLIB=1.5.3
-    - python: 3.6
-      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3
+      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3 SHAPELY=1.5.17
     - python: 3.6
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
+    - python: 3.6
+      env: PANDAS=0.22.0  MATPLOTLIB=2.2.2
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 


### PR DESCRIPTION
Clean-up of the travis yaml file. 
(could maybe even more aggressively remove more old versions)