### PR TITLE
TST/CI: update CRS tests + ensure compatibility with proj.4 6 / pyproj 2

### DIFF
--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -3,6 +3,8 @@ import numpy as np
 from geopandas import GeoDataFrame, points_from_xy
 from geopandas.testing import assert_geodataframe_equal
 
+import pytest
+
 
 def _create_df(x, y=None, crs=None):
     y = y or x
@@ -23,27 +25,69 @@ def df_epsg26918():
                       crs={'init': 'epsg:26918', 'no_defs': True})
 
 
-class TestToCRS:
+def test_to_crs_transform():
+    df = df_epsg26918()
+    lonlat = df.to_crs(epsg=4326)
+    utm = lonlat.to_crs(epsg=26918)
+    assert_geodataframe_equal(df, utm, check_less_precise=True)
 
-    def test_transform(self):
-        df = df_epsg26918()
-        lonlat = df.to_crs(epsg=4326)
-        utm = lonlat.to_crs(epsg=26918)
-        assert_geodataframe_equal(df, utm, check_less_precise=True)
 
-    def test_transform_inplace(self):
-        df = df_epsg26918()
-        lonlat = df.to_crs(epsg=4326)
-        df.to_crs(epsg=4326, inplace=True)
-        assert_geodataframe_equal(df, lonlat, check_less_precise=True)
+def test_to_crs_inplace():
+    df = df_epsg26918()
+    lonlat = df.to_crs(epsg=4326)
+    df.to_crs(epsg=4326, inplace=True)
+    assert_geodataframe_equal(df, lonlat, check_less_precise=True)
 
-    def test_to_crs_geo_column_name(self):
-        # Test to_crs() with different geometry column name (GH#339)
-        df = df_epsg26918()
-        df = df.rename(columns={'geometry': 'geom'})
-        df.set_geometry('geom', inplace=True)
-        lonlat = df.to_crs(epsg=4326)
-        utm = lonlat.to_crs(epsg=26918)
-        assert lonlat.geometry.name == 'geom'
-        assert utm.geometry.name == 'geom'
-        assert_geodataframe_equal(df, utm, check_less_precise=True)
+
+def test_to_crs_geo_column_name():
+    # Test to_crs() with different geometry column name (GH#339)
+    df = df_epsg26918()
+    df = df.rename(columns={'geometry': 'geom'})
+    df.set_geometry('geom', inplace=True)
+    lonlat = df.to_crs(epsg=4326)
+    utm = lonlat.to_crs(epsg=26918)
+    assert lonlat.geometry.name == 'geom'
+    assert utm.geometry.name == 'geom'
+    assert_geodataframe_equal(df, utm, check_less_precise=True)
+
+
+# -----------------------------------------------------------------------------
+# Test different supported formats for CRS specification
+
+
+@pytest.fixture(
+    params=[
+        4326,
+        {'init': 'epsg:4326'},
+        '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs',
+        {'proj': 'latlong', 'ellps': 'WGS84', 'datum': 'WGS84',
+         'no_defs': True}],
+    ids=['epsg_number', 'epsg_dict', 'proj4_string', 'proj4_dict'])
+def epsg4326(request):
+    if isinstance(request.param, int):
+        return dict(epsg=request.param)
+    return dict(crs=request.param)
+
+
+@pytest.fixture(
+    params=[
+        26918,
+        {'init': 'epsg:26918', 'no_defs': True},
+        '+proj=utm +zone=18 +ellps=GRS80 +datum=NAD83 +units=m +no_defs ',
+        {'proj': 'utm', 'zone': 18, 'datum': 'NAD83', 'units': 'm',
+         'no_defs': True}],
+    ids=['epsg_number', 'epsg_dict', 'proj4_string', 'proj4_dict'])
+def epsg26918(request):
+    if isinstance(request.param, int):
+        return dict(epsg=request.param)
+    return dict(crs=request.param)
+
+
+def test_transform2(epsg4326, epsg26918):
+    df = df_epsg26918()
+    lonlat = df.to_crs(**epsg4326)
+    utm = lonlat.to_crs(**epsg26918)
+    # can't check for CRS equality, as the formats differ although representing
+    # the same CRS
+    assert_geodataframe_equal(df, utm, check_less_precise=True,
+                              check_crs=False)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -1,41 +1,41 @@
-from shapely.geometry import Point
+import numpy as np
 
