### PR TITLE
CI: fix the conda-forge env with pd 0.20 (remove pin of old matplotlib)

### DIFF
--- a/ci/travis/36-pd020.yaml
+++ b/ci/travis/36-pd020.yaml
@@ -6,7 +6,9 @@ dependencies:
   - six
   # required
   - pandas==0.20.2
+  - nomkl
   - shapely
+  - gdal=2.3
   - fiona
   - pyproj
   # testing
@@ -15,7 +17,7 @@ dependencies:
   - codecov
   # optional
   - rtree
-  - matplotlib==1.5.3
+  - matplotlib=2
   - descartes
   - mapclassify
   - geopy


### PR DESCRIPTION
Travis CI tests were failing recently for one specific build, see https://github.com/conda-forge/gdal-feedstock/issues/261

Fixed by removing the pin of matplotlib to 1.5.3 (but added `gdal=2.3` to keep at older gdal version). 

Also added `nomkl` to have a built with numpy/openblas from conda-forge (not that it should matter though).