### PR TITLE
Set nominatim as default geocoding service

### DIFF
--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -23,7 +23,7 @@ with the detailed borough boundary file included within ``geopandas``.
     boros = geopandas.read_file(geopandas.datasets.get_path("nybb"))
     boros.BoroName
     boro_locations = geopandas.tools.geocode(boros.BoroName,
-                                             provider="geocodefarm")
+                                             provider="nominatim")
     boro_locations
 
     import matplotlib.pyplot as plt

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import sys
 import numpy as np
 import pandas as pd
 from fiona.crs import from_epsg
@@ -91,6 +90,7 @@ def test_prepare_result():
     assert coords[0] == pytest.approx(test[1])
     assert coords[1] == pytest.approx(test[0])
 
+
 def test_prepare_result_none():
     p0 = Point(12.3, -45.6)  # Treat these as lat/lon
     d = {'a': ('address0', p0.coords[0]),
@@ -106,20 +106,23 @@ def test_prepare_result_none():
     assert len(row['geometry'].coords) == 0
     assert np.isnan(row['address'])
 
+
 def test_bad_provider_forward():
     from geopy.exc import GeocoderNotFound
     with pytest.raises(GeocoderNotFound):
         geocode(['cambridge, ma'], 'badprovider')
+
 
 def test_bad_provider_reverse():
     from geopy.exc import GeocoderNotFound
     with pytest.raises(GeocoderNotFound):
         reverse_geocode(['cambridge, ma'], 'badprovider')
 
+
 def test_forward(locations, points):
-    from geopy.geocoders import GoogleV3
-    for provider in ['googlev3', GoogleV3]:
-        with mock.patch('geopy.geocoders.googlev3.GoogleV3.geocode',
+    from geopy.geocoders import GeocodeFarm
+    for provider in ['geocodefarm', GeocodeFarm]:
+        with mock.patch('geopy.geocoders.geocodefarm.GeocodeFarm.geocode',
                         ForwardMock()) as m:
             g = geocode(locations, provider=provider, timeout=2)
             assert len(locations) == m.call_count
@@ -133,10 +136,11 @@ def test_forward(locations, points):
         assert_series_equal(g['address'],
                             pd.Series(locations, name='address'))
 
+
 def test_reverse(locations, points):
-    from geopy.geocoders import GoogleV3
-    for provider in ['googlev3', GoogleV3]:
-        with mock.patch('geopy.geocoders.googlev3.GoogleV3.reverse',
+    from geopy.geocoders import GeocodeFarm
+    for provider in ['geocodefarm', GeocodeFarm]:
+        with mock.patch('geopy.geocoders.geocodefarm.GeocodeFarm.reverse',
                         ReverseMock()) as m:
             g = reverse_geocode(points, provider=provider, timeout=2)
             assert len(points) == m.call_count

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -120,9 +120,9 @@ def test_bad_provider_reverse():
 
 
 def test_forward(locations, points):
-    from geopy.geocoders import GeocodeFarm
-    for provider in ['geocodefarm', GeocodeFarm]:
-        with mock.patch('geopy.geocoders.geocodefarm.GeocodeFarm.geocode',
+    from geopy.geocoders import Nominatim
+    for provider in ['nominatim', Nominatim]:
+        with mock.patch('geopy.geocoders.osm.Nominatim.geocode',
                         ForwardMock()) as m:
             g = geocode(locations, provider=provider, timeout=2)
             assert len(locations) == m.call_count
@@ -138,9 +138,9 @@ def test_forward(locations, points):
 
 
 def test_reverse(locations, points):
-    from geopy.geocoders import GeocodeFarm
-    for provider in ['geocodefarm', GeocodeFarm]:
-        with mock.patch('geopy.geocoders.geocodefarm.GeocodeFarm.reverse',
+    from geopy.geocoders import Nominatim
+    for provider in ['nominatim', Nominatim]:
+        with mock.patch('geopy.geocoders.osm.Nominatim.reverse',
                         ReverseMock()) as m:
             g = reverse_geocode(points, provider=provider, timeout=2)
             assert len(points) == m.call_count

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -24,7 +24,7 @@ def _throttle_time(provider):
         return 0
 
 
-def geocode(strings, provider='geocodefarm', **kwargs):
+def geocode(strings, provider='nominatim', **kwargs):
     """
     Geocode a set of strings and get a GeoDataFrame of the resulting points.
 
@@ -32,10 +32,10 @@ def geocode(strings, provider='geocodefarm', **kwargs):
     ----------
     strings : list or Series of addresses to geocode
     provider : str or geopy.geocoder
-        Specifies geocoding service to use, default is 'geocodefarm'.
+        Specifies geocoding service to use, default is 'nominatim'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.GeocodeFarm) may be used.
+        (e.g., geopy.geocoders.Nominatim) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders
@@ -63,7 +63,7 @@ def geocode(strings, provider='geocodefarm', **kwargs):
     return _query(strings, True, provider, **kwargs)
 
 
-def reverse_geocode(points, provider='geocodefarm', **kwargs):
+def reverse_geocode(points, provider='nominatim', **kwargs):
     """
     Reverse geocode a set of points and get a GeoDataFrame of the resulting
     addresses.
@@ -76,10 +76,10 @@ def reverse_geocode(points, provider='geocodefarm', **kwargs):
         x coordinate is longitude
         y coordinate is latitude
     provider : str or geopy.geocoder (opt)
-        Specifies geocoding service to use, default is 'geocodefarm'.
+        Specifies geocoding service to use, default is 'nominatim'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.GeocodeFarm) may be used.
+        (e.g., geopy.geocoders.Nominatim) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -24,7 +24,7 @@ def _throttle_time(provider):
         return 0
 
 
-def geocode(strings, provider='googlev3', **kwargs):
+def geocode(strings, provider='geocodefarm', **kwargs):
     """
     Geocode a set of strings and get a GeoDataFrame of the resulting points.
 
@@ -32,10 +32,10 @@ def geocode(strings, provider='googlev3', **kwargs):
     ----------
     strings : list or Series of addresses to geocode
     provider : str or geopy.geocoder
-        Specifies geocoding service to use, default is 'googlev3'.
+        Specifies geocoding service to use, default is 'geocodefarm'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.GoogleV3) may be used.
+        (e.g., geopy.geocoders.GeocodeFarm) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders
@@ -63,7 +63,7 @@ def geocode(strings, provider='googlev3', **kwargs):
     return _query(strings, True, provider, **kwargs)
 
 
-def reverse_geocode(points, provider='googlev3', **kwargs):
+def reverse_geocode(points, provider='geocodefarm', **kwargs):
     """
     Reverse geocode a set of points and get a GeoDataFrame of the resulting
     addresses.
@@ -76,10 +76,10 @@ def reverse_geocode(points, provider='googlev3', **kwargs):
         x coordinate is longitude
         y coordinate is latitude
     provider : str or geopy.geocoder (opt)
-        Specifies geocoding service to use, default is 'googlev3'.
+        Specifies geocoding service to use, default is 'geocodefarm'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.GoogleV3) may be used.
+        (e.g., geopy.geocoders.GeocodeFarm) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders


### PR DESCRIPTION
I hesitated to do this before for the docs, but it is nice to have the
default provider be one that works without an API key (which is now
required for google). The downside of this is that geocodefarm has only
been an option since May 2018, so if someone tries just running the
examples and doesn't have prior experience, they'll get a crash due
to a missing provider rather than a crash due a missing API key.