### PR TITLE
REF: move element-wise geo ops to array class

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1,0 +1,249 @@
+import numpy as np
+
+from shapely.geometry.base import BaseGeometry
+
+
+def _binary_geo(op, left, right):
+    # type: (str, GeometryArray, [GeometryArray/BaseGeometry]) -> GeometryArray
+    """ Apply geometry-valued operation
+
+    Supports:
+
+    -   difference
+    -   symmetric_difference
+    -   intersection
+    -   union
+
+    Parameters
+    ----------
+    right: GeometryArray or single shapely BaseGeoemtry
+    op: string
+    """
+    if isinstance(right, BaseGeometry):
+        # intersection can return empty GeometryCollections, and if the
+        # result are only those, numpy will coerce it to empty 2D array
+        data = np.empty(len(left), dtype=object)
+        data[:] = [getattr(s, op)(right) for s in left.data]
+        return GeometryArray(data)
+    elif isinstance(right, GeometryArray):
+        if len(left) != len(right):
+            msg = (
+                "Lengths of inputs to not match. "
+                "Left: {0}, Right: {1}".format(len(left), len(right)))
+            raise ValueError(msg)
+        data = np.empty(len(left), dtype=object)
+        data[:] = [getattr(this_elem, op)(other_elem)
+                   for this_elem, other_elem in zip(left.data, right.data)]
+        return GeometryArray(data)
+    else:
+        raise TypeError(
+            "Type not known: {0} vs {1}".format(type(left), type(right)))
+
+
+def _binary_op(op, left, right, *args, **kwargs):
+    # type: (str, GeometryArray, GeometryArray/BaseGeometry, args/kwargs)
+    #        -> array
+    """Binary operation on GeometryArray that returns a ndarray"""
+    if op in ['distance', 'project']:
+        null_value = np.nan
+    elif op == 'relate':
+        null_value = None
+    else:
+        null_value = False
+    if op in ['distance', 'project']:
+        dtype = float
+    elif op == 'relate':
+        dtype = object
+    else:
+        dtype = bool
+
+    if isinstance(right, BaseGeometry):
+        data = [
+            getattr(s, op)(right, *args, **kwargs) if s else null_value
+            for s in left.data]
+        return np.array(data, dtype=dtype)
+    elif isinstance(right, GeometryArray):
+        if len(left) != len(right):
+            msg = (
+                "Lengths of inputs to not match. "
+                "Left: {0}, Right: {1}".format(len(left), len(right)))
+            raise ValueError(msg)
+        data = [
+            getattr(this_elem, op)(other_elem, *args, **kwargs)
+            if not this_elem.is_empty | other_elem.is_empty else null_value
+            for this_elem, other_elem in zip(left.data, right.data)]
+        return np.array(data, dtype=dtype)
+    else:
+        raise TypeError(
+            "Type not known: {0} vs {1}".format(type(left), type(right)))
+
+
+def _unary_geo(op, left):
+    # type: (str, GeometryArray) -> GeometryArray
+    """Unary operation that returns new geometries"""
+    # ensure 1D output, see note above
+    data = np.empty(len(left), dtype=object)
+    data[:] = [getattr(geom, op) for geom in left.data]
+    return GeometryArray(data)
+
+
+def _unary_op(op, left, null_value=False):
+    # type: (str, GeometryArray, Any) -> Series
+    """Unary operation that returns a Series"""
+    data = [getattr(geom, op, null_value) for geom in left.data]
+    return np.array(data, dtype=np.dtype(type(null_value)))
+
+
+class GeometryArray:
+    """
+    Class wrapping a numpy array of Shapely objects and
+    holding the array-based implementations.
+    """
+
+    def __init__(self, data):
+        if isinstance(data, self.__class__):
+            data = data.data
+        elif not isinstance(data, np.ndarray):
+            raise ValueError(
+                "'data' should be array of geometry objects. Use from_shapely,"
+                " from_wkb, from_wkt functions to construct a GeometryArray.")
+        self.data = data
+
+    def __len__(self):
+        return len(self.data)
+
+    # -------------------------------------------------------------------------
+    # Geometry related methods
+    # -------------------------------------------------------------------------
+
+    def covers(self, other):
+        return _binary_op('covers', self, other)
+
+    def contains(self, other):
+        return _binary_op('contains', self, other)
+
+    def crosses(self, other):
+        return _binary_op('crosses', self, other)
+
+    def disjoint(self, other):
+        return _binary_op('disjoint', self, other)
+
+    def equals(self, other):
+        return _binary_op('equals', self, other)
+
+    def intersects(self, other):
+        return _binary_op('intersects', self, other)
+
+    def overlaps(self, other):
+        return _binary_op('overlaps', self, other)
+
+    def touches(self, other):
+        return _binary_op('touches', self, other)
+
+    def within(self, other):
+        return _binary_op('within', self, other)
+
+    def equals_exact(self, other, tolerance):
+        return _binary_op('equals_exact', self, other, tolerance=tolerance)
+
+    def almost_equals(self, other, decimal):
+        return _binary_op('almost_equals', self, other, decimal=decimal)
+
+    def is_valid(self):
+        return _unary_op('is_valid', self, null_value=False)
+
+    def is_empty(self):
+        return _unary_op('is_empty', self, null_value=False)
+
+    def is_simple(self):
+        return _unary_op('is_simple', self, null_value=False)
+
+    def is_ring(self):
+        return _unary_op('is_ring', self, null_value=False)
+
+    def has_z(self):
+        return _unary_op('has_z', self, null_value=False)
+
+    def is_closed(self):
+        return _unary_op('is_closed', self, null_value=False)
+
+    def boundary(self):
+        return _unary_geo('boundary', self)
+
+    def centroid(self):
+        return _unary_geo('centroid', self)
+
+    def convex_hull(self):
+        return _unary_geo('convex_hull', self)
+
+    def envelope(self):
+        return _unary_geo('envelope', self)
+
+    def exterior(self):
+        return _unary_geo('exterior', self)
+
+    def representative_point(self):
+        return _unary_geo(self, 'representative_point')
+
+    def distance(self, other):
+        return _binary_op('distance', self, other)
+
+    def project(self, other, normalized=False):
+        return _binary_op('project', self, other, normalized=normalized)
+
+    def relate(self, other):
+        return _binary_op('relate', self, other)
+
+    def area(self):
+        return _unary_op('area', self, null_value=np.nan)
+
+    def length(self):
+        return _unary_op('length', self, null_value=np.nan)
+
+    def difference(self, other):
+        return _binary_geo('difference', self, other)
+
+    def symmetric_difference(self, other):
+        return _binary_geo('symmetric_difference', self, other)
+
+    def union(self, other):
+        return _binary_geo('union', self, other)
+
+    def intersection(self, other):
+        return _binary_geo('intersection', self, other)
+
+    # def buffer(self, distance, resolution=16, cap_style=CAP_STYLE.round,
+    #            join_style=JOIN_STYLE.round, mitre_limit=5.0):
+    #     """ Buffer operation on array of GEOSGeometry objects """
+    #     return GeometryArray(
+    #         vectorized.buffer(self.data, distance, resolution, cap_style,
+    #                           join_style, mitre_limit))
+
+    def geom_type(self):
+        return _unary_op('geom_type', self, null_value=None)
+
+    # def unary_union(self):
+    #     """ Unary union.
+
+    #     Returns a single shapely geometry
+    #     """
+    #     return vectorized.unary_union(self.data)
+
+    # def coords(self):
+    #     return vectorized.coords(self.data)
+
+    def x(self):
+        """Return the x location of point geometries in a GeoSeries"""
+        if (self.geom_type() == "Point").all():
+            return _unary_op('x', self, null_value=np.nan)
+        else:
+            message = "x attribute access only provided for Point geometries"
+            raise ValueError(message)
+
+    def y(self):
+        """Return the y location of point geometries in a GeoSeries"""
+        if (self.geom_type() == "Point").all():
+            return _unary_op('y', self, null_value=np.nan)
+        else:
+            message = "y attribute access only provided for Point geometries"
+            raise ValueError(message)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -131,32 +131,41 @@ class GeometryArray:
     # Geometry related methods
     # -------------------------------------------------------------------------
 
