### PR TITLE
ENH: parse date for read_postgis

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -240,7 +240,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     @classmethod
     def from_postgis(cls, sql, con, geom_col='geom', crs=None,
                      hex_encoded=True, index_col=None, coerce_float=True,
-                     params=None):
+                     parse_dates=None, params=None):
         """Alternate constructor to create a ``GeoDataFrame`` from a sql query
         containing a geometry column.
 
@@ -260,6 +260,15 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         coerce_float : boolean, default True
             Attempt to convert values of non-string, non-numeric objects (like
             decimal.Decimal) to floating point, useful for SQL result sets
+        parse_dates : list or dict, default: None
+            - List of column names to parse as dates.
+            - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+            - Dict of ``{column_name: arg dict}``, where the arg dict corresponds
+            to the keyword arguments of :func:`pandas.to_datetime`
+            Especially useful with databases without native Datetime support,
+            such as SQLite.
         params : list, tuple or dict, optional, default: None
             List of parameters to pass to execute method.
 
@@ -271,7 +280,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         df = geopandas.io.sql.read_postgis(
                 sql, con, geom_col=geom_col, crs=crs, hex_encoded=hex_encoded,
-                index_col=index_col, coerce_float=coerce_float, params=params)
+                index_col=index_col, coerce_float=coerce_float,
+                parse_dates=parse_dates, params=params)
         return df
 
     def to_json(self, na='null', show_bbox=False, **kwargs):

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -5,7 +5,8 @@ from geopandas import GeoDataFrame
 
 
 def read_postgis(sql, con, geom_col='geom', crs=None, hex_encoded=True,
-                 index_col=None, coerce_float=True, params=None):
+                 index_col=None, coerce_float=True, parse_dates=None,
+                 params=None):
     """
     Returns a GeoDataFrame corresponding to the result of the query
     string, which must contain a geometry column.
@@ -29,7 +30,7 @@ def read_postgis(sql, con, geom_col='geom', crs=None, hex_encoded=True,
 
     See the documentation for pandas.read_sql for further explanation
     of the following parameters:
-    index_col, coerce_float, params
+    index_col, coerce_float, parse_dates, params
 
     Returns
     -------
@@ -42,7 +43,7 @@ def read_postgis(sql, con, geom_col='geom', crs=None, hex_encoded=True,
     """
 
     df = pd.read_sql(sql, con, index_col=index_col, coerce_float=coerce_float,
-                     params=params)
+                     parse_dates=parse_dates, params=params)
 
     if geom_col not in df:
         raise ValueError("Query missing geometry column '{}'".format(geom_col))


### PR DESCRIPTION
It adds the argument `parse_dates`. The default value is None.

I just add the possibility you have pandas `read_sql` function to specify columns for date parsing to geopandas `read_postgis` function.

I didn't add any test because I was not sure if it was required for such a small change. I'm also unsure of how to do it but if you give me hints I will do it.