### PR TITLE
Switch geocoding default to geocodefarm

### DIFF
--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -23,7 +23,7 @@ with the detailed borough boundary file included within ``geopandas``.
     boros = geopandas.read_file(geopandas.datasets.get_path("nybb"))
     boros.BoroName
     boro_locations = geopandas.tools.geocode(boros.BoroName,
-                                             provider="nominatim")
+                                             provider="geocodefarm")
     boro_locations
 
     import matplotlib.pyplot as plt

--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -11,8 +11,7 @@ Geocoding
 
 ``geopandas`` supports geocoding (i.e., converting place names to
 location on Earth) through `geopy`_, an optional dependency of ``geopandas``.
-The following example shows how to use the `Google geocoding API
-<https://developers.google.com/maps/documentation/geocoding/start>`_ to get the
+The following example shows how to get the
 locations of boroughs in New York City, and plots those locations along
 with the detailed borough boundary file included within ``geopandas``.
 
@@ -22,8 +21,7 @@ with the detailed borough boundary file included within ``geopandas``.
 
     boros = geopandas.read_file(geopandas.datasets.get_path("nybb"))
     boros.BoroName
-    boro_locations = geopandas.tools.geocode(boros.BoroName,
-                                             provider="geocodefarm")
+    boro_locations = geopandas.tools.geocode(boros.BoroName)
     boro_locations
 
     import matplotlib.pyplot as plt
@@ -34,6 +32,11 @@ with the detailed borough boundary file included within ``geopandas``.
     boro_locations.plot(ax=ax, color="red");
 
 
+By default, the ``geocode`` function uses the
+`GeoCode.Farm geocoding API <https://geocode.farm/>`__ with a rate limitation
+applied. But a different geocoding service can be specified with the
+``provider`` keyword.
+
 The argument to ``provider`` can either be a string referencing geocoding
 services, such as ``'google'``, ``'bing'``, ``'yahoo'``, and
 ``'openmapquest'``, or an instance of a ``Geocoder`` from ``geopy``. See
@@ -41,7 +44,16 @@ services, such as ``'google'``, ``'bing'``, ``'yahoo'``, and
 For many providers, parameters such as API keys need to be passed as
 ``**kwargs`` in the ``geocode`` call.
 
-Please consult the Terms of Service for the chosen provider. The example above
-uses ``'geocodefarm'``, for which free users are limited to 250 calls per day
-and 4 requests per second
-(`geocodefarm ToS <https://geocode.farm/geocoding/free-api-documentation/>`_).
+For example, to use the OpenStreetMap Nominatim geocoder, you need to specify
+a user agent:
+
+.. code-block:: python
+
+    geopandas.tools.geocode(boros.BoroName, provider='nominatim', user_agent="my-application")
+
+.. attention::
+
+    Please consult the Terms of Service for the chosen provider. The example
+    above uses ``'geocodefarm'`` (the default), for which free users are
+    limited to 250 calls per day and 4 requests per second
+    (`geocodefarm ToS <https://geocode.farm/geocoding/free-api-documentation/>`_).

--- a/doc/source/geocoding.rst
+++ b/doc/source/geocoding.rst
@@ -41,4 +41,7 @@ services, such as ``'google'``, ``'bing'``, ``'yahoo'``, and
 For many providers, parameters such as API keys need to be passed as
 ``**kwargs`` in the ``geocode`` call.
 
-Please consult the Terms of Service for the chosen provider.
+Please consult the Terms of Service for the chosen provider. The example above
+uses ``'geocodefarm'``, for which free users are limited to 250 calls per day
+and 4 requests per second
+(`geocodefarm ToS <https://geocode.farm/geocoding/free-api-documentation/>`_).

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -120,9 +120,9 @@ def test_bad_provider_reverse():
 
 
 def test_forward(locations, points):
