### PR TITLE
DOC: continue doc build on warnings/errors in examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,9 @@ extensions = ['IPython.sphinxext.ipython_console_highlighting',
               'numpydoc',
 ]
 
+# continue doc build and only print warnings/errors in examples
+ipython_warning_is_error = False
+
 # Fix issue with warnings from numpydoc (see discussion in PR #534)
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
IPython 7.0 now makes sphinx stop the full doc build if an unexpected warning or error happens in one of the examples. There is an option to restore the old behaviour (to only print the tracebacks), which is IMO more useful (you at least see all errors, and not only the first one).