-from geopandas import GeoDataFrame
+from geopandas import GeoDataFrame, points_from_xy
+
+
+def _create_df(x, y=None, crs=None):
+    y = y or x
+    x = np.asarray(x)
+    y = np.asarray(y)
+
+    return GeoDataFrame(
+        {'geometry': points_from_xy(x, y), 'value1': x + y, 'value2': x * y},
+        crs=crs)
 
 
 class TestToCRS:
 
-    def setup_method(self):
-        N = 10
-        self.crs = {'init': 'epsg:4326'}
-        self.df2 = GeoDataFrame([
-            {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
-            for x, y in zip(range(N), range(N))], crs=self.crs)
-
     def test_transform(self):
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        lonlat = df2.to_crs(epsg=4326)
+        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        lonlat = df.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
-        assert all(df2['geometry'].geom_almost_equals(utm['geometry'],
-                                                      decimal=2))
+        assert all(df['geometry'].geom_almost_equals(utm['geometry'],
+                                                     decimal=))
 
     def test_transform_inplace(self):
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        lonlat = df2.to_crs(epsg=4326)
-        df2.to_crs(epsg=4326, inplace=True)
-        assert all(df2['geometry'].geom_almost_equals(lonlat['geometry'],
-                                                      decimal=2))
+        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        lonlat = df.to_crs(epsg=4326)
+        df.to_crs(epsg=4326, inplace=True)
+        assert all(df['geometry'].geom_almost_equals(lonlat['geometry'],
+                                                     decimal=2))
 
     def test_to_crs_geo_column_name(self):
         # Test to_crs() with different geometry column name (GH#339)
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        df2 = df2.rename(columns={'geometry': 'geom'})
-        df2.set_geometry('geom', inplace=True)
-        lonlat = df2.to_crs(epsg=4326)
+        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        df = df.rename(columns={'geometry': 'geom'})
+        df.set_geometry('geom', inplace=True)
+        lonlat = df.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
         assert lonlat.geometry.name == 'geom'
         assert utm.geometry.name == 'geom'
-        assert all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2))
+        assert all(df.geometry.geom_almost_equals(utm.geometry, decimal=2))

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from geopandas import GeoDataFrame, points_from_xy
+from geopandas.testing import assert_geodataframe_equal
 
 
 def _create_df(x, y=None, crs=None):
@@ -19,15 +20,13 @@ class TestToCRS:
         df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
         lonlat = df.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
-        assert all(df['geometry'].geom_almost_equals(utm['geometry'],
-                                                     decimal=))
+        assert_geodataframe_equal(df, utm, check_less_precise=True)
 
     def test_transform_inplace(self):
         df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
         lonlat = df.to_crs(epsg=4326)
         df.to_crs(epsg=4326, inplace=True)
-        assert all(df['geometry'].geom_almost_equals(lonlat['geometry'],
-                                                     decimal=2))
+        assert_geodataframe_equal(df, lonlat, check_less_precise=True)
 
     def test_to_crs_geo_column_name(self):
         # Test to_crs() with different geometry column name (GH#339)
@@ -38,4 +37,4 @@ class TestToCRS:
         utm = lonlat.to_crs(epsg=26918)
         assert lonlat.geometry.name == 'geom'
         assert utm.geometry.name == 'geom'
-        assert all(df.geometry.geom_almost_equals(utm.geometry, decimal=2))
+        assert_geodataframe_equal(df, utm, check_less_precise=True)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -1,0 +1,41 @@
+from shapely.geometry import Point
+
+from geopandas import GeoDataFrame
+
+
+class TestToCRS:
+
+    def setup_method(self):
+        N = 10
+        self.crs = {'init': 'epsg:4326'}
+        self.df2 = GeoDataFrame([
+            {'geometry': Point(x, y), 'value1': x + y, 'value2': x * y}
+            for x, y in zip(range(N), range(N))], crs=self.crs)
+
+    def test_transform(self):
+        df2 = self.df2.copy()
+        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
+        lonlat = df2.to_crs(epsg=4326)
+        utm = lonlat.to_crs(epsg=26918)
+        assert all(df2['geometry'].geom_almost_equals(utm['geometry'],
+                                                      decimal=2))
+
+    def test_transform_inplace(self):
+        df2 = self.df2.copy()
+        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
+        lonlat = df2.to_crs(epsg=4326)
+        df2.to_crs(epsg=4326, inplace=True)
+        assert all(df2['geometry'].geom_almost_equals(lonlat['geometry'],
+                                                      decimal=2))
+
+    def test_to_crs_geo_column_name(self):
+        # Test to_crs() with different geometry column name (GH#339)
+        df2 = self.df2.copy()
+        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
+        df2 = df2.rename(columns={'geometry': 'geom'})
+        df2.set_geometry('geom', inplace=True)
+        lonlat = df2.to_crs(epsg=4326)
+        utm = lonlat.to_crs(epsg=26918)
+        assert lonlat.geometry.name == 'geom'
+        assert utm.geometry.name == 'geom'
+        assert all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2))

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -14,23 +14,32 @@ def _create_df(x, y=None, crs=None):
         crs=crs)
 
 
