### PR TITLE
COMPAT: use .item() instead of deprecated np.asscalar()

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -132,7 +132,7 @@ def infer_schema(df):
     def convert_type(column, in_type):
         if in_type == object:
             return 'str'
-        out_type = type(np.asscalar(np.zeros(1, in_type))).__name__
+        out_type = type(np.zeros(1, in_type).item()).__name__
         if out_type == 'long':
             out_type = 'int'
         if not _FIONA18 and out_type == 'bool':


### PR DESCRIPTION
This was deprecated in numpy 1.16 and prints a warning on every invocation.
The function was just a thin wrapper around .item() since a long time(Maybe forever, not sure about that), so this should have no impact on people using older versions.