### PR TITLE
Access to all mapclassify schemes including keywords (#235, #357)

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -63,7 +63,7 @@ One can also modify the colors used by ``plot`` with the ``cmap`` option (for a 
     world.plot(column='gdp_per_cap', cmap='OrRd');
 
 
-The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``pysal`` installed, which can be accomplished via ``conda install pysal``). The ``scheme`` option can be set to 'equal_interval', 'quantiles' or 'fisher_jenks'. See the `PySAL documentation <http://pysal.readthedocs.io/en/latest/library/esda/mapclassify.html>`_ for further details about these map classification schemes.
+The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``mapclassify`` installed, which can be accomplished via ``conda install -c conda-forge mapclassify``). The ``scheme`` option can be set to 'box_plot', 'equal_interval', 'fisher_jenks', 'fisher_jenks_sampled', 'headtail_breaks', 'jenks_caspall', 'jenks_caspall_forced', 'jenks_caspall_sampled', 'max_p_classifier', 'maximum_breaks', 'natural_breaks', 'quantiles', 'percentiles', 'std_mean' or 'User_Defined'. Arguments can be passed in classification_kwds dict. See the `mapclassify documentation <https://mapclassify.readthedocs.io>`_ for further details about these map classification schemes.
 
 .. ipython:: python
 

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -63,7 +63,8 @@ One can also modify the colors used by ``plot`` with the ``cmap`` option (for a 
     world.plot(column='gdp_per_cap', cmap='OrRd');
 
 
-The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``mapclassify`` installed, which can be accomplished via ``conda install -c conda-forge mapclassify``). The ``scheme`` option can be set to 'box_plot', 'equal_interval', 'fisher_jenks', 'fisher_jenks_sampled', 'headtail_breaks', 'jenks_caspall', 'jenks_caspall_forced', 'jenks_caspall_sampled', 'max_p_classifier', 'maximum_breaks', 'natural_breaks', 'quantiles', 'percentiles', 'std_mean' or 'User_Defined'. Arguments can be passed in classification_kwds dict. See the `mapclassify documentation <https://mapclassify.readthedocs.io>`_ for further details about these map classification schemes.
+The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``mapclassify`` installed, which can be accomplished via ``conda install -c conda-forge mapclassify``). The ``scheme`` option can be set to any scheme provided by mapclassify (e.g. 'box_plot', 'equal_interval',
+'fisher_jenks', 'fisher_jenks_sampled', 'headtail_breaks', 'jenks_caspall', 'jenks_caspall_forced', 'jenks_caspall_sampled', 'max_p_classifier', 'maximum_breaks', 'natural_breaks', 'quantiles', 'percentiles', 'std_mean' or 'user_defined'). Arguments can be passed in classification_kwds dict. See the `mapclassify documentation <https://mapclassify.readthedocs.io>`_ for further details about these map classification schemes.
 
 .. ipython:: python
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -570,10 +570,11 @@ def _mapclassify_choro(values, scheme, **classification_kwds):
                          " set: %r" % schemes.keys())
     if classification_kwds['k'] is not None:
         try:
-            from inspect import signature
-            sig = signature(schemes[scheme]).parameters
-            sig['k']
-        except KeyError:
+            from inspect import getfullargspec as getspec
+        except ImportError:
+            from inspect import getargspec as getspec
+        spec = getspec(schemes[scheme])
+        if 'k' not in spec.args:
             del classification_kwds['k']
     try:
         binning = schemes[scheme](values, **classification_kwds)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -573,7 +573,7 @@ def _mapclassify_choro(values, scheme, **classification_kwds):
             from inspect import getfullargspec as getspec
         except ImportError:
             from inspect import getargspec as getspec
-        spec = getspec(schemes[scheme])
+        spec = getspec(schemes[scheme].__init__)
         if 'k' not in spec.args:
             del classification_kwds['k']
     try:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -350,7 +350,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         Plot a legend. Ignored if no `column` is given, or if `color` is given.
     scheme : str (default None)
         Name of a choropleth classification scheme (requires mapclassify).
-        A mapclassify.Classifiers object will be used
+        A mapclassify.Map_Classifier object will be used
         under the hood. Supported are all schemes provided by mapclassify (e.g.
         'Box_Plot', 'Equal_Interval', 'Fisher_Jenks', 'Fisher_Jenks_Sampled',
         'HeadTail_Breaks', 'Jenks_Caspall', 'Jenks_Caspall_Forced',

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -351,7 +351,11 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
     scheme : str (default None)
         Name of a choropleth classification scheme (requires mapclassify).
         A mapclassify.Map_Classifier object will be used
-        under the hood. All schemes are supported, arguments can be passed in
+        under the hood. Supported schemes: 'Box_Plot', 'Equal_Interval',
+        'Fisher_Jenks', 'Fisher_Jenks_Sampled', 'HeadTail_Breaks',
+        'Jenks_Caspall', 'Jenks_Caspall_Forced', 'Jenks_Caspall_Sampled',
+        'Max_P_Classifier', 'Maximum_Breaks', 'Natural_Breaks', 'Quantiles',
+        'Percentiles', 'Std_Mean', 'User_Defined'. Arguments can be passed in
         classification_kwds.
     k : int (default 5)
         Number of classes (ignored if scheme is None)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -351,8 +351,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
     scheme : str (default None)
         Name of a choropleth classification scheme (requires mapclassify).
         A mapclassify.Map_Classifier object will be used
-        under the hood. Supported schemes: 'Quantiles',
-        'Equal_Interval', 'Fisher_Jenks', 'Fisher_Jenks_Sampled'
+        under the hood. All schemes are supported, arguments can be passed in
+        classification_kwds.
     k : int (default 5)
         Number of classes (ignored if scheme is None)
     vmin : None or float (default None)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -413,6 +413,14 @@ class TestMapclassifyPlotting:
         expected = [u'-10.00 - -3.41', u'-3.41 - 3.30', u'3.30 - 10.00']
         assert labels == expected
 
+    def test_classification_kwds(self):
+        ax = self.df.plot(column='pop_est', scheme='percentiles', k=3,
+                          classification_kwds={'pct': [50, 100]}, cmap='OrRd',
+                          legend=True)
+        labels = [t.get_text() for t in ax.get_legend().get_texts()]
+        expected = ['-99.00 - 9035536.00', '9035536.00 - 1338612970.00']
+        assert labels == expected
+
     def test_invalid_scheme(self):
         with pytest.raises(ValueError):
             scheme = 'invalid_scheme_*#&)(*#'


### PR DESCRIPTION
Following #872 and responding to #235 and #357, I have added access to all mapclassify schemes. It is possible to pass kwargs in classification_kwds dict in the exactly same way as it is for legend_kwds. k can be passed as normal argument (same as now)(will be ignored if scheme does is not k-based) or in classification_kwds. If both will be passed, latter will overwrite former. 

I have also added simple test to check if args were passed. Hope you will find it useful, those issues are quite old, I just felt it could be easily done.