### PR TITLE
DOC/BLD: update geoplot version in readthedocs environment

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -22,6 +22,6 @@ dependencies:
 - cartopy=0.17.0
 - contextily=1.0rc1
 - rasterio=1.0.21
-- geoplot=0.2.3
+- geoplot=0.2.4
 - sphinx-gallery=0.2.0
 - jinja2=2.10


### PR DESCRIPTION
This should fix the version check error we are seeing on readthedocs (can't reproduce it locally, but it is fixed in the latest geoplot anyway, xref https://github.com/ResidentMario/geoplot/issues/72)