### PR TITLE
PERF: Optimize pyproj >= 2.1 transformations 

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 from pandas import Series
 import pyproj
+from pyproj import Transformer
 from shapely.geometry import shape, Point
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform
@@ -299,7 +300,8 @@ class GeoSeries(GeoPandasBase, Series):
                 raise TypeError('Must set either crs or epsg for output.')
         proj_in = pyproj.Proj(self.crs, preserve_units=True)
         proj_out = pyproj.Proj(crs, preserve_units=True)
-        project = partial(pyproj.transform, proj_in, proj_out)
+        transformer = Transformer.from_proj(proj_in, proj_out)
+        project = transformer.transform
         result = self.apply(lambda geom: transform(project, geom))
         result.__class__ = GeoSeries
         result.crs = crs

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -5,18 +5,15 @@ import json
 import numpy as np
 from pandas import Series
 import pyproj
-
-_PYPROJ2 = LooseVersion(pyproj.__version__) >= LooseVersion('2.1.0')
-
-if _PYPROJ2:
-    from pyproj import Transformer
-
 from shapely.geometry import shape, Point
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform
 
 from geopandas.plotting import plot_series
 from geopandas.base import GeoPandasBase, _unary_op, _CoordinateIndexer
+
+
+_PYPROJ2 = LooseVersion(pyproj.__version__) >= LooseVersion('2.1.0')
 
 
 def _is_empty(x):
@@ -307,7 +304,7 @@ class GeoSeries(GeoPandasBase, Series):
         proj_in = pyproj.Proj(self.crs, preserve_units=True)
         proj_out = pyproj.Proj(crs, preserve_units=True)
         if _PYPROJ2:
-            transformer = Transformer.from_proj(proj_in, proj_out)
+            transformer = pyproj.Transformer.from_proj(proj_in, proj_out)
             project = transformer.transform
         else:
             project = partial(pyproj.transform, proj_in, proj_out)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -6,7 +6,7 @@ import numpy as np
 from pandas import Series
 import pyproj
 
-_PYPROJ2 = LooseVersion(pyproj.__version__) >= LooseVersion('2.0.0')
+_PYPROJ2 = LooseVersion(pyproj.__version__) >= LooseVersion('2.1.0')
 
 if _PYPROJ2:
     from pyproj import Transformer

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ such as PostGIS.
 if os.environ.get('READTHEDOCS', False) == 'True':
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'pyproj']
+    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'pyproj>2']
 
 # get all data dirs in the datasets module
 data_files = []

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ such as PostGIS.
 if os.environ.get('READTHEDOCS', False) == 'True':
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'pyproj>2']
+    INSTALL_REQUIRES = ['pandas', 'shapely', 'fiona', 'pyproj']
 
 # get all data dirs in the datasets module
 data_files = []


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/pull/962#issue-267016435

Since version 2.0.0 pyproj have a new way to optimize transformation.
I don't know a lot about geopandas to maybe i did it wrong but the last version of pyproj make the transformation a lot slower (about 100 000 times slower).
see https://pyproj4.github.io/pyproj/html/optimize_transformations.html for more information.

so this PR intend to fix the performance loss