### PR TITLE
DOC: set pandas display options to ensure non-truncated output

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,6 +36,12 @@ extensions = ['IPython.sphinxext.ipython_console_highlighting',
 
 # continue doc build and only print warnings/errors in examples
 ipython_warning_is_error = False
+ipython_exec_lines = [
+    # ensure that dataframes are not truncated in the IPython code blocks
+    'import pandas as _pd',
+    '_pd.set_option("display.max_columns", 20)',
+    '_pd.set_option("display.width", 100)'
+]
 
 # Fix issue with warnings from numpydoc (see discussion in PR #534)
 numpydoc_show_class_members = False


### PR DESCRIPTION
See eg the result of the spatial join in this example: https://geopandas.readthedocs.io/en/v0.4.0/mergingdata.html#spatial-joins

Due to some changes in the pandas display machinery (default option for the number of columns changed from 20 to "whathever fits on one line"), the output is not always shown. Therefore setting it here manually to the old setting, and also increasing the width a bit.