### PR TITLE
Raise exception from sjoin if inputs are not GeoDataFrames

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from shapely import prepared
 
+from geopandas import GeoDataFrame
+
 
 def sjoin(left_df, right_df, how='inner', op='intersects',
           lsuffix='left', rsuffix='right'):
@@ -29,6 +31,14 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
 
     """
     import rtree
+
+    if not isinstance(left_df, GeoDataFrame):
+        raise ValueError("`left_df` should be GeoDataFrame, got %s" %
+                         (type(left_df)))
+
+    if not isinstance(right_df, GeoDataFrame):
+        raise ValueError("`right_df` should be GeoDataFrame, got %s" %
+                         (type(right_df)))
 
     allowed_hows = ['left', 'right', 'inner']
     if how not in allowed_hows:
@@ -95,22 +105,22 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         check_predicates = np.vectorize(predicate_d[op])
 
         result = (
-                  pd.DataFrame(
-                      np.column_stack(
-                          [l_idx,
-                           r_idx,
-                           check_predicates(
-                               left_df.geometry
-                               .apply(lambda x: prepared.prep(x))[l_idx],
-                               right_df[right_df.geometry.name][r_idx])
-                           ]))
-                   )
+            pd.DataFrame(
+                np.column_stack(
+                    [l_idx,
+                     r_idx,
+                     check_predicates(
+                         left_df.geometry
+                         .apply(lambda x: prepared.prep(x))[l_idx],
+                         right_df[right_df.geometry.name][r_idx])
+                     ]))
+        )
 
         result.columns = ['_key_left', '_key_right', 'match_bool']
         result = (
-                  pd.DataFrame(result[result['match_bool']==1])
-                  .drop('match_bool', axis=1)
-                  )
+            pd.DataFrame(result[result['match_bool'] == 1])
+            .drop('match_bool', axis=1)
+        )
 
     else:
         # when output from the join has no overlapping geometries
@@ -122,39 +132,38 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
         result = result.rename(columns={'_key_left': '_key_right',
                                         '_key_right': '_key_left'})
 
-
     if how == 'inner':
         result = result.set_index('_key_left')
         joined = (
-                  left_df
-                  .merge(result, left_index=True, right_index=True)
-                  .merge(right_df.drop(right_df.geometry.name, axis=1),
-                      left_on='_key_right', right_index=True,
-                      suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
-                 )
+            left_df
+            .merge(result, left_index=True, right_index=True)
+            .merge(right_df.drop(right_df.geometry.name, axis=1),
+                   left_on='_key_right', right_index=True,
+                   suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
+        )
         joined = joined.set_index(index_left).drop(['_key_right'], axis=1)
         joined.index.name = None
     elif how == 'left':
         result = result.set_index('_key_left')
         joined = (
-                  left_df
-                  .merge(result, left_index=True, right_index=True, how='left')
-                  .merge(right_df.drop(right_df.geometry.name, axis=1),
-                      how='left', left_on='_key_right', right_index=True,
-                      suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
-                 )
+            left_df
+            .merge(result, left_index=True, right_index=True, how='left')
+            .merge(right_df.drop(right_df.geometry.name, axis=1),
+                   how='left', left_on='_key_right', right_index=True,
+                   suffixes=('_%s' % lsuffix, '_%s' % rsuffix))
+        )
         joined = joined.set_index(index_left).drop(['_key_right'], axis=1)
         joined.index.name = None
     else:  # how == 'right':
         joined = (
-                  left_df
-                  .drop(left_df.geometry.name, axis=1)
-                  .merge(result.merge(right_df,
-                      left_on='_key_right', right_index=True,
-                      how='right'), left_index=True,
-                      right_on='_key_left', how='right')
-                  .set_index(index_right)
-                 )
+            left_df
+            .drop(left_df.geometry.name, axis=1)
+            .merge(result.merge(right_df,
+                                left_on='_key_right', right_index=True,
+                                how='right'), left_index=True,
+                   right_on='_key_left', how='right')
+            .set_index(index_right)
+        )
         joined = joined.drop(['_key_left', '_key_right'], axis=1)
 
     return joined

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -33,12 +33,12 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
     import rtree
 
     if not isinstance(left_df, GeoDataFrame):
-        raise ValueError("`left_df` should be GeoDataFrame, got %s" %
-                         (type(left_df)))
+        raise ValueError("'left_df' should be GeoDataFrame, got {}".format(
+                         type(left_df)))
 
     if not isinstance(right_df, GeoDataFrame):
-        raise ValueError("`right_df` should be GeoDataFrame, got %s" %
-                         (type(right_df)))
+        raise ValueError("'right_df' should be GeoDataFrame, got {}".format(
+                         type(right_df)))
 
     allowed_hows = ['left', 'right', 'inner']
     if how not in allowed_hows:

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -51,7 +51,10 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
                          (op, allowed_ops))
 
     if left_df.crs != right_df.crs:
-        warn('CRS of frames being joined does not match!')
+        warn(
+            ('CRS of frames being joined does not match!'
+             '(%s != %s)' % (left_df.crs, right_df.crs))
+        )
 
     index_left = 'index_%s' % lsuffix
     index_right = 'index_%s' % rsuffix

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -15,7 +15,7 @@ from pandas.util.testing import assert_frame_equal
 
 
 pandas_0_18_problem = 'fails under pandas < 0.19 due to pandas issue 15692,'\
-                        'not problem with sjoin.'
+    'not problem with sjoin.'
 
 
 @pytest.fixture()
@@ -119,20 +119,38 @@ class TestSpatialJoin:
 
     def test_empty_join(self):
         # Check empty joins
-        polygons = geopandas.GeoDataFrame({'col2': [1, 2], 
-                                           'geometry':  [Polygon([(0, 0), (1, 0), 
-                                                                  (1, 1), (0, 1)]), 
-                                                         Polygon([(1, 0), (2, 0), 
-                                                                  (2, 1), (1, 1)])
+        polygons = geopandas.GeoDataFrame({'col2': [1, 2],
+                                           'geometry': [Polygon([(0, 0), (1, 0),
+                                                                 (1, 1), (0, 1)]),
+                                                        Polygon([(1, 0), (2, 0),
+                                                                 (2, 1), (1, 1)])
                                                         ]})
-        not_in = geopandas.GeoDataFrame({'col1': [1], 
-                             'geometry': [Point(-0.5, 0.5)]})
+        not_in = geopandas.GeoDataFrame({'col1': [1],
+                                         'geometry': [Point(-0.5, 0.5)]})
         empty = sjoin(not_in, polygons, how='left', op='intersects')
         assert empty.index_right.isnull().all()
         empty = sjoin(not_in, polygons, how='right', op='intersects')
         assert empty.index_left.isnull().all()
         empty = sjoin(not_in, polygons, how='inner', op='intersects')
         assert empty.empty
+
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
+                             indirect=True)
+    def test_sjoin_invalid_right(self, dfs):
+        index, df1, df2, expected = dfs
+        with pytest.raises(ValueError) as excinfo:
+            res = sjoin(df1, df2.geometry)
+
+        assert '`right_df` should be GeoDataFrame' in str(excinfo.value)
+
+    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
+                             indirect=True)
+    def test_sjoin_invalid_left(self, dfs):
+        index, df1, df2, expected = dfs
+        with pytest.raises(ValueError) as excinfo:
+            res = sjoin(df1.geometry, df2)
+
+        assert '`left_df` should be GeoDataFrame' in str(excinfo.value)
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
@@ -167,8 +185,8 @@ class TestSpatialJoinNYBB:
         self.pointdf = GeoDataFrame(
             [{'geometry': Point(x, y),
               'pointattr1': x + y, 'pointattr2': x - y}
-             for x, y in zip(range(b[0], b[2], int((b[2]-b[0])/N)),
-                             range(b[1], b[3], int((b[3]-b[1])/N)))],
+             for x, y in zip(range(b[0], b[2], int((b[2] - b[0]) / N)),
+                             range(b[1], b[3], int((b[3] - b[1]) / N)))],
             crs=self.crs)
 
     def test_geometry_name(self):
@@ -227,7 +245,7 @@ class TestSpatialJoinNYBB:
 
     @pytest.mark.parametrize('how', ['left', 'right', 'inner'])
     def test_sjoin_named_index(self, how):
-        #original index names should be unchanged
+        # original index names should be unchanged
         pointdf2 = self.pointdf.copy()
         pointdf2.index.name = 'pointid'
         df = sjoin(pointdf2, self.polydf, how=how)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -136,21 +136,17 @@ class TestSpatialJoin:
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)
-    def test_sjoin_invalid_right(self, dfs):
+    def test_sjoin_invalid_args(self, dfs):
         index, df1, df2, expected = dfs
-        with pytest.raises(ValueError) as excinfo:
-            res = sjoin(df1, df2.geometry)
 
-        assert '`right_df` should be GeoDataFrame' in str(excinfo.value)
-
-    @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
-                             indirect=True)
-    def test_sjoin_invalid_left(self, dfs):
-        index, df1, df2, expected = dfs
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError,
+                           match="'left_df' should be GeoDataFrame"):
             res = sjoin(df1.geometry, df2)
 
-        assert '`left_df` should be GeoDataFrame' in str(excinfo.value)
+        with pytest.raises(ValueError,
+                           match="'right_df' should be GeoDataFrame"):
+            res = sjoin(df1, df2.geometry)
+
 
     @pytest.mark.parametrize('dfs', ['default-index', 'string-index'],
                              indirect=True)


### PR DESCRIPTION
Fix for #841. Also added some more information to the warning raised for mismatching CRS.

Seems like my autopep8 format on save also touched a few more lines in the sjoin test.