### PR TITLE
CLN: Use generators inplace of lists

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -438,7 +438,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
                 cmap = 'Set1'
         categories = list(set(values))
         categories.sort()
-        valuemap = dict([(k, v) for (v, k) in enumerate(categories)])
+        valuemap = dict((k, v) for (v, k) in enumerate(categories))
         values = np.array([valuemap[k] for k in values])
 
     if scheme is not None:


### PR DESCRIPTION
A minor refactoring to use generators instead of lists in built-in Python functions. Please feel free to reject this, if it's unnecessary. 