### PR TITLE
Make interiors method correspond to non-polygons

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -231,13 +231,17 @@ class GeoPandasBase(object):
 
     @property
     def interiors(self):
-        """Returns a ``GeoSeries`` of InteriorRingSequences representing the
+        """Returns a ``Series`` of InteriorRingSequences representing the
         inner rings of each polygon in the GeoSeries.
 
         Applies to GeoSeries containing only Polygons.
+
+        Returns
+        ----------
+        inner_rings: Series of InteriorRingSequences
+            Inner rings of each polygon in the GeoSeries.
         """
-        # TODO: return empty list or None for non-polygons
-        return _unary_op('interiors', self, null_value=False)
+        return _unary_op('interiors', self, null_value=None)
 
     def representative_point(self):
         """Returns a ``GeoSeries`` of (cheaply computed) points that are

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -395,9 +395,14 @@ class TestGeomMethods:
 
     def test_interiors(self):
         square_series = GeoSeries(self.nested_squares)
-        exp_interiors = GeoSeries([LinearRing(self.inner_sq.boundary)])
-        for expected, computed in zip(exp_interiors, square_series.interiors):
-            assert computed[0].equals(expected)
+        square_series = self.g0
+
+        expected = []
+        assert list(square_series.interiors[0]) == expected
+        expected = LinearRing(self.inner_sq.boundary)
+        assert square_series.interiors[4][0].equals(expected)
+        expected = None
+        assert square_series.interiors[5] is expected
 
     def test_interpolate(self):
         expected = GeoSeries([Point(0.5, 1.0), Point(0.75, 1.0)])


### PR DESCRIPTION
I made interiors method return None for non-polygons.
This is the matter written in TODO of base.py.

Currently, bool value is returned when GeoSeries contains non polygon.
This state was not intended by method, and I attempted to correct it.
