### PR TITLE
CLN: Use read_file from geodataframe in geoseries

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -163,7 +163,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-
         filename : str
             File path or file handle to read from. Depending on which kwargs
             are included, the content of filename may vary. See
@@ -175,7 +174,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Examples
         --------
-
         >>> df = geopandas.GeoDataFrame.from_file('nybb.shp')
         """
         return geopandas.io.file.read_file(filename, **kwargs)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -78,7 +78,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Parameters
         ----------
-
         filename : str
             File path or file handle to read from. Depending on which kwargs
             are included, the content of filename may vary. See
@@ -88,15 +87,11 @@ class GeoSeries(GeoPandasBase, Series):
             access multi-layer data, data stored within archives (zip files),
             etc.
         """
-        import fiona
-        geoms = []
-        with fiona.open(filename, **kwargs) as f:
-            crs = f.crs
-            for rec in f:
-                geoms.append(shape(rec['geometry']))
-        g = GeoSeries(geoms)
-        g.crs = crs
-        return g
+
+        from geopandas import GeoDataFrame
+        df = GeoDataFrame.from_file(filename, **kwargs)
+
+        return GeoSeries(df.geometry, crs=df.crs)
 
     @property
     def __geo_interface__(self):
@@ -113,8 +108,8 @@ class GeoSeries(GeoPandasBase, Series):
     def to_file(self, filename, driver="ESRI Shapefile", **kwargs):
         from geopandas import GeoDataFrame
         data = GeoDataFrame({"geometry": self,
-                          "id":self.index.values},
-                          index=self.index)
+                             "id": self.index.values},
+                            index=self.index)
         data.crs = self.crs
         data.to_file(filename, driver, **kwargs)
 
@@ -335,5 +330,6 @@ class GeoSeries(GeoPandasBase, Series):
     def __sub__(self, other):
         """Implement - operator as for builtin set type"""
         return self.difference(other)
+
 
 GeoSeries._create_indexer('cx', _CoordinateIndexer)


### PR DESCRIPTION
I started looking at the issue raised in #881, and realized there was a
somewehat extraneous codepath with `fiona.open` in the geoseries
`read_file` method. This gives one fewer place to make
updates to use `fiona.Env()`.

It seems a little more natural to me to use the
`io.file.read_file` method here, but the adjoining two class methods are
importing from geodataframe and using the methods on `GeoDataFrame`
objects, so I followed suit here.