### PR TITLE
BUG: fix empty sjoin

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -114,7 +114,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
 
     else:
         # when output from the join has no overlapping geometries
-        result = pd.DataFrame(columns=['_key_left', '_key_right'])
+        result = pd.DataFrame(columns=['_key_left', '_key_right'], dtype=float)
 
     if op == "within":
         # within implemented as the inverse of contains; swap names

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -117,17 +117,22 @@ class TestSpatialJoin:
 
         assert_frame_equal(res, exp)
 
-        # Check empty joins on left
-        polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
-                                           'geometry':  [Polygon([(0, 0), (1, 0), 
-                                                                  (1, 1), (0, 1)]), 
-                                                         Polygon([(1, 0), (2, 0), 
-                                                                  (2, 1), (1, 1)])
-                                                         ]})
-        not_in = geopandas.GeoDataFrame({'col1': [1], 
-                                         'geometry': [Point(-0.5, 0.5)]})
-        empty = sjoin(not_in, polygons, how='left', op='intersects')
-        assert empty.index_right.isnull().all()
+    def test_empty_join(self):
+            # Check empty joins on left
+            polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
+                                               'geometry':  [Polygon([(0, 0), (1, 0), 
+                                                                      (1, 1), (0, 1)]), 
+                                                             Polygon([(1, 0), (2, 0), 
+                                                                      (2, 1), (1, 1)])
+                                                             ]})
+            not_in = geopandas.GeoDataFrame({'col1': [1], 
+                                             'geometry': [Point(-0.5, 0.5)]})
+            empty = sjoin(not_in, polygons, how='left', op='intersects')
+            assert empty.index_right.isnull().all()
+            empty = sjoin(not_in, polygons, how='right', op='intersects')
+            assert empty.index_left.isnull().all()
+            empty = sjoin(not_in, polygons, how='inner', op='intersects')
+            assert empty.empty
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -118,21 +118,21 @@ class TestSpatialJoin:
         assert_frame_equal(res, exp)
 
     def test_empty_join(self):
-            # Check empty joins on left
-            polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
-                                               'geometry':  [Polygon([(0, 0), (1, 0), 
-                                                                      (1, 1), (0, 1)]), 
-                                                             Polygon([(1, 0), (2, 0), 
-                                                                      (2, 1), (1, 1)])
-                                                             ]})
-            not_in = geopandas.GeoDataFrame({'col1': [1], 
-                                             'geometry': [Point(-0.5, 0.5)]})
-            empty = sjoin(not_in, polygons, how='left', op='intersects')
-            assert empty.index_right.isnull().all()
-            empty = sjoin(not_in, polygons, how='right', op='intersects')
-            assert empty.index_left.isnull().all()
-            empty = sjoin(not_in, polygons, how='inner', op='intersects')
-            assert empty.empty
+        # Check empty joins
+        polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
+                                           'geometry':  [Polygon([(0, 0), (1, 0), 
+                                                                  (1, 1), (0, 1)]), 
+                                                         Polygon([(1, 0), (2, 0), 
+                                                                  (2, 1), (1, 1)])
+                                                        ]})
+        not_in = geopandas.GeoDataFrame({'col1': [1], 
+                             'geometry': [Point(-0.5, 0.5)]})
+        empty = sjoin(not_in, polygons, how='left', op='intersects')
+        assert empty.index_right.isnull().all()
+        empty = sjoin(not_in, polygons, how='right', op='intersects')
+        assert empty.index_left.isnull().all()
+        empty = sjoin(not_in, polygons, how='inner', op='intersects')
+        assert empty.empty
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -117,6 +117,18 @@ class TestSpatialJoin:
 
         assert_frame_equal(res, exp)
 
+        # Check empty joins on left
+        polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
+                                           'geometry':  [Polygon([(0, 0), (1, 0), 
+                                                                  (1, 1), (0, 1)]), 
+                                                         Polygon([(1, 0), (2, 0), 
+                                                                  (2, 1), (1, 1)])
+                                                         ]})
+        not_in = geopandas.GeoDataFrame({'col1': [1], 
+                                         'geometry': [Point(-0.5, 0.5)]})
+        empty = sjoin(not_in, polygons, how='left', op='intersects')
+        assert empty.index_right.isnull().all()
+
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
     @pytest.mark.parametrize('op', ['intersects', 'contains', 'within'])


### PR DESCRIPTION
Closes #731

This makes sure that the key dtype in empty spatial joins is `float`, addressing but #731. 