+    @property
     def is_valid(self):
         return _unary_op('is_valid', self, null_value=False)
 
+    @property
     def is_empty(self):
         return _unary_op('is_empty', self, null_value=False)
 
+    @property
     def is_simple(self):
         return _unary_op('is_simple', self, null_value=False)
 
+    @property
     def is_ring(self):
         # operates on the exterior, so can't use _unary_op()
         return np.array(
             [geom.exterior.is_ring for geom in self.data], dtype=bool)
 
+    @property
     def is_closed(self):
         return _unary_op('is_closed', self, null_value=False)
 
+    @property
     def has_z(self):
         return _unary_op('has_z', self, null_value=False)
 
+    @property
     def geom_type(self):
         return _unary_op('geom_type', self, null_value=None)
 
+    @property
     def area(self):
         return _unary_op('area', self, null_value=np.nan)
 
+    @property
     def length(self):
         return _unary_op('length', self, null_value=np.nan)
 
@@ -164,21 +173,27 @@ class GeometryArray:
     # Unary operations that return new geometries
     #
 
+    @property
     def boundary(self):
         return _unary_geo('boundary', self)
 
+    @property
     def centroid(self):
         return _unary_geo('centroid', self)
 
+    @property
     def convex_hull(self):
         return _unary_geo('convex_hull', self)
 
