### PR TITLE
Default to `'Unknown'` geometry schema

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -138,10 +138,6 @@ def infer_schema(df):
         raise ValueError("Cannot write empty DataFrame to file.")
 
     geom_type = _common_geom_type(df)
-    
-    if not geom_type:
-        raise ValueError("Geometry column cannot contain mutiple "
-                         "geometry types when writing to file.")
 
     schema = {'geometry': geom_type, 'properties': properties}
 
@@ -159,7 +155,7 @@ def _common_geom_type(df):
     # then reverse the result to get back to a geom type
     geom_type = commonprefix([g[::-1] for g in geom_types if g])[::-1]
     if not geom_type:
-        return None
+        return 'Unknown'
 
     if df.geometry.has_z.any():
         geom_type = "3D " + geom_type

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -418,6 +418,7 @@ class TestDataFrame:
         tempfilename = os.path.join(self.tempdir, 'test.shp')
         s = GeoDataFrame({'geometry': [Point(0, 0),
                                        Polygon([(0, 0), (1, 0), (1, 1)])]})
+        # Exception type is different for different `fiona` versions
         with pytest.raises((ValueError, RuntimeError)):
             s.to_file(tempfilename)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -347,10 +347,14 @@ class TestDataFrame:
         assert type(df2) is GeoDataFrame
         assert self.df.crs == df2.crs
 
-    def test_to_file(self):
+    @pytest.mark.parametrize("driver,ext", [
+        ('ESRI Shapefile', 'shp'),
+        ('GeoJSON', 'geojson')
+    ])
+    def test_to_file(self, driver, ext):
         """ Test to_file and from_file """
-        tempfilename = os.path.join(self.tempdir, 'boros.shp')
-        self.df.to_file(tempfilename)
+        tempfilename = os.path.join(self.tempdir, 'boros.' + ext)
+        self.df.to_file(tempfilename, driver=driver)
         # Read layer back in
         df = GeoDataFrame.from_file(tempfilename)
         assert 'geometry' in df
@@ -358,8 +362,8 @@ class TestDataFrame:
         assert np.alltrue(df['BoroName'].values == self.boros)
 
         # Write layer with null geometry out to file
-        tempfilename = os.path.join(self.tempdir, 'null_geom.shp')
-        self.df3.to_file(tempfilename)
+        tempfilename = os.path.join(self.tempdir, 'null_geom.' + ext)
+        self.df3.to_file(tempfilename, driver=driver)
         # Read layer back in
         df3 = GeoDataFrame.from_file(tempfilename)
         assert 'geometry' in df3
@@ -414,8 +418,15 @@ class TestDataFrame:
         tempfilename = os.path.join(self.tempdir, 'test.shp')
         s = GeoDataFrame({'geometry': [Point(0, 0),
                                        Polygon([(0, 0), (1, 0), (1, 1)])]})
-        with pytest.raises(ValueError):
+        with pytest.raises((ValueError, RuntimeError)):
             s.to_file(tempfilename)
+
+    def test_mixed_types_to_geojson(self):
+        """ Test that mixed geometry types can be saved as GeoJSON (GH #827) """
+        tempfilename = os.path.join(self.tempdir, 'test.geojson')
+        s = GeoDataFrame({'geometry': [Point(0, 0),
+                                       Polygon([(0, 0), (1, 0), (1, 1)])]})
+        s.to_file(tempfilename, driver='GeoJSON')
 
     def test_empty_to_file(self):
         input_empty_df = GeoDataFrame()


### PR DESCRIPTION
Per https://github.com/Toblerity/Fiona/pull/539 this seems like the right way to handle this case.

```
import os
import geopandas as gpd
from shapely.geometry import Polygon, MultiPolygon

p = Polygon([(0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)])
gdf = gpd.GeoDataFrame({'a':[1,2]}, geometry=[p, MultiPolygon([p])])

try:
    os.remove('/tmp/test.geojson')
except:
    pass
gdf.to_file('/tmp/test.geojson', driver='GeoJSON')
```

The above works on Fiona==1.7.13 but on Fiona==1.8a2 gives
```
GeometryTypeValidationError: Record's geometry type does not match collection schema's geometry type: 'MultiPolygon' != 'Polygon'
```

Setting the schema like in this PR works with both versions:
```
gdf.to_file('/tmp/test.geojson', driver='GeoJSON', schema={**gpd.io.file.infer_schema(gdf), 'geometry': 'Unknown'})
```