### PR TITLE
BUG: fix from_postgis to accept nullable geometry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     # Python 2.7 and 3.6 test all supported Pandas versions
     - env: ENV_FILE="ci/travis/27-pd020.yaml"
     - env: ENV_FILE="ci/travis/27-latest-defaults.yaml"
+    - env: ENV_FILE="ci/travis/27-latest-conda-forge.yaml"
     - env: ENV_FILE="ci/travis/27-dev.yaml"
 
     - env: ENV_FILE="ci/travis/36-pd020.yaml"

--- a/ci/travis/27-dev.yaml
+++ b/ci/travis/27-dev.yaml
@@ -23,6 +23,7 @@ dependencies:
   #- geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite
   - pip:
     - git+https://github.com/pydata/pandas.git
     - codecov

--- a/ci/travis/27-latest-conda-forge.yaml
+++ b/ci/travis/27-latest-conda-forge.yaml
@@ -1,0 +1,28 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=2.7
+  - six
+  # required
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  # testing
+  - pytest
+  - pytest-cov
+  #- codecov
+  - mock
+  # optional
+  - rtree
+  - matplotlib
+  - descartes
+  - pysal
+  #- geopy
+  - SQLalchemy
+  - psycopg2
+  - libspatialite
+  - pip:
+    - codecov
+    - geopy

--- a/ci/travis/27-latest-defaults.yaml
+++ b/ci/travis/27-latest-defaults.yaml
@@ -22,6 +22,7 @@ dependencies:
   #- geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite
   - pip:
     - codecov
     - geopy

--- a/ci/travis/27-pd020.yaml
+++ b/ci/travis/27-pd020.yaml
@@ -24,3 +24,4 @@ dependencies:
   - geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite

--- a/ci/travis/35-minimal.yaml
+++ b/ci/travis/35-minimal.yaml
@@ -22,3 +22,4 @@ dependencies:
   - geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite

--- a/ci/travis/36-pd020.yaml
+++ b/ci/travis/36-pd020.yaml
@@ -21,3 +21,4 @@ dependencies:
   - geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite

--- a/ci/travis/36-pd022.yaml
+++ b/ci/travis/36-pd022.yaml
@@ -21,6 +21,7 @@ dependencies:
   #- geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite
   - pip:
     - codecov
     - geopy

--- a/ci/travis/37-dev.yaml
+++ b/ci/travis/37-dev.yaml
@@ -22,6 +22,7 @@ dependencies:
   #- geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite
   - pip:
     - git+https://github.com/matplotlib/matplotlib.git
     - git+https://github.com/pydata/pandas.git

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -21,3 +21,4 @@ dependencies:
   - geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -21,6 +21,7 @@ dependencies:
   #- geopy
   - SQLalchemy
   - psycopg2
+  - libspatialite
   - pip:
     - codecov
     - geopy

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -145,7 +145,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             level.crs = crs
 
         # Check that we are using a listlike of geometries
