### PR TITLE
CI: update travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ matrix:
 
     # Python 2.7 and 3.6 test all supported Pandas versions
     - env: ENV_FILE="ci/travis/27-pd020.yaml"
+    - env: ENV_FILE="ci/travis/27-pd023.yaml"
     - env: ENV_FILE="ci/travis/27-latest-defaults.yaml"
     - env: ENV_FILE="ci/travis/27-latest-conda-forge.yaml"
-    - env: ENV_FILE="ci/travis/27-dev.yaml"
 
     - env: ENV_FILE="ci/travis/36-pd020.yaml"
     - env: ENV_FILE="ci/travis/36-pd022.yaml"
 
     - env: ENV_FILE="ci/travis/37-latest-defaults.yaml"
     - env: ENV_FILE="ci/travis/37-latest-conda-forge.yaml"
-    - env: ENV_FILE="ci/travis/37-dev.yaml"
+    - env: ENV_FILE="ci/travis/37-dev.yaml" DEV=true
 
 install:
   # Install conda
@@ -31,6 +31,8 @@ install:
   # Install dependencies
   - conda env create --file="${ENV_FILE}"
   - source activate test
+  - if [ "$DEV" ]; then pip install git+https://github.com/pydata/pandas.git; fi
+  - if [ "$DEV" ]; then pip install git+https://github.com/matplotlib/matplotlib.git; fi
   - pip install -e .
   - conda list
 

--- a/ci/travis/27-pd023.yaml
+++ b/ci/travis/27-pd023.yaml
@@ -6,7 +6,7 @@ dependencies:
   - six
   - cython
   # required
-  - pandas
+  - pandas=0.23
   - shapely
   - fiona
   - pyproj
@@ -24,7 +24,6 @@ dependencies:
   - psycopg2
   - libspatialite
   - pip:
-    - git+https://github.com/pydata/pandas.git
     - codecov
     - geopy
     - mapclassify==1.0.1

--- a/ci/travis/37-dev.yaml
+++ b/ci/travis/37-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - pandas
   - shapely
-  - conda-forge/label/dev::fiona
+  - fiona
   - pyproj
   # testing
   - pytest
@@ -23,8 +23,6 @@ dependencies:
   - psycopg2
   - libspatialite
   - pip:
-    - git+https://github.com/matplotlib/matplotlib.git
-    - git+https://github.com/pydata/pandas.git
     - codecov
     - geopy
     - mapclassify


### PR DESCRIPTION
- remove py27 dev build (pandas master no longer supports python 2.7) and replace with pandas 0.23 build
- py37 dev build: move installing pandas and matplotlib master to separate steps in travis yml file (otherwise the conda create step takes too long)
- remove conda-forge/label/dev label for fiona (was still installing the rc instead of actual released version)