+    @property
     def envelope(self):
         return _unary_geo('envelope', self)
 
+    @property
     def exterior(self):
         return _unary_geo('exterior', self)
 
+    @property
     def interiors(self):
         has_non_poly = False
         inner_rings = []
@@ -334,17 +349,19 @@ class GeometryArray:
     # Coordinate related properties
     #
 
+    @property
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
-        if (self.geom_type() == "Point").all():
+        if (self.geom_type == "Point").all():
             return _unary_op('x', self, null_value=np.nan)
         else:
             message = "x attribute access only provided for Point geometries"
             raise ValueError(message)
 
+    @property
     def y(self):
         """Return the y location of point geometries in a GeoSeries"""
-        if (self.geom_type() == "Point").all():
+        if (self.geom_type == "Point").all():
             return _unary_op('y', self, null_value=np.nan)
         else:
             message = "y attribute access only provided for Point geometries"

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -119,6 +119,9 @@ class GeometryArray:
             raise ValueError(
                 "'data' should be array of geometry objects. Use from_shapely,"
                 " from_wkb, from_wkt functions to construct a GeometryArray.")
+        elif not data.ndim == 1:
+            raise ValueError(
+                "'data' should be a 1-dimensional array of geometry objects.")
         self.data = data
 
     def __len__(self):
@@ -346,3 +349,17 @@ class GeometryArray:
         else:
             message = "y attribute access only provided for Point geometries"
             raise ValueError(message)
+
+    @property
+    def bounds(self):
+        # TODO fix for empty / missing geometries
+        bounds = np.array([geom.bounds for geom in self.data])
+        return bounds
+
+    @property
+    def total_bounds(self):
+        b = self.bounds
+        return np.array((b[:, 0].min(),  # minx
+                         b[:, 1].min(),  # miny
+                         b[:, 2].max(),  # maxx
+                         b[:, 3].max()))  # maxy

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -128,39 +128,6 @@ class GeometryArray:
     # Geometry related methods
     # -------------------------------------------------------------------------
 
