### PR TITLE
Ensure GeoSeries.isna is always a Series and not GeoSeries

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -192,7 +192,7 @@ class GeoSeries(GeoPandasBase, Series):
         """
         non_geo_null = super(GeoSeries, self).isnull()
         val = self.apply(_is_empty)
-        return np.logical_or(non_geo_null, val)
+        return Series(np.logical_or(non_geo_null, val))
 
     def isnull(self):
         """Alias for `isna` method. See `isna` for more detail."""

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -179,9 +179,10 @@ def test_dropna():
 
 @pytest.mark.parametrize("NA", [None, np.nan, Point(), Polygon()])
 def test_isna(NA):
-    s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)])
-    exp = pd.Series([False, True, False])
+    s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)], index=[2, 4, 5], name='tt')
+    exp = pd.Series([False, True, False], index=[2, 4, 5], name='tt')
     res = s2.isnull()
+    assert type(res) == pd.Series
     assert_series_equal(res, exp)
     res = s2.isna()
     assert_series_equal(res, exp)


### PR DESCRIPTION
A recent change on pandas master (https://github.com/pandas-dev/pandas/pull/25272) made it so that `isna` now preserves the subclass (resulting in a boolean GeoSeries, which caused the current failures on travis for pandas master).

It might still be changed on the pandas side before a release, but ensuring it on the GeoPandas side with this fix (so our builds are green, and also it shouldn't cause any harm even if the pandas behaviour would be changed back).