### PR TITLE
ENH Provide API to convert x, y(, z) coordinates to geometry

### DIFF
--- a/examples/create_geopandas_from_pandas.py
+++ b/examples/create_geopandas_from_pandas.py
@@ -30,11 +30,11 @@ df = pd.DataFrame(
 # A ``GeoDataFrame`` needs a ``shapely`` object. We use geopandas
 # ``points_from_xy()`` to transform **Longitude** and **Latitude** into a list
 # of ``shapely.Point`` objects and set it as a ``geometry`` while creating the
-# ``GeoDataFrame``.
+# ``GeoDataFrame``. (note that ``points_from_xy()`` is an enhanced wrapper for
+# ``[Point(x, y) for x, y in zip(df.Longitude, df.Latitude)]``)
 
-gdf = geopandas.GeoDataFrame(df,
-                             geometry=geopandas.points_from_xy(df.Longitude,
-                                                               df.Latitude))
+gdf = geopandas.GeoDataFrame(
+    df, geometry=geopandas.points_from_xy(df.Longitude, df.Latitude))
 
 
 ###############################################################################

--- a/examples/create_geopandas_from_pandas.py
+++ b/examples/create_geopandas_from_pandas.py
@@ -11,7 +11,6 @@ two columns.
 """
 import pandas as pd
 import geopandas
-from shapely.geometry import Point
 import matplotlib.pyplot as plt
 
 ###############################################################################
@@ -28,21 +27,15 @@ df = pd.DataFrame(
      'Longitude': [-58.66, -47.91, -70.66, -74.08, -66.86]})
 
 ###############################################################################
-# A ``GeoDataFrame`` needs a ``shapely`` object, so we create a new column
-# **Coordinates** as a tuple of **Longitude** and **Latitude** :
+# A ``GeoDataFrame`` needs a ``shapely`` object. We use geopandas
+# ``points_from_xy()`` to transform **Longitude** and **Latitude** into a list
+# of ``shapely.Point`` objects and set it as a ``geometry`` while creating the
+# ``GeoDataFrame``.
 
-df['Coordinates'] = list(zip(df.Longitude, df.Latitude))
+gdf = geopandas.GeoDataFrame(df,
+                             geometry=geopandas.points_from_xy(df['Longitude'],
+                                                               df['Latitude']))
 
-###############################################################################
-# Then, we transform tuples to ``Point`` :
-
-df['Coordinates'] = df['Coordinates'].apply(Point)
-
-###############################################################################
-# Now, we can create the ``GeoDataFrame`` by setting ``geometry`` with the
-# coordinates created previously.
-
-gdf = geopandas.GeoDataFrame(df, geometry='Coordinates')
 
 ###############################################################################
 # ``gdf`` looks like this :

--- a/examples/create_geopandas_from_pandas.py
+++ b/examples/create_geopandas_from_pandas.py
@@ -33,8 +33,8 @@ df = pd.DataFrame(
 # ``GeoDataFrame``.
 
 gdf = geopandas.GeoDataFrame(df,
-                             geometry=geopandas.points_from_xy(df['Longitude'],
-                                                               df['Latitude']))
+                             geometry=geopandas.points_from_xy(df.Longitude,
+                                                               df.Latitude))
 
 
 ###############################################################################

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -1,5 +1,6 @@
 from geopandas.geoseries import GeoSeries
 from geopandas.geodataframe import GeoDataFrame
+from geopandas.geodataframe import points_from_xy
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -638,7 +638,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
 def points_from_xy(x, y, z=None):
     """
-    Generate list of shapely.Point geometries from x, y(, z) cordinates.
+    Generate list of shapely Point geometries from x, y(, z) coordinates.
 
     Parameters
     ----------
@@ -648,9 +648,8 @@ def points_from_xy(x, y, z=None):
     --------
     >>> geometry = geopandas.points_from_xy(x=[1, 0], y=[0, 1])
     >>> geometry = geopandas.points_from_xy(df['x'], df['y'], df['z'])
-    >>> gdf = geopandas.GeoDataFrame(df,
-                                     geometry=geopandas.points_from_xy(df['x'],
-                                                                       df['y']))
+    >>> gdf = geopandas.GeoDataFrame(
+            df, geometry=geopandas.points_from_xy(df['x'], df['y']))
 
     Returns
     -------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
-from shapely.geometry import mapping, shape
+from shapely.geometry import mapping, shape, Point
 from shapely.geometry.base import BaseGeometry
 from six import string_types, PY3
 
@@ -634,6 +634,37 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         df.index.names = list(self.index.names) + [None]
         geo_df = df.set_geometry(self._geometry_column_name)
         return geo_df
+
+
+def points_from_xy(x, y, z=None):
+    """
+    Generate list of shapely.Point geometries from x, y(, z) cordinates.
+
+    Parameters
+    ----------
+    x, y, z : array
+
+    Examples
+    --------
+    >>> geometry = geopandas.points_from_xy(x=[1, 0], y=[0, 1])
+    >>> geometry = geopandas.points_from_xy(df['x'], df['y'], df['z'])
+    >>> gdf = geopandas.GeoDataFrame(df,
+                                     geometry=geopandas.points_from_xy(df['x'],
+                                                                       df['y']))
+
+    Returns
+    -------
+    list : list
+    """
+    if not len(x) == len(y):
+        raise ValueError("x and y arrays must be equal length.")
+    if z is not None:
+        if not len(z) == len(x):
+            raise ValueError("z array must be same length as x and y.")
+        geom = [Point(i, j, k) for i, j, k in zip(x, y, z)]
+    else:
+        geom = [Point(i, j) for i, j in zip(x, y)]
+    return geom
 
 
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -718,6 +718,13 @@ class TestDataFrame:
             assert geometry1 == gs
             assert geometry2 == gsz
 
+        # using different lenghts should throw error
+        arr_10 = np.arange(10)
+        arr_20 = np.arange(20)
+        with pytest.raises(ValueError):
+            points_from_xy(x=arr_10, y=arr_20)
+            points_from_xy(x=arr_10, y=arr_10, z=arr_20)
+
         # Using incomplete arguments should throw error
         with pytest.raises(TypeError):
             points_from_xy(x=s)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -12,7 +12,8 @@ from shapely.geometry import Point, Polygon
 import fiona
 
 import geopandas
-from geopandas import GeoDataFrame, read_file, GeoSeries, points_from_xy
+from geopandas import GeoDataFrame, read_file, GeoSeries
+from geopandas.geodataframe import points_from_xy
 
 import pytest
 from pandas.util.testing import (


### PR DESCRIPTION
Following discussion at #833 this PR is adding `points_from_xy()` function to convert coordinates stored in the separate columns (or other objects) to `shapely.Point` to be used as `geometry`. 

I just wasn't sure where to put the function (and the test) as it is a bit independent function not so much related to GeoDataFrame or GeoSeries. It is in geodataframe.py as it is designed to be used while creating geometry for GeoDataFrame.

**From longitudes and latitudes** example has been updated to use this new function a well.