### PR TITLE
Fix assert_geodataframe_equal to correctly compare left and right

### DIFF
--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -171,6 +171,6 @@ def assert_geodataframe_equal(left, right,
 
     # drop geometries and check remaining columns
     left2 = left.drop([left._geometry_column_name], axis=1)
-    right2 = left.drop([right._geometry_column_name], axis=1)
+    right2 = right.drop([right._geometry_column_name], axis=1)
     assert_frame_equal(left2, right2, check_dtype=check_dtype,
                        check_index_type=check_index_type, obj='GeoDataFrame')

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -189,4 +189,6 @@ def assert_geodataframe_equal(left, right,
     left2 = left.drop([left._geometry_column_name], axis=1)
     right2 = right.drop([right._geometry_column_name], axis=1)
     assert_frame_equal(left2, right2, check_dtype=check_dtype,
-                       check_index_type=check_index_type, obj='GeoDataFrame')
+                       check_index_type=check_index_type,
+                       check_column_type=check_column_type,
+                       obj='GeoDataFrame')

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -80,6 +80,7 @@ def test_overlay(dfs_index, how, use_sindex):
             expected_intersection,
             expected_difference
         ], ignore_index=True, **CONCAT_KWARGS)
+        expected['col1'] = expected['col1'].astype(float)
     else:
         expected = _read(how)
 

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -38,7 +38,7 @@ def test_geodataframe():
     df3 = df2.copy()
     df3.loc[0, 'col1'] = 10
     with pytest.raises(AssertionError):
-        assert_geodataframe_equal(df1, df2)
+        assert_geodataframe_equal(df1, df3)
 
 
 def test_equal_nans():

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -33,3 +33,8 @@ def test_geodataframe():
         assert_geodataframe_equal(df1, df2[['geometry', 'col1']])
 
     assert_geodataframe_equal(df1, df2[['geometry', 'col1']], check_like=True)
+
+    df3 = df2.copy()
+    df3.loc[0, 'col1'] = 10
+    with pytest.raises(AssertionError):
+        assert_geodataframe_equal(df1, df2)


### PR DESCRIPTION
I just tracked down this bug when using geopandas.testing.assert_geodataframe_equal. I kept being confused as to why my test was succeeding when it shouldn't. This appears to be a typo. I didn't see any other mistakes.

This is my first commit to geopandas. Let me know if you need anything else. Thanks for all your hard work!