### PR TITLE
DOC: temp allow failure in geoplot example gallary

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,7 +59,8 @@ sphinx_gallery_conf = {
                       'numpy': 'http://docs.scipy.org/doc/numpy',
                       'scipy': 'http://docs.scipy.org/doc/scipy/reference',
                       'geopandas': None},
-    'backreferences_dir': 'reference'
+    'backreferences_dir': 'reference',
+    'expected_failing_examples': ['../../examples/plotting_with_geoplot.py']
 }
 
 # The suffix of source filenames.


### PR DESCRIPTION
Currently due to an installation problem (https://github.com/conda-forge/geoplot-feedstock/pull/5#issuecomment-450808839), the example is not running. 
But even when the latest geoplot is used, it will fail for some time due to the `__pysal_choro` -> `_mapclassify_choro` rename.