-    from geopy.geocoders import Nominatim
-    for provider in ['nominatim', Nominatim]:
-        with mock.patch('geopy.geocoders.osm.Nominatim.geocode',
+    from geopy.geocoders import GeocodeFarm
+    for provider in ['geocodefarm', GeocodeFarm]:
+        with mock.patch('geopy.geocoders.GeocodeFarm.geocode',
                         ForwardMock()) as m:
             g = geocode(locations, provider=provider, timeout=2)
             assert len(locations) == m.call_count
@@ -138,9 +138,9 @@ def test_forward(locations, points):
 
 
 def test_reverse(locations, points):
-    from geopy.geocoders import Nominatim
-    for provider in ['nominatim', Nominatim]:
-        with mock.patch('geopy.geocoders.osm.Nominatim.reverse',
+    from geopy.geocoders import GeocodeFarm
+    for provider in ['geocodefarm', GeocodeFarm]:
+        with mock.patch('geopy.geocoders.GeocodeFarm.reverse',
                         ReverseMock()) as m:
             g = reverse_geocode(points, provider=provider, timeout=2)
             assert len(points) == m.call_count

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -32,8 +32,9 @@ def geocode(strings, provider=None, **kwargs):
     strings : list or Series of addresses to geocode
     provider : str or geopy.geocoder
         Specifies geocoding service to use. If none is provided,
-        will use 'geocodefarm'. (see the geocodefarm terms of service at:
-        https://geocode.farm/geocoding/free-api-documentation/ )
+        will use 'geocodefarm' with a rate limit applied (see the geocodefarm
+        terms of service at:
+        https://geocode.farm/geocoding/free-api-documentation/ ).
 
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
@@ -86,8 +87,9 @@ def reverse_geocode(points, provider=None, **kwargs):
         y coordinate is latitude
     provider : str or geopy.geocoder (opt)
         Specifies geocoding service to use. If none is provided,
-        will use 'geocodefarm'. (see the geocodefarm terms of service at:
-        https://geocode.farm/geocoding/free-api-documentation/ )
+        will use 'geocodefarm' with a rate limit applied (see the geocodefarm
+        terms of service at:
+        https://geocode.farm/geocoding/free-api-documentation/ ).
 
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -13,18 +13,18 @@ import geopandas
 def _throttle_time(provider):
     """ Amount of time to wait between requests to a geocoding API.
 
-    Currently implemented for Nominatim, as their terms of service
+    Currently implemented for GeocodeFarm, as their terms of service
     require a maximum of 1 request per second.
-    https://wiki.openstreetmap.org/wiki/Nominatim_usage_policy
+    https://wiki.openstreetmap.org/wiki/GeocodeFarm_usage_policy
     """
     import geopy.geocoders
-    if provider == geopy.geocoders.Nominatim:
+    if provider == geopy.geocoders.GeocodeFarm:
         return 1
     else:
         return 0
 
 
-def geocode(strings, provider='nominatim', **kwargs):
+def geocode(strings, provider='geocodefarm', **kwargs):
     """
     Geocode a set of strings and get a GeoDataFrame of the resulting points.
 
@@ -32,10 +32,10 @@ def geocode(strings, provider='nominatim', **kwargs):
     ----------
     strings : list or Series of addresses to geocode
     provider : str or geopy.geocoder
-        Specifies geocoding service to use, default is 'nominatim'.
+        Specifies geocoding service to use, default is 'geocodefarm'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.Nominatim) may be used.
+        (e.g., geopy.geocoders.GeocodeFarm) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders
@@ -63,7 +63,7 @@ def geocode(strings, provider='nominatim', **kwargs):
     return _query(strings, True, provider, **kwargs)
 
 
-def reverse_geocode(points, provider='nominatim', **kwargs):
+def reverse_geocode(points, provider='geocodefarm', **kwargs):
     """
     Reverse geocode a set of points and get a GeoDataFrame of the resulting
     addresses.
@@ -76,10 +76,10 @@ def reverse_geocode(points, provider='nominatim', **kwargs):
         x coordinate is longitude
         y coordinate is latitude
     provider : str or geopy.geocoder (opt)
-        Specifies geocoding service to use, default is 'nominatim'.
+        Specifies geocoding service to use, default is 'geocodefarm'.
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
-        (e.g., geopy.geocoders.Nominatim) may be used.
+        (e.g., geopy.geocoders.GeocodeFarm) may be used.
 
         Some providers require additional arguments such as access keys
         See each geocoder's specific parameters in geopy.geocoders

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -11,15 +11,17 @@ import geopandas
 
 
 def _throttle_time(provider):
-    """ Amount of time to wait between requests to a geocoding API.
-
-    Currently implemented for GeocodeFarm, as their terms of service
-    require a maximum of 1 request per second.
-    https://wiki.openstreetmap.org/wiki/GeocodeFarm_usage_policy
+    """
+    Amount of time to wait between requests to a geocoding API, for providers
+    that specify rate limits in their terms of service.
     """
     import geopy.geocoders
-    if provider == geopy.geocoders.GeocodeFarm:
+    # https://wiki.openstreetmap.org/wiki/GeocodeFarm_usage_policy
+    if provider == geopy.geocoders.Nominatim:
         return 1
+    # https://geocode.farm/geocoding/free-api-documentation/
+    elif provider == geopy.geocoders.GeocodeFarm:
+        return 0.25
     else:
         return 0
 

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -16,12 +16,9 @@ def _throttle_time(provider):
     that specify rate limits in their terms of service.
     """
     import geopy.geocoders
-    # https://wiki.openstreetmap.org/wiki/GeocodeFarm_usage_policy
+    # https://operations.osmfoundation.org/policies/nominatim/
     if provider == geopy.geocoders.Nominatim:
         return 1
-    # https://geocode.farm/geocoding/free-api-documentation/
-    elif provider == geopy.geocoders.GeocodeFarm:
-        return 0.25
     else:
         return 0
 
@@ -35,6 +32,8 @@ def geocode(strings, provider='geocodefarm', **kwargs):
     strings : list or Series of addresses to geocode
     provider : str or geopy.geocoder
         Specifies geocoding service to use, default is 'geocodefarm'.
+        (see the geocodefarm terms of service at:
+            https://geocode.farm/geocoding/free-api-documentation/ )
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
         (e.g., geopy.geocoders.GeocodeFarm) may be used.
@@ -79,6 +78,8 @@ def reverse_geocode(points, provider='geocodefarm', **kwargs):
         y coordinate is latitude
     provider : str or geopy.geocoder (opt)
         Specifies geocoding service to use, default is 'geocodefarm'.
+        (see the geocodefarm terms of service at:
+            https://geocode.farm/geocoding/free-api-documentation/ )
         Either the string name used by geopy (as specified in
         geopy.geocoders.SERVICE_TO_GEOCODER) or a geopy Geocoder instance
         (e.g., geopy.geocoders.GeocodeFarm) may be used.


### PR DESCRIPTION
I started off this way in #907, then switched to nominatim, but our
current usage appears to be a violation of the nominatim terms of
service. Geocodefarm doesn't seem perfect, but given my reading of their
terms of service, I think using it in our examples in docs is okay.