### PR TITLE
TST/CI: pin a few builds to older fiona version

### DIFF
--- a/ci/travis/27-pd023.yaml
+++ b/ci/travis/27-pd023.yaml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - pandas=0.23
   - shapely
-  - fiona
+  - fiona=1.7
   - pyproj
   # testing
   - pytest

--- a/ci/travis/35-minimal.yaml
+++ b/ci/travis/35-minimal.yaml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - pandas==0.19.2
   - shapely=1.5
-  - fiona=1.6
+  - fiona=1.7
   - pyproj
   # testing
   - pytest

--- a/ci/travis/35-minimal.yaml
+++ b/ci/travis/35-minimal.yaml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - pandas==0.19.2
   - shapely=1.5
-  - fiona
+  - fiona=1.6
   - pyproj
   # testing
   - pytest

--- a/ci/travis/36-pd022.yaml
+++ b/ci/travis/36-pd022.yaml
@@ -7,7 +7,7 @@ dependencies:
   # required
   - pandas=0.22
   - shapely
-  - fiona
+  - fiona=1.7
   - pyproj
   # testing
   - pytest


### PR DESCRIPTION
Some of the builds on defaults are still using fiona 1.7, but pinning this explicitly in the env files to make sure we keep testing it for now, also if the packages would get updated.