-    def covers(self, other):
-        return _binary_op('covers', self, other)
-
-    def contains(self, other):
-        return _binary_op('contains', self, other)
-
-    def crosses(self, other):
-        return _binary_op('crosses', self, other)
-
-    def disjoint(self, other):
-        return _binary_op('disjoint', self, other)
-
-    def equals(self, other):
-        return _binary_op('equals', self, other)
-
-    def intersects(self, other):
-        return _binary_op('intersects', self, other)
-
-    def overlaps(self, other):
-        return _binary_op('overlaps', self, other)
-
-    def touches(self, other):
-        return _binary_op('touches', self, other)
-
-    def within(self, other):
-        return _binary_op('within', self, other)
-
-    def equals_exact(self, other, tolerance):
-        return _binary_op('equals_exact', self, other, tolerance=tolerance)
-
-    def almost_equals(self, other, decimal):
-        return _binary_op('almost_equals', self, other, decimal=decimal)
-
     def is_valid(self):
         return _unary_op('is_valid', self, null_value=False)
 
@@ -175,11 +142,24 @@ class GeometryArray:
         return np.array(
             [geom.exterior.is_ring for geom in self.data], dtype=bool)
 
+    def is_closed(self):
+        return _unary_op('is_closed', self, null_value=False)
+
     def has_z(self):
         return _unary_op('has_z', self, null_value=False)
 
-    def is_closed(self):
-        return _unary_op('is_closed', self, null_value=False)
+    def geom_type(self):
+        return _unary_op('geom_type', self, null_value=None)
+
+    def area(self):
+        return _unary_op('area', self, null_value=np.nan)
+
+    def length(self):
+        return _unary_op('length', self, null_value=np.nan)
+
+    #
+    # Unary operations that return new geometries
+    #
 
     def boundary(self):
         return _unary_geo('boundary', self)
@@ -221,17 +201,52 @@ class GeometryArray:
         data[:] = [geom.representative_point() for geom in self.data]
         return GeometryArray(data)
 
-    def distance(self, other):
-        return _binary_op('distance', self, other)
+    #
+    # Binary predicates
+    #
 
-    def area(self):
-        return _unary_op('area', self, null_value=np.nan)
+    def covers(self, other):
+        return _binary_op('covers', self, other)
 
-    def length(self):
-        return _unary_op('length', self, null_value=np.nan)
+    def contains(self, other):
+        return _binary_op('contains', self, other)
+
+    def crosses(self, other):
+        return _binary_op('crosses', self, other)
+
+    def disjoint(self, other):
+        return _binary_op('disjoint', self, other)
+
+    def equals(self, other):
+        return _binary_op('equals', self, other)
+
+    def intersects(self, other):
+        return _binary_op('intersects', self, other)
+
+    def overlaps(self, other):
+        return _binary_op('overlaps', self, other)
+
+    def touches(self, other):
+        return _binary_op('touches', self, other)
+
+    def within(self, other):
+        return _binary_op('within', self, other)
+
+    def equals_exact(self, other, tolerance):
+        return _binary_op('equals_exact', self, other, tolerance=tolerance)
+
+    def almost_equals(self, other, decimal):
+        return _binary_op('almost_equals', self, other, decimal=decimal)
+
+    #
+    # Binary operations that return new geometries
+    #
 
     def difference(self, other):
         return _binary_geo('difference', self, other)
+
+    def intersection(self, other):
+        return _binary_geo('intersection', self, other)
 
     def symmetric_difference(self, other):
         return _binary_geo('symmetric_difference', self, other)
@@ -239,8 +254,12 @@ class GeometryArray:
     def union(self, other):
         return _binary_geo('union', self, other)
 
-    def intersection(self, other):
-        return _binary_geo('intersection', self, other)
+    #
+    # Other operations
+    #
+
+    def distance(self, other):
+        return _binary_op('distance', self, other)
 
     def buffer(self, distance, resolution=16, **kwargs):
         if isinstance(distance, np.ndarray):
@@ -282,14 +301,35 @@ class GeometryArray:
     def relate(self, other):
         return _binary_op('relate', self, other)
 
-    def geom_type(self):
-        return _unary_op('geom_type', self, null_value=None)
+    #
+    # Reduction operations that return a Shapely geometry
+    #
 
     def unary_union(self):
         return unary_union(self.data)
 
