### PR TITLE
ENH convenience function for converting GeoDataFrame to pandas DataFrame

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -473,7 +473,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         -------
         DataFrame
         """
-        result = self.drop(columns=self._geometry_column_name)
+        result = self.drop(self._geometry_column_name, axis=1)
         if preserve_xy and (self.geom_type == "Point").all():
             result['x'] = self.geometry.x
             result['y'] = self.geometry.y

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -462,6 +462,24 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if not inplace:
             return df
 
+    def to_pandas(self, preserve_xy=False):
+        """Returns a Pandas Dataframe without a geometry column, optionally attempting to preserve point geometries as separate columns.
+        Parameters
+        ----------
+        preserve_xy : boolean, default False
+            Save point geometries as new x, y columns
+
+        Returns
+        -------
+        DataFrame
+        """
+        result = self.drop(columns=self._geometry_column_name)
+        if preserve_xy and (self.geom_type == "Point").all():
+            result['x'] = self.geometry.x
+            result['y'] = self.geometry.y
+
+        return DataFrame(result)
+
     def __getitem__(self, key):
         """
         If the result is a column containing only 'geometry', return a

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -344,6 +344,14 @@ class TestDataFrame:
                 assert np.isnan(props['Shape_Leng'])
                 assert 'Shape_Area' in props
 
+    def test_to_pandas(self):
+        df = self.df.to_pandas()
+        assert type(df) is pd.DataFrame
+        df2 = self.df2.to_pandas(preserve_xy=True)
+        assert type(df2) is pd.DataFrame
+        assert len(df2['x']) > 0
+        assert len(df2['x']) == len(df2['y'])
+
     def test_copy(self):
         df2 = self.df.copy()
         assert type(df2) is GeoDataFrame


### PR DESCRIPTION
Addresses #544 and complements #896 to give us a lower friction pathway from df to gdf and back again.

Should `preserve_points` also attempt to preserve the z coords? If so, what's the best way to get that from the points?

