### PR TITLE
VIS: remove marker edge from legend

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -498,7 +498,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
                 patches.append(
                     Line2D([0], [0], linestyle="none", marker="o",
                            alpha=style_kwds.get('alpha', 1), markersize=10,
-                           markerfacecolor=n_cmap.to_rgba(value)))
+                           markerfacecolor=n_cmap.to_rgba(value),
+                           markeredgewidth=0))
             if legend_kwds is None:
                 legend_kwds = {}
             legend_kwds.setdefault('numpoints', 1)


### PR DESCRIPTION
Working with some rather brightly colored labelled data, I noticed that the legend styling can be very visually discordant for some colormaps. 
![2018-08-24-101118_1347x1677_scrot](https://user-images.githubusercontent.com/2250995/44576280-0f5cdb00-a786-11e8-802b-2e520452e6bc.png)

This errs in the same direction as the other cartography, using no boundaries on patches by default:
![2018-08-24-101512_1491x1484_scrot](https://user-images.githubusercontent.com/2250995/44576510-aa55b500-a786-11e8-822c-f957e03f52b7.png)

If there's anything else we'd like to see from legend symbology here, I'm very OK with keeping this open and adding that functionality (@lwasser #735), so long as it's agreed. 

For instance, we could align `geom_types` and `categories` and check during the`(value,cat)` loop at line 497 if `cat` is all of one geometry type. If it is, we could set the marker style intelligently based that type (e.g. polygons get `marker='s'`, points get `marker='o'`, and lines get `marker='-'` or something via `markeredgewidth`).