### PR TITLE
Fix warnings with overlay and pandas >= 0.23

### DIFF
--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+from distutils.version import LooseVersion
 
 import pandas as pd
 from shapely.geometry import Point, Polygon
@@ -14,6 +15,12 @@ import pytest
 
 DATA = os.path.join(
     os.path.abspath(os.path.dirname(__file__)), 'data', 'overlay')
+
+
+if str(pd.__version__) < LooseVersion('0.23'):
+    CONCAT_KWARGS = {}
+else:
+    CONCAT_KWARGS = {'sort': False}
 
 
 @pytest.fixture
@@ -72,7 +79,7 @@ def test_overlay(dfs_index, how, use_sindex):
         expected = pd.concat([
             expected_intersection,
             expected_difference
-        ], ignore_index=True)
+        ], ignore_index=True, **CONCAT_KWARGS)
     else:
         expected = _read(how)
 

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -1,5 +1,6 @@
 import warnings
 from functools import reduce
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -7,6 +8,12 @@ from shapely.ops import unary_union, polygonize
 from shapely.geometry import MultiLineString
 
 from geopandas import GeoDataFrame, GeoSeries
+
+
+if str(pd.__version__) < LooseVersion('0.23'):
+    CONCAT_KWARGS = {}
+else:
+    CONCAT_KWARGS = {'sort': False}
 
 
 def _uniquify(columns):
@@ -290,7 +297,7 @@ def _overlay_union(df1, df2):
     """
     dfinter = _overlay_intersection(df1, df2)
     dfsym = _overlay_symmetric_diff(df1, df2)
-    dfunion = pd.concat([dfinter, dfsym], ignore_index=True)
+    dfunion = pd.concat([dfinter, dfsym], ignore_index=True, **CONCAT_KWARGS)
     # keep geometry column last
     columns = list(dfunion.columns)
     columns.remove('geometry')


### PR DESCRIPTION
This should fix the warnings about concat sorting for pandas >= 0.23