### PR TITLE
Consider a new plotting artist for improving colormap legends

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -52,6 +52,32 @@ Choropleth Maps
     world.plot(column='gdp_per_cap');
 
 
+Creating a legend
+~~~~~~~~~~~~~~~~~
+
+When plotting a map, you may be interested in having a proper legend. As this behavior is managed by ``matplotlib``, you can simply create the map straightforwardly with the ``legend`` argument:
+
+.. ipython:: python
+
+    # Plot population estimates with an accurate legend
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(1, 1)
+    @savefig world_pop_est.png
+    world.plot(column='pop_est', ax=ax, legend=True)
+
+However there may be some misalignment artifacts with the legend plotting. A workaround in order to vertically align your legend is provided by ``mpl_toolkits``, and the creation of an additional axe. ``geopandas`` is able to handle such axe with the ``cax`` param:
+
+.. ipython:: python
+
+    # Plot population estimates with an accurate legend
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+    fig, ax = plt.subplots(1, 1)
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size="5%", pad=0.1)
+    @savefig world_pop_est_fixed_legend_height.png
+    world.plot(column='pop_est', ax=ax, legend=True, cax=cax)
+
+
 Choosing colors
 ~~~~~~~~~~~~~~~~
 

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -55,7 +55,7 @@ Choropleth Maps
 Creating a legend
 ~~~~~~~~~~~~~~~~~
 
-When plotting a map, you may be interested in having a proper legend. As this behavior is managed by ``matplotlib``, you can simply create the map straightforwardly with the ``legend`` argument:
+When plotting a map, one can enable a legend using the ``legend`` argument:
 
 .. ipython:: python
 
@@ -65,7 +65,7 @@ When plotting a map, you may be interested in having a proper legend. As this be
     @savefig world_pop_est.png
     world.plot(column='pop_est', ax=ax, legend=True)
 
-However there may be some misalignment artifacts with the legend plotting. A workaround in order to vertically align your legend is provided by ``mpl_toolkits``, and the creation of an additional axe. ``geopandas`` is able to handle such axe with the ``cax`` param:
+However, the default appearance of the legend and plot axes may not be desirable. One can define the plot axes (with ``ax``) and the legend axes (with ``cax``) and then pass those in to the ``plot`` call. The following example uses ``mpl_toolkits`` to vertically align the plot axes and the legend axes:
 
 .. ipython:: python
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -314,7 +314,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
     return ax
 
 
-def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
+def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                    categorical=False, legend=False, scheme=None, k=5,
                    vmin=None, vmax=None, markersize=None, figsize=None,
                    legend_kwds=None, classification_kwds=None, **style_kwds):
@@ -342,6 +342,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         If specified, all objects will be colored uniformly.
     ax : matplotlib.pyplot.Artist (default None)
         axes on which to draw the plot
+    cax : matplotlib.pyplot Artist (default None)
+        axes on which to draw the legend in case of color map.
     categorical : bool (default False)
         If False, cmap will reflect numerical values of the
         column being plotted.  For non-numerical columns, this
@@ -487,6 +489,11 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
         plot_linestring_collection(ax, lines, values[line_idx],
                                    vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
 
+    if cax is not None:
+        cbar_kwargs = {"cax": cax}
+    else:
+        cbar_kwargs = {"ax": ax}
+
     # plot all Points in the same collection
     points = df.geometry[point_idx]
     if not points.empty:
@@ -518,7 +525,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
             ax.legend(patches, categories, **legend_kwds)
         else:
             n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap, ax=ax)
+            ax.get_figure().colorbar(n_cmap, **cbar_kwargs)
 
     plt.draw()
     return ax

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -408,6 +408,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
     import matplotlib.pyplot as plt
 
     if ax is None:
+        if cax is not None:
+            raise ValueError("'ax' can not be None if 'cax' is not.")
         fig, ax = plt.subplots(figsize=figsize)
     ax.set_aspect('equal')
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -437,6 +437,20 @@ class TestMapclassifyPlotting:
             self.df.plot(column='gdp_md_est', scheme=scheme, k=3,
                          cmap='OrRd', legend=True)
 
+    def test_cax_legend_passing(self):
+        """Pass a 'cax' argument to 'df.plot(.)', that is valid only if 'ax' is
+        passed as well (if not, a new figure is created ad hoc, and 'cax' is
+        ignored)
+        """
+        ax = plt.axes()
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes('right', size='5%', pad=0.1)
+        with pytest.raises(ValueError):
+            ax = self.df.plot(
+                column='pop_est', cmap='OrRd', legend=True, cax=cax
+            )
+
     def test_cax_legend_height(self):
         """Pass a cax argument to 'df.plot(.)', the legend location must be
         aligned with those of main plot

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -474,7 +474,7 @@ class TestMapclassifyPlotting:
             )
         plot_height = ax2.get_figure().get_axes()[0].get_position().height
         legend_height = ax2.get_figure().get_axes()[1].get_position().height
-        assert plot_height - legend_height < 1e-6
+        assert abs(plot_height - legend_height) < 1e-6
 
 
 class TestPlotCollections:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -437,6 +437,31 @@ class TestMapclassifyPlotting:
             self.df.plot(column='gdp_md_est', scheme=scheme, k=3,
                          cmap='OrRd', legend=True)
 
+    def test_cax_legend_height(self):
+        """Pass a cax argument to 'df.plot(.)', the legend location must be
+        aligned with those of main plot
+        """
+        # base case
+        with warnings.catch_warnings(record=True) as _:  # don't print warning
+            ax = self.df.plot(
+                column='pop_est', cmap='OrRd', legend=True
+            )
+        plot_height = ax.get_figure().get_axes()[0].get_position().height
+        legend_height = ax.get_figure().get_axes()[1].get_position().height
+        assert abs(plot_height - legend_height) >= 1e-6
+        # fix heights with cax argument
+        ax2 = plt.axes()
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+        divider = make_axes_locatable(ax2)
+        cax = divider.append_axes('right', size='5%', pad=0.1)
+        with warnings.catch_warnings(record=True) as _:
+            ax2 = self.df.plot(
+                column='pop_est', cmap='OrRd', legend=True, cax=cax, ax=ax2
+            )
+        plot_height = ax2.get_figure().get_axes()[0].get_position().height
+        legend_height = ax2.get_figure().get_axes()[1].get_position().height
+        assert plot_height - legend_height < 1e-6
+
 
 class TestPlotCollections:
 


### PR DESCRIPTION
This PR aims at solving issue #702 , and it is directly inspired from reviews done in PR #704 by @jdmcbr .

The point is to improve colormap representation when plotting a GeoDataFrame feature. On master we get oversized colormaps next to main plot:
![insee_population_bkp](https://user-images.githubusercontent.com/15051098/50889386-23813c00-13f8-11e9-8dc7-dfac8352d24e.png)

The `geopandas` new version after PR gives:
![insee_population](https://user-images.githubusercontent.com/15051098/50889422-35fb7580-13f8-11e9-871b-48f2e37f2a6c.png)

Before calling the `gdf.plot(.)` method, we have to write the following lines:
```
import matplotlib.pyplot as plt
from mpl_toolkits.axes_grid1 import make_axes_locatable
fig, ax = plt.subplots(1, 1)
divider = make_axes_locatable(ax)
cax = divider.append_axes("right", size="5%", pad=0.2) # depends on the user needs
```
Hence goes the GeoDataFrame feature plotting:
```
gdf.plot("feature", ax=ax, cax=cax, legend=True)
```

This new behavior allows to tune the colormap, without including the tuning process directly into `geopandas` source code.