-        if not all(isinstance(item, BaseGeometry) or not item for item in level):
+        if not all(isinstance(item, BaseGeometry) or pd.isnull(item) for item in level):
             raise TypeError("Input geometry column must contain valid geometry objects.")
         frame[geo_column_name] = level
         frame._geometry_column_name = geo_column_name

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -239,10 +239,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     @classmethod
     def from_postgis(cls, sql, con, geom_col='geom', crs=None,
-                     hex_encoded=True, index_col=None, coerce_float=True,
-                     params=None):
+                     index_col=None, coerce_float=True, params=None):
         """Alternate constructor to create a ``GeoDataFrame`` from a sql query
-        containing a geometry column.
+        containing a geometry column in WKB representation.
 
         Parameters
         ----------
@@ -252,9 +251,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             column name to convert to shapely geometries
         crs : optional
             Coordinate reference system to use for the returned GeoDataFrame
-        hex_encoded : bool, optional
-            Whether the geometry is in a hex-encoded string. Default is True,
-            standard for postGIS.
         index_col : string or list of strings, optional, default: None
             Column(s) to set as index(MultiIndex)
         coerce_float : boolean, default True
@@ -265,12 +261,15 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Examples
         --------
-        >>> sql = "SELECT geom, highway FROM roads;"
+        PostGIS
+        >>> sql = "SELECT geom, highway FROM roads"
+        SpatiaLite
+        >>> sql = "SELECT ST_Binary(geom) AS geom, highway FROM roads"
         >>> df = geopandas.GeoDataFrame.from_postgis(sql, con)
         """
 
         df = geopandas.io.sql.read_postgis(
-                sql, con, geom_col=geom_col, crs=crs, hex_encoded=hex_encoded,
+                sql, con, geom_col=geom_col, crs=crs,
                 index_col=index_col, coerce_float=coerce_float, params=params)
         return df
 

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+import sqlite3
 
 from geopandas import GeoDataFrame
 from geopandas.testing import (
@@ -48,33 +49,70 @@ def connect(dbname):
 
     return con
 
+def get_srid(df):
+    """Return srid from `df.crs`."""
+    crs = df.crs
+    return (int(crs['init'][5:]) if 'init' in crs
+                                 and crs['init'].startswith('epsg:')
+            else 0)
 
-def create_sqlite(df, con, geom_col="geom"):
+def connect_spatialite():
     """
-    Create the nybb table in sqlite. This was the result of using ogr2ogr
-    to create a sqlite database from a shapefile, and then the .dump command
-    within sqlite to produce the commands to reproduce the database, so may
-    not representative of standard sqlite databases.
+    Return a memory-based SQLite3 connection with SpatiaLite enabled & initialized.
+
+    `The sqlite3 module must be built with loadable extension support <https://docs.python.org/3/library/sqlite3.html#f1>`_ and `SpatiaLite <https://www.gaia-gis.it/fossil/libspatialite/index>`_ must be available on the system as a SQLite module.
+    Packages available on Anaconda meet requirements.
+
+    Exceptions
+    ----------
+    ``AttributeError`` on missing support for loadable SQLite extensions
+    ``sqlite3.OperationalError`` on missing SpatiaLite
+    """
+    try:
+        with sqlite3.connect(':memory:') as con:
+            con.enable_load_extension(True)
+            con.load_extension('mod_spatialite')
+            con.execute('SELECT InitSpatialMetaData(TRUE)')
+    except Exception:
+        con.close()
+        raise
+    return con
+
+def create_spatialite(con, df):
+    """
+    Return a SpatiaLite connection containing the nybb table.
+
+    Parameters
+    ----------
+    `con`: ``sqlite3.Connection``
+    `df`: ``GeoDataFrame``
     """
 
-    is_legacy = sys.version_info.major < 3
     with con:
-        con.execute("CREATE TABLE IF NOT EXISTS 'nybb' "
-                    "( ogc_fid INTEGER PRIMARY KEY, "
-                    "'{}' BLOB, 'borocode' INTEGER, ".format(geom_col) +
-                    "'boroname' VARCHAR(32), 'shape_leng' FLOAT, "
-                    "'shape_area' FLOAT);")
-        sql_row = "INSERT INTO nybb VALUES(?,?,?,?,?,?);"
+        geom_col = df.geometry.name
+        srid = get_srid(df)
+        con.execute('CREATE TABLE IF NOT EXISTS nybb '
+                    '( ogc_fid INTEGER PRIMARY KEY'
+                    ', borocode INTEGER'
+                    ', boroname TEXT'
+                    ', shape_leng REAL'
+                    ', shape_area REAL'
+                    ')')
+        con.execute('SELECT AddGeometryColumn(?, ?, ?, ?)',
+                    ('nybb', geom_col, srid, df.geom_type.dropna().iat[0].upper()))
+        con.execute('SELECT CreateSpatialIndex(?, ?)', ('nybb', geom_col))
+        sql_row = "INSERT INTO nybb VALUES(?, ?, ?, ?, ?, GeomFromText(?, ?))"
         con.executemany(sql_row,
                         ((None,
-                          (buffer(row.geometry.wkb) if is_legacy
-                           else row.geometry.wkb) if row.geometry
-                          else None,
                           row.BoroCode,
                           row.BoroName,
                           row.Shape_Leng,
-                          row.Shape_Area
+                          row.Shape_Area,
+                          row.geometry.wkt if row.geometry
+                          else None,
+                          srid
                          ) for row in df.itertuples(index=False)))
+    return con
 
 
 def create_postgis(df, srid=None, geom_col="geom"):


### PR DESCRIPTION
Though GIS databases allow missing geometry values, `from_postgis` breaks when it encounters them.
These patches fix `from_postgis` and `GeoDataFrame` to allow nulls, and test for the feature with sqlite.

Should [`create_sqlite`][1] get a GIS-oriented rewrite?
Though [`create_sqlite`][1] seemed to have been written for SQLite tests, its original design assumes data isn't stored to perform geospatial analysis within SQLite, which I find questionable.
While comments under [`create_postgis`][2] remind the tester to load a GIS extension in their database, [`create_sqlite`][1] lacks such comments and instead stores geometries as opaque blobs that SQLite's GIS extension, [SpatiaLite][3], wouldn't store.
I would think anyone seriously using GeoPandas and SQLite for GIS analysis would load and store geometries with [SpatiaLite][3] and want that tested much as they would with PostgreSQL and PostGIS.
Nonetheless, I preserved that questionable design in [`create_sqlite`][1] and used it as its name would suggest.

[1]: https://github.com/geopandas/geopandas/pull/856/files#diff-a69da126b34c78887116607be6f68b3cL52
[2]: https://github.com/geopandas/geopandas/pull/856/files#diff-a69da126b34c78887116607be6f68b3cL77
[3]: https://www.gaia-gis.it/fossil/libspatialite/index