### PR TITLE
Fix broken links to Shapely and Fiona docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GeoPandas is a project to add support for geographic data to
 [pandas](http://pandas.pydata.org) objects.  It currently implements
 `GeoSeries` and `GeoDataFrame` types which are subclasses of
 `pandas.Series` and `pandas.DataFrame` respectively.  GeoPandas
-objects can act on [shapely](http://toblerity.github.io/shapely)
+objects can act on [shapely](http://shapely.readthedocs.io/en/latest/)
 geometry objects and perform geometric operations.
 
 GeoPandas geometry operations are cartesian.  The coordinate reference
@@ -81,7 +81,7 @@ GeoPandas objects also know how to plot themselves.  GeoPandas uses [descartes](
 
     >>> g.plot()
 
-GeoPandas also implements alternate constructors that can read any data format recognized by [fiona](http://toblerity.github.io/fiona). To read a zip file containing an ESRI shapefile with the [boroughs boundaries of New York City](https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm) (GeoPandas includes this as an example dataset):
+GeoPandas also implements alternate constructors that can read any data format recognized by [fiona](http://fiona.readthedocs.io/en/latest/). To read a zip file containing an ESRI shapefile with the [boroughs boundaries of New York City](https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm) (GeoPandas includes this as an example dataset):
 
     >>> nybb_path = geopandas.datasets.get_path('nybb')
     >>> boros = geopandas.read_file(nybb_path)

--- a/doc/source/geometric_manipulations.rst
+++ b/doc/source/geometric_manipulations.rst
@@ -3,7 +3,7 @@
 Geometric Manipulations
 ========================
 
-*geopandas* makes available all the tools for geometric manipulations in the `*shapely* library <http://toblerity.org/shapely/manual.html>`_.
+*geopandas* makes available all the tools for geometric manipulations in the `*shapely* library <http://shapely.readthedocs.io/en/latest/manual.html>`_.
 
 Note that documentation for all set-theoretic tools for creating new shapes using the relationship between two different spatial datasets -- like creating intersections, or differences -- can be found on the :doc:`set operations <set_operations>` page.
 
@@ -216,7 +216,7 @@ borough that are in the holes:
 
 .. _Descartes: https://pypi.python.org/pypi/descartes
 .. _matplotlib: http://matplotlib.org
-.. _fiona: http://toblerity.github.io/fiona
+.. _fiona: http://fiona.readthedocs.io/en/latest/
 .. _geopy: https://github.com/geopy/geopy
 .. _geo_interface: https://gist.github.com/sgillies/2217756
 .. _borough boundaries of New York City: https://data.cityofnewyork.us/City-Government/Borough-Boundaries/tqmj-j8zm

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -12,7 +12,7 @@ Reading Spatial Data
 
     geopandas.read_file()
 
-which returns a GeoDataFrame object. (This is possible because *geopandas* makes use of the great `fiona <http://toblerity.org/fiona/manual.html>`_ library, which in turn makes use of a massive open-source program called `GDAL/OGR <http://www.gdal.org/>`_ designed to facilitate spatial data transformations).
+which returns a GeoDataFrame object. (This is possible because *geopandas* makes use of the great `fiona <http://fiona.readthedocs.io/en/latest/manual.html>`_ library, which in turn makes use of a massive open-source program called `GDAL/OGR <http://www.gdal.org/>`_ designed to facilitate spatial data transformations).
 
 Any arguments passed to ``read_file()`` after the file name will be passed directly to ``fiona.open``, which does the actual data importation. In general, ``read_file`` is pretty smart and should do what you want without extra arguments, but for more help, type::
 

--- a/doc/source/mergingdata.rst
+++ b/doc/source/mergingdata.rst
@@ -85,7 +85,7 @@ The ```op`` argument specifies how ``geopandas`` decides whether or not to join 
 * `within`: The attributes will be joined if the object’s boundary and interior intersect *only* with the interior of the other object (not its boundary or exterior).
 * `contains`: The attributes will be joined if the object’s interior contains the boundary and interior of the other object and their boundaries do not touch at all.
 
-You can read more about each join type in the `Shapely documentation <http://toblerity.org/shapely/manual.html#binary-predicates>`__.
+You can read more about each join type in the `Shapely documentation <http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates>`__.
 
 **how**
 

--- a/examples/spatial_joins.ipynb
+++ b/examples/spatial_joins.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Spatial Joins\n",
     "\n",
-    "A *spatial join* uses [binary predicates](http://toblerity.org/shapely/manual.html#binary-predicates) \n",
+    "A *spatial join* uses [binary predicates](http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates) \n",
     "such as `intersects` and `crosses` to combine two `GeoDataFrames` based on the spatial relationship \n",
     "between their geometries.\n",
     "\n",

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -159,7 +159,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """Alternate constructor to create a ``GeoDataFrame`` from a file.
 
         Can load a ``GeoDataFrame`` from a file in any format recognized by
-        `fiona`. See http://toblerity.org/fiona/manual.html for details.
+        `fiona`. See http://fiona.readthedocs.io/en/latest/manual.html for details.
 
         Parameters
         ----------
@@ -167,7 +167,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         filename : str
             File path or file handle to read from. Depending on which kwargs
             are included, the content of filename may vary. See
-            http://toblerity.org/fiona/README.html#usage for usage details.
+            http://fiona.readthedocs.io/en/latest/README.html#usage for usage details.
         kwargs : key-word arguments
             These arguments are passed to fiona.open, and can be used to
             access multi-layer data, data stored within archives (zip files),

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -74,7 +74,7 @@ class GeoSeries(GeoPandasBase, Series):
         """Alternate constructor to create a ``GeoSeries`` from a file.
 
         Can load a ``GeoSeries`` from a file from any format recognized by
-        `fiona`. See http://toblerity.org/fiona/manual.html for details.
+        `fiona`. See http://fiona.readthedocs.io/en/latest/manual.html for details.
 
         Parameters
         ----------
@@ -82,7 +82,7 @@ class GeoSeries(GeoPandasBase, Series):
         filename : str
             File path or file handle to read from. Depending on which kwargs
             are included, the content of filename may vary. See
-            http://toblerity.org/fiona/README.html#usage for usage details.
+            http://fiona.readthedocs.io/en/latest/README.html#usage for usage details.
         kwargs : key-word arguments
             These arguments are passed to fiona.open, and can be used to
             access multi-layer data, data stored within archives (zip files),

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -23,7 +23,7 @@ def sjoin(left_df, right_df, how='inner', op='intersects',
           left_df geometry column
     op : string, default 'intersection'
         Binary predicate, one of {'intersects', 'contains', 'within'}.
-        See http://toblerity.org/shapely/manual.html#binary-predicates.
+        See http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates.
     lsuffix : string, default 'left'
         Suffix to apply to overlapping column names (left GeoDataFrame).
     rsuffix : string, default 'right'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ operations in python that would otherwise require a spatial database
 such as PostGIS.
 
 .. _pandas: http://pandas.pydata.org
-.. _shapely: http://toblerity.github.io/shapely
+.. _shapely: http://shapely.readthedocs.io/en/latest/
 """
 
 if os.environ.get('READTHEDOCS', False) == 'True':


### PR DESCRIPTION
Update links to point at `shapely.readthedocs.io` and `fiona.readthedocs.io` to avoid the 404 page found on `toblerity.org` in the current documentation.