### PR TITLE
[WIP] add promotion logic for multi-typed geoms

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -109,7 +109,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=False,
     to multi-layer data, store data within archives (zip files), etc.
     """
     if schema is None:
-        schema = infer_schema(df)
+        schema = infer_schema(df, promote=promote)
     if promote and schema['geometry'].startswith('Multi'):
         original_geometry = df.geometry.copy()
         df[df.geometry.name] = df.geometry.apply(_maybe_promote_geometry)
@@ -122,7 +122,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=False,
         df[original_geometry.name] = original_geometry
 
 
-def infer_schema(df):
+def infer_schema(df, promote=False):
     try:
         from collections import OrderedDict
     except ImportError:
@@ -148,7 +148,7 @@ def infer_schema(df):
     if df.empty:
         raise ValueError("Cannot write empty DataFrame to file.")
 
-    geom_type = _common_geom_type(df)
+    geom_type = _common_geom_type(df, promote=promote)
     
     if not geom_type:
         raise ValueError("Geometry column cannot contain mutiple "

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -111,17 +111,15 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=False,
     if schema is None:
         schema = infer_schema(df)
     if promote and schema['geometry'].startswith('Multi'):
-        df['_temporary_geometry'] = df.geometry.apply(_maybe_promote_geometry)
-        original_geometry = df.geometry.name
-        df = df.set_geometry('_temporary_geometry')
+        original_geometry = df.geometry.copy()
+        df[df.geometry.name] = df.geometry.apply(_maybe_promote_geometry)
     filename = os.path.abspath(os.path.expanduser(filename))
     with fiona.drivers():
         with fiona.open(filename, 'w', driver=driver, crs=df.crs,
                         schema=schema, **kwargs) as colxn:
             colxn.writerecords(df.iterfeatures())
     if promote and schema['geometry'].startswith('Multi'):
-        df.drop('_temporary_geometry', inplace=True, axis=1)
-        df.set_geometry(original_geometry)
+        df[original_geometry.name] = original_geometry
 
 
 def infer_schema(df):

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -79,7 +79,7 @@ def read_file(filename, bbox=None, **kwargs):
     return gdf
 
 
-def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=True,
+def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=False,
             **kwargs):
     """
     Write this GeoDataFrame to an OGR data source
@@ -99,7 +99,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, promote=True,
         If specified, the schema dictionary is passed to Fiona to
         better control how the file is written. If None, GeoPandas
         will determine the schema based on each column's dtype
-    promote : bool, default True
+    promote : bool, default False 
         If True, geometry types will always be converted to multi-geometry
         forms for writing to formats that only support a single geometry type.
         If False, geometry types will not be converted, and writes may fail 
@@ -161,7 +161,7 @@ def infer_schema(df):
     return schema
 
 
-def _common_geom_type(df, promote=True):
+def _common_geom_type(df, promote=False):
     # Need to check geom_types before we write to file...
     # Some (most?) providers expect a single geometry type:
     # Point, LineString, or Polygon


### PR DESCRIPTION
```python
import geopandas, pysal
df = geopandas.read_file(pysal.examples.get_path('south.dbf'))
# works now
df.to_file('./test_promotion.gpkg', promote=True, driver='GPKG')
# fails with the multi-type
df.to_file('./test_promotion.gpkg', promote=False, driver='GPKG')
```
While this is possible, I'm still not quite sure why QGIS is able to do this without forcing everything into multipolygon types. Maybe we can do this right by building a better schema? not sure yet, but wanted to post this up so the discussion from #834 continues. 