### PR TITLE
DOC: Add hint on how to plot unfilled polygons.

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -241,7 +241,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
-        ``alpha``.
+        ``alpha``. Use 'facecolor='none' to get an unfilled polygon.
 
     Returns
     -------
@@ -382,7 +382,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None,
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
-        ``alpha``.
+        ``alpha``. Use 'facecolor='none' to get an unfilled polygon.
 
     Returns
     -------


### PR DESCRIPTION
According to #898 I started by adding a hint to the API documentation.

I could also add an example to the examples section but I will not have time until the end of February.

If it is easy for anybody, so just go ahead, otherwise I will make a proposal in March. I think it would be good to keep the world map but I do not have a second map to plot onto. Any ideas?