### PR TITLE
DOC: Corrected Mapping Tools scheme options

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -63,7 +63,7 @@ One can also modify the colors used by ``plot`` with the ``cmap`` option (for a 
     world.plot(column='gdp_per_cap', cmap='OrRd');
 
 
-The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``pysal`` installed, which can be accomplished via ``conda install pysal``). The ``scheme`` option can be set to 'equal_interval', 'quantiles' or 'percentiles'. See the `PySAL documentation <http://pysal.readthedocs.io/en/latest/library/esda/mapclassify.html>`_ for further details about these map classification schemes.
+The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``pysal`` installed, which can be accomplished via ``conda install pysal``). The ``scheme`` option can be set to 'equal_interval', 'quantiles' or 'fisher_jenks'. See the `PySAL documentation <http://pysal.readthedocs.io/en/latest/library/esda/mapclassify.html>`_ for further details about these map classification schemes.
 
 .. ipython:: python
 


### PR DESCRIPTION
Corrected mapping scheme options from percentiles to fisher_jenks.
"Options are 'Equal_interval', 'Quantiles', 'Fisher_Jenks'"
See: https://github.com/geopandas/geopandas/blob/master/geopandas/plotting.py#L522