+def df_epsg26918():
+    # EPSG:26918
+    # Center coordinates
+    # -1683723.64 6689139.23
+    return _create_df(x=range(-1683723, -1683723 + 10, 1),
+                      y=range(6689139, 6689139 + 10, 1),
+                      crs={'init': 'epsg:26918', 'no_defs': True})
+
+
 class TestToCRS:
 
     def test_transform(self):
-        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        df = df_epsg26918()
         lonlat = df.to_crs(epsg=4326)
         utm = lonlat.to_crs(epsg=26918)
         assert_geodataframe_equal(df, utm, check_less_precise=True)
 
     def test_transform_inplace(self):
-        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        df = df_epsg26918()
         lonlat = df.to_crs(epsg=4326)
         df.to_crs(epsg=4326, inplace=True)
         assert_geodataframe_equal(df, lonlat, check_less_precise=True)
 
     def test_to_crs_geo_column_name(self):
         # Test to_crs() with different geometry column name (GH#339)
-        df = _create_df(range(10), crs={'init': 'epsg:26918', 'no_defs': True})
+        df = df_epsg26918()
         df = df.rename(columns={'geometry': 'geom'})
         df.set_geometry('geom', inplace=True)
         lonlat = df.to_crs(epsg=4326)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -365,34 +365,6 @@ class TestDataFrame:
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[:, 5:])
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, 5:])
 
-    def test_transform(self):
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        lonlat = df2.to_crs(epsg=4326)
-        utm = lonlat.to_crs(epsg=26918)
-        assert all(df2['geometry'].geom_almost_equals(utm['geometry'],
-                                                      decimal=2))
-
-    def test_transform_inplace(self):
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        lonlat = df2.to_crs(epsg=4326)
-        df2.to_crs(epsg=4326, inplace=True)
-        assert all(df2['geometry'].geom_almost_equals(lonlat['geometry'],
-                                                      decimal=2))
-
-    def test_to_crs_geo_column_name(self):
-        # Test to_crs() with different geometry column name (GH#339)
-        df2 = self.df2.copy()
-        df2.crs = {'init': 'epsg:26918', 'no_defs': True}
-        df2 = df2.rename(columns={'geometry': 'geom'})
-        df2.set_geometry('geom', inplace=True)
-        lonlat = df2.to_crs(epsg=4326)
-        utm = lonlat.to_crs(epsg=26918)
-        assert lonlat.geometry.name == 'geom'
-        assert utm.geometry.name == 'geom'
-        assert all(df2.geometry.geom_almost_equals(utm.geometry, decimal=2))
-
     def test_from_features(self):
         nybb_filename = geopandas.datasets.get_path('nybb')
         with fiona.open(nybb_filename) as f:

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from distutils.version import LooseVersion
+
+import pyproj
 from shapely.geometry import Point, MultiPoint, LineString
 
 from geopandas import GeoSeries
@@ -58,6 +61,10 @@ class TestTools:
         assert epsg_from_crs({'init': 'EPSG:4326'}) == 4326
         assert epsg_from_crs('+init=epsg:4326') == 4326
 
+    @pytest.mark.skipif(
+        LooseVersion(pyproj.__version__) >= LooseVersion('2.0.0'),
+        reason="explicit_crs_from_epsg depends on parsing data files of "
+               "proj.4 < 6 / pyproj < 2 ")
     def test_explicit_crs_from_epsg(self):
         expected = {'no_defs': True, 'proj': 'longlat', 'datum': 'WGS84', 'init': 'epsg:4326'}
         assert explicit_crs_from_epsg(epsg=4326) == expected


### PR DESCRIPTION
Our tests are broken with proj.4 6 / pyproj 2 (see https://github.com/pyproj4/pyproj/issues/269 for context). 
So updating the tests here to just make sure they are correctly working and passing with the latest pyproj (without any change to optimally use the changes in pyproj 2, that's already done in another PR). 

And while at it, I isolated the `to_crs` related tests in a separate file, with the intent to add some more extensive testing of the current functionality.