### PR TITLE
DOC: buffer resolution is an int, not a float.

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -556,7 +556,7 @@ class GeoPandasBase(object):
         distance : float, np.array, pd.Series
             The radius of the buffer. If np.array or pd.Series are used
             then it must have same length as the GeoSeries.
-        resolution: float
+        resolution: int
             Optional, the resolution of the buffer around each vertex.
         """
         if isinstance(distance, (np.ndarray, pd.Series)):


### PR DESCRIPTION
The buffer resolution has to be an int. Passing a float will result in:

```ArgumentError: argument 4: <class 'TypeError'>: wrong type```