### PR TITLE
ENH: Friendlier error if dataset is not found

### DIFF
--- a/geopandas/datasets/__init__.py
+++ b/geopandas/datasets/__init__.py
@@ -29,5 +29,6 @@ def get_path(dataset):
             os.path.join(_module_path, _available_zip[dataset]))
         return 'zip://' + fpath
     else:
-        msg = "The dataset '{data}' is not available".format(data=dataset)
+        msg = "The dataset '{data}' is not available. ".format(data=dataset)
+        msg += "Available datasets are {}".format(", ".join(available))
         raise ValueError(msg)


### PR DESCRIPTION
Added a list of available datasets to the error raised when trying to get a path of a dataset that does not exist.

Example:

    >>> import geopandas
    >>> geopandas.datasets.get_path("naturalearth")
    ValueError: The dataset 'naturalearth' is not available. Available datasets are naturalearth_lowres, naturalearth_cities, nybb