-    # def coords(self):
-    #     return vectorized.coords(self.data)
+    #
+    # Affinity operations
+    #
+
+    def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
+        return _affinity_method('translate', self, xoff, yoff, zoff)
+
+    def rotate(self, angle, origin='center', use_radians=False):
+        return _affinity_method('rotate', self, angle, origin=origin,
+                                use_radians=use_radians)
+
+    def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin='center'):
+        return _affinity_method(
+            'scale', self, xfact, yfact, zfact, origin=origin)
+
+    def skew(self, xs=0.0, ys=0.0, origin='center', use_radians=False):
+        return _affinity_method('skew', self, xs, ys, origin=origin,
+                                use_radians=use_radians)
+
+    #
+    # Coordinate related properties
+    #
 
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
@@ -306,18 +346,3 @@ class GeometryArray:
         else:
             message = "y attribute access only provided for Point geometries"
             raise ValueError(message)
-
-    def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
-        return _affinity_method('translate', self, xoff, yoff, zoff)
-
-    def rotate(self, angle, origin='center', use_radians=False):
-        return _affinity_method('rotate', self, angle, origin=origin,
-                                use_radians=use_radians)
-
-    def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin='center'):
-        return _affinity_method(
-            'scale', self, xfact, yfact, zfact, origin=origin)
-
-    def skew(self, xs=0.0, ys=0.0, origin='center', use_radians=False):
-        return _affinity_method('skew', self, xs, ys, origin=origin,
-                                use_radians=use_radians)

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -632,9 +632,7 @@ class GeoPandasBase(object):
             xoff, yoff, and zoff for translation along the x, y, and z
             dimensions respectively.
         """
-        return gpd.GeoSeries([affinity.translate(s, xoff, yoff, zoff)
-                              for s in self.geometry],
-                             index=self.index, crs=self.crs)
+        return _unary_geo('translate', self, xoff, yoff, zoff)
 
     def rotate(self, angle, origin='center', use_radians=False):
         """Returns a ``GeoSeries`` with rotated geometries.
@@ -655,11 +653,8 @@ class GeoPandasBase(object):
         use_radians : boolean
             Whether to interpret the angle of rotation as degrees or radians
         """
-        return gpd.GeoSeries(
-            [affinity.rotate(s, angle, origin=origin,
-                             use_radians=use_radians)
-             for s in self.geometry],
-            index=self.index, crs=self.crs)
+        return _unary_geo('rotate', self, angle, origin=origin,
+                          use_radians=use_radians)
 
     def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin='center'):
         """Returns a ``GeoSeries`` with scaled geometries.
@@ -679,10 +674,7 @@ class GeoPandasBase(object):
             box center (default), 'centroid' for the geometry's 2D centroid, a
             Point object or a coordinate tuple (x, y, z).
         """
-        return gpd.GeoSeries(
-            [affinity.scale(s, xfact, yfact, zfact, origin=origin)
-             for s in self.geometry],
-            index=self.index, crs=self.crs)
+        return _unary_geo('scale', self, xfact, yfact, zfact, origin=origin)
 
     def skew(self, xs=0.0, ys=0.0, origin='center', use_radians=False):
         """Returns a ``GeoSeries`` with skewed geometries.
@@ -705,10 +697,8 @@ class GeoPandasBase(object):
         use_radians : boolean
             Whether to interpret the shear angle(s) as degrees or radians
         """
-        return gpd.GeoSeries(
-            [affinity.skew(s, xs, ys, origin=origin, use_radians=use_radians)
-             for s in self.geometry],
-            index=self.index, crs=self.crs)
+        return _unary_geo('skew', self, xs, ys, origin=origin,
+                          use_radians=use_radians)
 
     def explode(self):
         """

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -30,9 +30,10 @@ def _delegate_binary_method(op, this, other, *args, **kwargs):
     if isinstance(other, GeoPandasBase):
         this, other = this.align(other.geometry)
 
