### PR TITLE
adding type check to handle numpy datetime64 types

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -132,6 +132,8 @@ def infer_schema(df):
     def convert_type(column, in_type):
         if in_type == object:
             return 'str'
+        if hasattr(in_type, 'type') and in_type.type == np.datetime64:
+            return 'datetime'
         out_type = type(np.zeros(1, in_type).item()).__name__
         if out_type == 'long':
             out_type = 'int'


### PR DESCRIPTION
This is in response to issue #746 . Note that it will only work for drivers that support datetime fields; eg GPKG and not ESRI Shapefile. 