### PR TITLE
DOC: fix random state in geoplot voronoi example to prevent random errors

### DIFF
--- a/examples/plotting_with_geoplot.py
+++ b/examples/plotting_with_geoplot.py
@@ -74,7 +74,7 @@ geoplot.polyplot(boroughs, ax=ax)
 # using Voronoi tessellation.
 
 ax = geoplot.voronoi(
-    injurious_collisions.sample(1000),
+    injurious_collisions.sample(1000, random_state=42),
     hue='NUMBER OF PERSONS INJURED', cmap='Reds', scheme='fisher_jenks',
     clip=boroughs.geometry,
     linewidth=0)


### PR DESCRIPTION
See https://github.com/ResidentMario/geoplot/issues/69: depending on how the data are subsampled, we stumble into a potential bug in geoplot. So fixing the random state with a working one to prevent this.