### PR TITLE
ENH: allow to specify varying distances for buffer and interpolate

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -506,7 +506,7 @@ class GeoPandasBase(object):
                 raise ValueError("Length of distance sequence does not match "
                                  "length of the GeoSeries")
             if isinstance(distance, pd.Series):
-                if not (distance.index == self.index).all():
+                if not self.index.equals(distance.index):
                     raise ValueError("Index values of distance sequence does "
                                      "not match index values of the GeoSeries")
             return gpd.GeoSeries(
@@ -577,7 +577,7 @@ class GeoPandasBase(object):
                 raise ValueError("Length of distance sequence does not match "
                                  "length of the GeoSeries")
             if isinstance(distance, pd.Series):
-                if not (distance.index == self.index).all():
+                if not self.index.equals(distance.index):
                     raise ValueError("Index values of distance sequence does "
                                      "not match index values of the GeoSeries")
             return gpd.GeoSeries(

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -573,11 +573,11 @@ class GeoPandasBase(object):
                 raise ValueError("Length of distance sequence does not match "
                                  "length of the GeoSeries")
             return gpd.GeoSeries(
-                    [s.interpolate(dist, normalized)
+                    [s.interpolate(dist, normalized=normalized)
                     for (s, dist) in zip(self.geometry, distance)],
                 index=self.index, crs=self.crs)
 
-        return gpd.GeoSeries([s.interpolate(distance, normalized)
+        return gpd.GeoSeries([s.interpolate(distance, normalized=normalized)
                              for s in self.geometry],
             index=self.index, crs=self.crs)
 
@@ -679,8 +679,8 @@ class GeoPandasBase(object):
         Returns
         ------
         A GeoSeries with a MultiIndex. The levels of the MultiIndex are the
-        original index and a zero-based integer index that counts the 
-        number of single geometries within a multi-part geometry. 
+        original index and a zero-based integer index that counts the
+        number of single geometries within a multi-part geometry.
 
         Example
         -------

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -502,9 +502,13 @@ class GeoPandasBase(object):
             Optional, the resolution of the buffer around each vertex.
         """
         if isinstance(distance, (np.ndarray, pd.Series)):
-            if distance.shape[0] != self.shape[0]:
+            if len(distance) != len(self.index):
                 raise ValueError("Length of distance sequence does not match "
                                  "length of the GeoSeries")
+            if isinstance(distance, pd.Series):
+                if not (distance.index == self.index).all():
+                    raise ValueError("Index values of distance sequence does "
+                                     "not match index values of the GeoSeries")
             return gpd.GeoSeries(
                     [geom.buffer(dist, resolution, **kwargs)
                     for geom, dist in zip(self.geometry, distance)],
@@ -569,9 +573,13 @@ class GeoPandasBase(object):
             of the geometric object's length.
         """
         if isinstance(distance, (np.ndarray, pd.Series)):
-            if distance.shape[0] != self.shape[0]:
+            if len(distance) != len(self.index):
                 raise ValueError("Length of distance sequence does not match "
                                  "length of the GeoSeries")
+            if isinstance(distance, pd.Series):
+                if not (distance.index == self.index).all():
+                    raise ValueError("Index values of distance sequence does "
+                                     "not match index values of the GeoSeries")
             return gpd.GeoSeries(
                     [s.interpolate(dist, normalized=normalized)
                     for (s, dist) in zip(self.geometry, distance)],

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -423,6 +423,11 @@ class TestGeomMethods:
         with pytest.raises(ValueError):
             self.g5.interpolate(distances)
 
+    def test_interpolate_distance_wrong_length(self):
+        distances = Series([1, 2], index=[99, 98])
+        with pytest.raises(ValueError):
+            self.g5.interpolate(distances)
+
     def test_project(self):
         expected = Series([2.0, 1.5], index=self.g5.index)
         p = Point(1.0, 0.5)
@@ -507,12 +512,17 @@ class TestGeomMethods:
              Polygon(((10, 5), (5, 0), (0, 5), (5, 10), (10, 5))),
              ])
         calculated = original.buffer(np.array([1, 5]), resolution=1)
-        for _expected, _calculated in zip(expected, calculated):
-            assert _calculated.almost_equals(_expected)
+        assert_geoseries_equal(calculated, expected, check_less_precise=True)
 
     def test_buffer_distance_wrong_length(self):
         original = GeoSeries([self.p0, self.p0])
         distances = np.array([1, 2, 3])
+        with pytest.raises(ValueError):
+            original.buffer(distances)
+
+    def test_buffer_distance_wrong_index(self):
+        original = GeoSeries([self.p0, self.p0], index=[0, 1])
+        distances = Series(data=[1, 2], index=[99, 98])
         with pytest.raises(ValueError):
             original.buffer(distances)
 

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -421,7 +421,7 @@ class TestGeomMethods:
     def test_interpolate_distance_wrong_length(self):
         distances = np.array([1, 2, 3])
         with pytest.raises(ValueError):
-            self.g5.buffer(distances)
+            self.g5.interpolate(distances)
 
     def test_project(self):
         expected = Series([2.0, 1.5], index=self.g5.index)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -409,6 +409,20 @@ class TestGeomMethods:
         self._test_binary_topological('interpolate', expected, self.g5,
                                       1.5)
 
+    def test_interpolate_distance_array(self):
+        expected = GeoSeries([Point(0.0, 0.75), Point(1.0, 0.5)])
+        self._test_binary_topological('interpolate', expected, self.g5,
+                                      np.array([0.75, 1.5]))
+
+        expected = GeoSeries([Point(0.5, 1.0), Point(0.0, 1.0)])
+        self._test_binary_topological('interpolate', expected, self.g5,
+                                      np.array([0.75, 1.5]), normalized=True)
+
+    def test_interpolate_distance_wrong_length(self):
+        distances = np.array([1, 2, 3])
+        with pytest.raises(ValueError):
+            self.g5.buffer(distances)
+
     def test_project(self):
         expected = Series([2.0, 1.5], index=self.g5.index)
         p = Point(1.0, 0.5)
@@ -485,6 +499,22 @@ class TestGeomMethods:
         for original, calculated in zip(self.g0, calculated_series):
             expected = original.buffer(10, **args)
             assert calculated.equals(expected)
+
+    def test_buffer_distance_array(self):
+        original = GeoSeries([self.p0, self.p0])
+        expected = GeoSeries(
+            [Polygon(((6, 5), (5, 4), (4, 5), (5, 6), (6, 5))),
+             Polygon(((10, 5), (5, 0), (0, 5), (5, 10), (10, 5))),
+             ])
+        calculated = original.buffer(np.array([1, 5]), resolution=1)
+        for _expected, _calculated in zip(expected, calculated):
+            assert _calculated.almost_equals(_expected)
+
+    def test_buffer_distance_wrong_length(self):
+        original = GeoSeries([self.p0, self.p0])
+        distances = np.array([1, 2, 3])
+        with pytest.raises(ValueError):
+            original.buffer(distances)
 
     def test_envelope(self):
         e = self.g3.envelope


### PR DESCRIPTION
This PR allow to use a `np.ndarray` or a `pd.Series` as `distance` argument for the `buffer` and `interpolate` methods of GeoSeries and should closes #767 if merged.