### PR TITLE
BUG: Remove read_sql alias

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -1,13 +1,11 @@
-import functools
-
 import pandas as pd
 import shapely.wkb
 
-from geopandas import GeoSeries, GeoDataFrame
+from geopandas import GeoDataFrame
 
 
-def read_sql(sql, con, geom_col='geom', crs=None, hex_encoded=True,
-             index_col=None, coerce_float=True, params=None):
+def read_postgis(sql, con, geom_col='geom', crs=None, hex_encoded=True,
+                 index_col=None, coerce_float=True, params=None):
     """
     Returns a GeoDataFrame corresponding to the result of the query
     string, which must contain a geometry column.
@@ -65,6 +63,3 @@ def read_sql(sql, con, geom_col='geom', crs=None, hex_encoded=True,
                 crs = {"init": "epsg:{}".format(srid)}
 
     return GeoDataFrame(df, crs=crs, geometry=geom_col)
-
-
-read_postgis = functools.partial(read_sql, hex_encoded=True)

--- a/geopandas/io/tests/test_io.py
+++ b/geopandas/io/tests/test_io.py
@@ -1,6 +1,4 @@
 from __future__ import absolute_import
-import sqlite3
-import os
 
 from collections import OrderedDict
 
@@ -10,9 +8,7 @@ from shapely.geometry import box
 
 import geopandas
 from geopandas import read_postgis, read_file
-from geopandas.io.sql import read_sql
-from geopandas.tests.util import (connect, create_postgis, create_sqlite,
-                                  validate_boro_df)
+from geopandas.tests.util import connect, create_postgis, validate_boro_df
 
 
 @pytest.fixture
@@ -21,17 +17,6 @@ def nybb_df():
     df = read_file(nybb_path)
 
     return df
-
-
-def test_read_sqlite(tmpdir, nybb_df):
-    tmp_filename = os.path.join(str(tmpdir), "nybb.sqlite")
-    create_sqlite(nybb_df, tmp_filename)
-    con = sqlite3.connect(tmp_filename)
-    try:
-        sqlite_df = read_sql("SELECT * FROM nybb;", con, hex_encoded=False)
-    finally:
-        con.close()
-    validate_boro_df(sqlite_df)
 
 
 class TestIO:
@@ -153,8 +138,8 @@ class TestIO:
         full_df_shape = self.df.shape
         nybb_filename = geopandas.datasets.get_path('nybb')
         bbox = geopandas.GeoDataFrame(
-            geometry=[box(1031051.7879884212, 224272.49231459625, 1047224.3104931959,
-                          244317.30894023244)],
+            geometry=[box(1031051.7879884212, 224272.49231459625,
+                          1047224.3104931959, 244317.30894023244)],
             crs=self.crs)
         filtered_df = read_file(nybb_filename, bbox=bbox)
         filtered_df_shape = filtered_df.shape
@@ -165,8 +150,8 @@ class TestIO:
         full_df_shape = self.df.shape
         nybb_filename = geopandas.datasets.get_path('nybb')
         bbox = geopandas.GeoDataFrame(
-            geometry=[box(1031051.7879884212, 224272.49231459625, 1047224.3104931959,
-                          244317.30894023244)],
+            geometry=[box(1031051.7879884212, 224272.49231459625,
+                          1047224.3104931959, 244317.30894023244)],
             crs=self.crs)
         bbox.to_crs(epsg=4326, inplace=True)
         filtered_df = read_file(nybb_filename, bbox=bbox)


### PR DESCRIPTION
After further investigation, it seems like the current `read_postgis`
command would not support a spatialite database in the wild (as compared
to the one I'd created using ogr2ogr that had made me optimistic that we
had spatialite read capabilities in place). So long as it is not likely
to work for more use cases, let's leave it as `read_postgis`, since that
is all we think it is likely able to do.