### PR TITLE
BUG: Ignore NaN in setting mn and mx (#877)

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -453,8 +453,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
                       for i in range(len(binedges)-1)]
         values = np.array(binning.yb)
 
-    mn = values.min() if vmin is None else vmin
-    mx = values.max() if vmax is None else vmax
+    mn = values[~np.isnan(values)].min() if vmin is None else vmin
+    mx = values[~np.isnan(values)].max() if vmax is None else vmax
 
     geom_types = df.geometry.type
     poly_idx = np.asarray((geom_types == 'Polygon')

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -294,11 +294,10 @@ class TestPolygonPlotting:
         actual_colors = ax.collections[0].get_facecolors()
         np.testing.assert_array_equal(actual_colors[0], actual_colors[1])
 
-        # vmin vmax set correctly for array with NaN
+        # vmin vmax set correctly for array with NaN (GitHub issue 877)
         ax = self.df3.plot(column='values')
         actual_colors = ax.collections[0].get_facecolors()
-        np.testing.assert_equal(np.any(np.not_equal(actual_colors[0],
-                                actual_colors[1])), True)
+        assert np.any(np.not_equal(actual_colors[0], actual_colors[1]))
 
 
     def test_style_kwargs(self):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -261,6 +261,10 @@ class TestPolygonPlotting:
         self.df2 = GeoDataFrame({'geometry': [multipoly1, multipoly2],
                                  'values': [0, 1]})
 
+        t3 = Polygon([(2, 0), (3, 0), (3, 1)])
+        df_nan = GeoDataFrame({'geometry': t3, 'values': [np.nan]})
+        self.df3 = self.df.append(df_nan)
+
     def test_single_color(self):
 
         ax = self.polys.plot(color='green')
@@ -289,6 +293,13 @@ class TestPolygonPlotting:
         ax = self.df.plot(column='values', categorical=True, vmin=0, vmax=0)
         actual_colors = ax.collections[0].get_facecolors()
         np.testing.assert_array_equal(actual_colors[0], actual_colors[1])
+
+        # vmin vmax set correctly for array with NaN
+        ax = self.df3.plot(column='values')
+        actual_colors = ax.collections[0].get_facecolors()
+        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
+                                 actual_colors[0], actual_colors[1])
+
 
     def test_style_kwargs(self):
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -297,8 +297,8 @@ class TestPolygonPlotting:
         # vmin vmax set correctly for array with NaN
         ax = self.df3.plot(column='values')
         actual_colors = ax.collections[0].get_facecolors()
-        np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
-                                 actual_colors[0], actual_colors[1])
+        np.testing.assert_equal(np.any(np.not_equal(actual_colors[0],
+                                actual_colors[1])), True)
 
 
     def test_style_kwargs(self):


### PR DESCRIPTION
Changes in #770 wrong behaviour of `mn = values.min() if vmin is None else vmin` and `mx = values.max() if vmax is None else vmax` which lead to wrong colours during plotting. 

Previous version was passing Series, which ignores NaNs in min() and max(). Now it is passing numpy array which returns NaN for min() and max() (if there are any).

Resolves #877 