### PR TITLE
Clean output from tests by removing warnings

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -64,7 +64,6 @@ class TestGeomMethods:
         self.g5 = GeoSeries([self.l1, self.l2])
         self.g6 = GeoSeries([self.p0, self.t3])
         self.empty = GeoSeries([])
-        self.empty.crs = {'init': 'epsg:4326', 'no_defs': True}
         self.empty_poly = Polygon()
 
         # Crossed lines

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -400,8 +400,9 @@ class TestPySALPlotting:
         cls.df['NEGATIVES'] = np.linspace(-10, 10, len(cls.df.index))
 
     def test_legend(self):
-        ax = self.df.plot(column='CRIME', scheme='QUANTILES', k=3,
-                          cmap='OrRd', legend=True)
+        with warnings.catch_warnings(record=True) as _:  # don't print warning
+            ax = self.df.plot(column='CRIME', scheme='QUANTILES', k=3,
+                              cmap='OrRd', legend=True)
         labels = [t.get_text() for t in ax.get_legend().get_texts()]
         expected = [u'0.18 - 26.07', u'26.07 - 41.97', u'41.97 - 68.89']
         assert labels == expected

--- a/geopandas/tests/test_types.py
+++ b/geopandas/tests/test_types.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from pandas import Series, DataFrame
+import pytest
 from shapely.geometry import Point
 
 from geopandas import GeoSeries, GeoDataFrame
@@ -42,7 +43,8 @@ class TestSeries:
         assert type(self.pts.take(list(range(0, self.N, 2)))) is GeoSeries
 
     def test_select(self):
-        assert type(self.pts.select(lambda x: x % 2 == 0)) is GeoSeries
+        with pytest.warns(FutureWarning):
+            assert type(self.pts.select(lambda x: x % 2 == 0)) is GeoSeries
 
     def test_groupby(self):
         for f, s in self.pts.groupby(lambda x: x % 2):


### PR DESCRIPTION
Removes warnings emitted from tests:

- crs mismatch because of unnecessary crs on `self.empty` series
- downstream warning from `scipy.stats`
- future warning for `.select()`