### PR TITLE
CI: fix usage of conda-forge in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - if [ -n "$CHANNEL" ]; then conda config --add channels $CHANNEL; fi
 
   # Install dependencies
-  - conda create -n test-geopandas python=$TRAVIS_PYTHON_VERSION pytest matplotlib six psycopg2 sqlalchemy codecov pytest-cov mock
+  - conda create -n test-geopandas python=$TRAVIS_PYTHON_VERSION pytest matplotlib six psycopg2 sqlalchemy pytest-cov mock
   - source activate test-geopandas
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then conda install shapely=$SHAPELY; else conda install shapely; fi
@@ -46,6 +46,9 @@ install:
 
   - if [[ $PANDAS != 'master' ]]; then conda install pandas==$PANDAS; fi
   - if [[ $PANDAS == 'master' ]]; then conda install pandas cython; pip install git+https://github.com/pydata/pandas.git; fi
+
+  # codecov is not available from defaults
+  - conda install -c conda-forge codecov
 
 script:
   - py.test geopandas --cov geopandas -v --cov-report term-missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,18 @@ matrix:
     - python: 2.7
       env: PANDAS=0.19.2  MATPLOTLIB=1.5.3 SHAPELY=1.5
     - python: 2.7
-      env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
+      env: PANDAS=0.20.2  MATPLOTLIB=2.0.2 CHANNEL=conda-forge
     - python: 2.7
       env: PANDAS=0.23.2  MATPLOTLIB=2.1.2
     - python: 2.7
       env: PANDAS=master  MATPLOTLIB=2.2.2
 
     - python: 3.6
-      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3 SHAPELY=1.5 CHANNEL=conda-forge
+      env: PANDAS=0.19.2  MATPLOTLIB=1.5.3 SHAPELY=1.5 CHANNEL=conda-forge # conda-forge is needed here for this combination
     - python: 3.6
       env: PANDAS=0.20.2  MATPLOTLIB=2.0.2
     - python: 3.6
-      env: PANDAS=0.23.2  MATPLOTLIB=2.2.2
+      env: PANDAS=0.23.2  MATPLOTLIB=2.2.2 CHANNEL=conda-forge
     - python: 3.6
       env: PANDAS=master  MATPLOTLIB=master
 
@@ -38,7 +38,7 @@ install:
   - if [ -n "$CHANNEL" ]; then conda config --add channels $CHANNEL; fi
 
   # Install dependencies
-  - conda create -n test-geopandas -c conda-forge python=$TRAVIS_PYTHON_VERSION pytest matplotlib six psycopg2 sqlalchemy codecov pytest-cov mock
+  - conda create -n test-geopandas python=$TRAVIS_PYTHON_VERSION pytest matplotlib six psycopg2 sqlalchemy codecov pytest-cov mock
   - source activate test-geopandas
   - if [[ $MATPLOTLIB == 'master' ]]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - if [ -n "$SHAPELY" ]; then conda install shapely=$SHAPELY; else conda install shapely; fi


### PR DESCRIPTION
All tests are currently failing due to installation problems with conda-forge (see also https://github.com/conda-forge/geopandas-feedstock/pull/43#issuecomment-412686051). 

This PR will not solve this for the conda-forge builds, but does correct the mixing of conda-forge and defaults (I added a channel flag and added the channel if it was specified, but then hard-coded the use of conda-forge for the first install command). 
Now we explicitly run some builds with conda-forge channel added, and the others without conda-forge