### PR TITLE
DOC: Use geocodefarm rather than google for example

### DIFF
--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -22,7 +22,8 @@ with the detailed borough boundary file included within ``geopandas``.
 
     boros = geopandas.read_file(geopandas.datasets.get_path("nybb"))
     boros.BoroName
-    boro_locations = geopandas.tools.geocode(boros.BoroName, provider="google")
+    boro_locations = geopandas.tools.geocode(boros.BoroName,
+                                             provider="geocodefarm")
     boro_locations
 
     import matplotlib.pyplot as plt


### PR DESCRIPTION
The request to google is frequently (always?) failing in the past few
months, so use geocodefarm instead for the example of how to use
geocoding in geopandas.