### PR TITLE
TST: fix to_csv test on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ environment:
     - PYTHON_VERSION: "2.7"
       MINICONDA: C:\Miniconda-x64
 
-    - PYTHON_VERSION: "3.5"
-      MINICONDA: C:\Miniconda35-x64
+    - PYTHON_VERSION: "3.7"
+      MINICONDA: C:\Miniconda37-x64
 
 # all our python builds have to happen in tests_script...
 build: false

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from distutils.version import LooseVersion
+import os
 
 from six import PY3
 
@@ -106,7 +107,7 @@ def test_astype(s):
 def test_to_csv(df):
 
     exp = ('geometry,value1,value2\nPOINT (0 0),0,1\nPOINT (1 1),1,2\n'
-           'POINT (2 2),2,1\n')
+           'POINT (2 2),2,1\n').replace('\n', os.linesep)
     assert df.to_csv(index=False) == exp
 
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 psycopg2>=2.5.1
 SQLAlchemy>=0.8.3
-geopy==1.10.0
+geopy
 matplotlib>=1.2.1
 descartes>=1.0
 mock>=1.0.1  # technically not need for python >= 3.3


### PR DESCRIPTION
Pandas 0.24 changed default lineterminator
to os.linesep (so OS dependent now).