### PR TITLE
always set equal aspect on active axis

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -251,7 +251,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
     import matplotlib.pyplot as plt
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-        ax.set_aspect('equal')
+    ax.set_aspect('equal')
 
     if s.empty:
         warnings.warn("The GeoSeries you are attempting to plot is "
@@ -390,7 +390,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-        ax.set_aspect('equal')
+    ax.set_aspect('equal')
 
     if df.empty:
         warnings.warn("The GeoDataFrame you are attempting to plot is "


### PR DESCRIPTION
This is one way to address #715 

Another way is to push this on users, to suggest that every time a multi-axis figure is built using:

`f,ax = plt.subplots(2,2,figsize=(10,10), subplot_kw=dict(aspect='equal'))`

If it's better to not set `aspect=equal` by default, then maybe just showing the way to set all axes in a subplot to equal aspect in docs would help it be recognized.