-        if this.crs != other.crs:
-            warn('GeoSeries crs mismatch: {0} and {1}'.format(this.crs,
-                                                              other.crs))
+        # TODO reenable for all operations once we use pyproj > 2
+        # if this.crs != other.crs:
+        #     warn('GeoSeries crs mismatch: {0} and {1}'.format(this.crs,
+        #                                                       other.crs))
         a_this = GeometryArray(this.values)
         other = GeometryArray(other.values)
     elif isinstance(other, BaseGeometry):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -472,7 +472,7 @@ class GeoPandasBase(object):
 
         See ``GeoSeries.total_bounds`` for the limits of the entire series.
         """
-        bounds = np.array([geom.bounds for geom in self.geometry])
+        bounds = GeometryArray(self.geometry.values).bounds
         return DataFrame(bounds,
                          columns=['minx', 'miny', 'maxx', 'maxy'],
                          index=self.index)
@@ -485,11 +485,7 @@ class GeoPandasBase(object):
         See ``GeoSeries.bounds`` for the bounds of the geometries contained in
         the series.
         """
-        b = self.bounds
-        return np.array((b['minx'].min(),
-                         b['miny'].min(),
-                         b['maxx'].max(),
-                         b['maxy'].max()))
+        return GeometryArray(self.geometry.values).total_bounds
 
     @property
     def sindex(self):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -58,20 +58,12 @@ class GeoSeries(GeoPandasBase, Series):
     @property
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
-        if (self.geom_type == "Point").all():
-            return _unary_op('x', self, null_value=np.nan)
-        else:
-            message = "x attribute access only provided for Point geometries"
-            raise ValueError(message)
+        return _unary_op('x', self)
 
     @property
     def y(self):
         """Return the y location of point geometries in a GeoSeries"""
-        if (self.geom_type == "Point").all():
-            return _unary_op('y', self, null_value=np.nan)
-        else:
-            message = "y attribute access only provided for Point geometries"
-            raise ValueError(message)
+        return _unary_op('y', self)
 
     @classmethod
     def from_file(cls, filename, **kwargs):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -10,7 +10,8 @@ from shapely.geometry.base import BaseGeometry
 from shapely.ops import transform
 
 from geopandas.plotting import plot_series
-from geopandas.base import GeoPandasBase, _unary_op, _CoordinateIndexer
+from geopandas.base import (
+    GeoPandasBase, _delegate_property, _CoordinateIndexer)
 
 
 _PYPROJ2 = LooseVersion(pyproj.__version__) >= LooseVersion('2.1.0')
@@ -58,12 +59,12 @@ class GeoSeries(GeoPandasBase, Series):
     @property
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
-        return _unary_op('x', self)
+        return _delegate_property('x', self)
 
     @property
     def y(self):
         """Return the y location of point geometries in a GeoSeries"""
-        return _unary_op('y', self)
+        return _delegate_property('y', self)
 
     @classmethod
     def from_file(cls, filename, **kwargs):

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -198,13 +198,14 @@ class TestGeomMethods:
         result = getattr(gdf, op)
         fcmp(result, expected)
 
-    def test_crs_warning(self):
-        # operations on geometries should warn for different CRS
-        no_crs_g3 = self.g3.copy()
-        no_crs_g3.crs = None
-        with pytest.warns(UserWarning):
-            self._test_binary_topological('intersection', self.g3,
-                                          self.g3, no_crs_g3)
+    # TODO reenable for all operations once we use pyproj > 2
+    # def test_crs_warning(self):
+    #     # operations on geometries should warn for different CRS
+    #     no_crs_g3 = self.g3.copy()
+    #     no_crs_g3.crs = None
+    #     with pytest.warns(UserWarning):
+    #         self._test_binary_topological('intersection', self.g3,
+    #                                       self.g3, no_crs_g3)
 
     def test_intersection(self):
         self._test_binary_topological('intersection', self.t1,


### PR DESCRIPTION
Another part of https://github.com/geopandas/geopandas/pull/835, in preparation to make GeometryArray an actual ExtensionArray. 
This PR already moves the implementations out of base.py to a GeometryArray class (which for now is just holder of those methods, without other functionality) in array.py.

It might not look like a that useful refactor on its own, but will make the diff for the ExtensionArray PR smaller.