### PR TITLE
DOC: Remove warnings when building docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,7 +53,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['gallery'],
     'doc_module': ('geopandas',),
     'reference_url': {'matplotlib': 'http://matplotlib.org',
-                      'numpy': 'http://docs.scipy.org/doc/numpy/reference',
+                      'numpy': 'http://docs.scipy.org/doc/numpy',
                       'scipy': 'http://docs.scipy.org/doc/scipy/reference',
                       'geopandas': None},
     'backreferences_dir': 'reference'

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -22,8 +22,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     with geometry. In addition to the standard DataFrame constructor arguments,
     GeoDataFrame also accepts the following keyword arguments:
 
-    Keyword Arguments
-    -----------------
+    Parameters
+    ----------
     crs : str (optional)
         Coordinate system
     geometry : str or array (optional)

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -40,20 +40,21 @@ def geocode(strings, provider='googlev3', **kwargs):
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders
 
+    Notes
+    -----
     Ensure proper use of the results by consulting the Terms of Service for
     your provider.
 
     Geocoding requires geopy. Install it using 'pip install geopy'. See also
     https://github.com/geopy/geopy
 
-    Example
-    -------
+    Examples
+    --------
     >>> df = geocode(['boston, ma', '1600 pennsylvania ave. washington, dc'])
-
-                                                 address  \
+    >>> df
+                                                 address  \\
     0                                    Boston, MA, USA
     1  1600 Pennsylvania Avenue Northwest, President'...
-
                              geometry
     0  POINT (-71.0597732 42.3584308)
     1  POINT (-77.0365305 38.8977332)
@@ -83,21 +84,21 @@ def reverse_geocode(points, provider='googlev3', **kwargs):
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders
 
+    Notes
+    -----
     Ensure proper use of the results by consulting the Terms of Service for
     your provider.
 
     Reverse geocoding requires geopy. Install it using 'pip install geopy'.
     See also https://github.com/geopy/geopy
 
-    Example
-    -------
+    Examples
+    --------
     >>> df = reverse_geocode([Point(-71.0594869, 42.3584697),
                               Point(-77.0365305, 38.8977332)])
-
-                                             address  \
+                                             address  \\
     0             29 Court Square, Boston, MA 02108, USA
     1  1600 Pennsylvania Avenue Northwest, President'...
-
                              geometry
     0  POINT (-71.0594869 42.3584697)
     1  POINT (-77.0365305 38.8977332)

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -96,6 +96,7 @@ def reverse_geocode(points, provider='googlev3', **kwargs):
     --------
     >>> df = reverse_geocode([Point(-71.0594869, 42.3584697),
                               Point(-77.0365305, 38.8977332)])
+    >>> df
                                              address  \\
     0             29 Court Square, Boston, MA 02108, USA
     1  1600 Pennsylvania Avenue Northwest, President'...
@@ -109,7 +110,6 @@ def reverse_geocode(points, provider='googlev3', **kwargs):
 
 def _query(data, forward, provider, **kwargs):
     # generic wrapper for calls over lists to geopy Geocoders
-    import geopy
     from geopy.geocoders.base import GeocoderQueryError
     from geopy.geocoders import get_geocoder_for_service
 


### PR DESCRIPTION
There are some warnings issued by Sphinx when building the docs.

This PR fixes most of the warnings. There are four outstanding warnings about missing `source/reference/geopandas.<smth>.examples` files. These warnings should probably be fixed by creating examples :blush: 

