### PR TITLE
ENH: add constructors / converters for shapely, WKT and WKB

### DIFF
--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -1,6 +1,6 @@
 from geopandas.geoseries import GeoSeries
 from geopandas.geodataframe import GeoDataFrame
-from geopandas.geodataframe import points_from_xy
+from geopandas.array import _points_from_xy as points_from_xy
 
 from geopandas.io.file import read_file
 from geopandas.io.sql import read_postgis

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -636,36 +636,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return geo_df
 
 
-def points_from_xy(x, y, z=None):
-    """
-    Generate list of shapely Point geometries from x, y(, z) coordinates.
-
-    Parameters
-    ----------
-    x, y, z : array
-
-    Examples
-    --------
-    >>> geometry = geopandas.points_from_xy(x=[1, 0], y=[0, 1])
-    >>> geometry = geopandas.points_from_xy(df['x'], df['y'], df['z'])
-    >>> gdf = geopandas.GeoDataFrame(
-            df, geometry=geopandas.points_from_xy(df['x'], df['y']))
-
-    Returns
-    -------
-    list : list
-    """
-    if not len(x) == len(y):
-        raise ValueError("x and y arrays must be equal length.")
-    if z is not None:
-        if not len(z) == len(x):
-            raise ValueError("z array must be same length as x and y.")
-        geom = [Point(i, j, k) for i, j, k in zip(x, y, z)]
-    else:
-        geom = [Point(i, j) for i, j in zip(x, y)]
-    return geom
-
-
 def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     if inplace:
         raise ValueError("Can't do inplace setting when converting from"

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -1,0 +1,115 @@
+import random
+
+import numpy as np
+
+import shapely
+import shapely.geometry
+import shapely.wkb
+
+from geopandas.array import (
+    GeometryArray, points_from_xy, from_shapely, from_wkb, from_wkt, to_wkb,
+    to_wkt)
+
+import pytest
+import six
+
+
+triangles = [shapely.geometry.Polygon([(random.random(), random.random())
+                                       for i in range(3)])
+             for _ in range(10)]
+T = from_shapely(triangles)
+
+points = [shapely.geometry.Point(random.random(), random.random())
+          for _ in range(20)]
+P = from_shapely(points)
+
+
+point = points[0]
+
+
+def test_points():
+    x = np.arange(10).astype(np.float)
+    y = np.arange(10).astype(np.float) ** 2
+
+    points = points_from_xy(x, y)
+
+    for i in range(10):
+        assert isinstance(points[i], shapely.geometry.Point)
+        assert points[i].x == x[i]
+        assert points[i].y == y[i]
+
+
+def test_from_shapely():
+    assert isinstance(T, GeometryArray)
+    assert [v.equals(t) for v, t in zip(T, triangles)]
+
+
+def test_from_wkb():
+    # list
+    L_wkb = [p.wkb for p in points]
+    res = from_wkb(L_wkb)
+    assert isinstance(res, GeometryArray)
+    assert all(v.equals(t) for v, t in zip(res, points))
+
+    # array
+    res = from_wkb(np.array(L_wkb, dtype=object))
+    assert isinstance(res, GeometryArray)
+    assert all(v.equals(t) for v, t in zip(res, points))
+
+    # missing values
+    L_wkb.extend([b'', None])
+    res = from_wkb(L_wkb)
+    assert res[-1] is None
+    assert res[-2] is None
+
+
+def test_to_wkb():
+    res = to_wkb(P)
+    exp = np.array([p.wkb for p in points], dtype=object)
+    assert isinstance(res, np.ndarray)
+    np.testing.assert_array_equal(res, exp)
+
+    # missing values
+    a = from_shapely([None, points[0]])
+    res = to_wkb(a)
+    assert res[0] is None
+
+
+@pytest.mark.parametrize('string_type', ['str', 'bytes'])
+def test_from_wkt(string_type):
+    if string_type == 'str':
+        f = six.text_type
+    else:
+        if six.PY3:
+            def f(x): return bytes(x, 'utf8')
+        else:
+            def f(x): return x
+
+    # list
+    L_wkt = [f(p.wkt) for p in points]
+    res = from_wkt(L_wkt)
+    assert isinstance(res, GeometryArray)
+    assert all(v.almost_equals(t) for v, t in zip(res, points))
+
+    # array
+    res = from_wkt(np.array(L_wkt, dtype=object))
+    assert isinstance(res, GeometryArray)
+    assert all(v.almost_equals(t) for v, t in zip(res, points))
+
+    # missing values
+    L_wkt.extend([f(''), None])
+    res = from_wkt(L_wkt)
+    assert res[-1] is None
+    assert res[-2] is None
+
+
+def test_to_wkt():
+    res = to_wkt(P)
+    exp = np.array([p.wkt for p in points], dtype=object)
+    assert isinstance(res, np.ndarray)
+    np.testing.assert_array_equal(res, exp)
+
+    # missing values
+    a = from_shapely([None, points[0]])
+    res = to_wkt(a)
+    assert res[0] is None

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -80,6 +80,24 @@ def test_from_shapely():
     assert [v.equals(t) for v, t in zip(T, triangles)]
 
 
+def test_from_shapely_geo_interface():
+
+    class Point:
+
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+        @property
+        def __geo_interface__(self):
+            return {'type': 'Point', 'coordinates': (self.x, self.y)}
+
+    result = from_shapely([Point(1.0, 2.0), Point(3.0, 4.0)])
+    expected = from_shapely([
+        shapely.geometry.Point(1.0, 2.0), shapely.geometry.Point(3.0, 4.0)])
+    assert all(v.equals(t) for v, t in zip(result, expected))
+
+
 def test_from_wkb():
     # list
     L_wkb = [p.wkb for p in points]

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -13,7 +13,6 @@ import fiona
 
 import geopandas
 from geopandas import GeoDataFrame, read_file, GeoSeries
-from geopandas.geodataframe import points_from_xy
 
 import pytest
 from pandas.util.testing import (
@@ -539,36 +538,6 @@ class TestDataFrame:
         unpickled = pd.read_pickle(filename)
         assert_frame_equal(self.df, unpickled)
         assert self.df.crs == unpickled.crs
-
-    def test_points_from_xy(self):
-        # using GeoDataFrame column
-        df = GeoDataFrame([{'x': x, 'y': x, 'z': x} for x in range(10)])
-        gs = [Point(x, x) for x in range(10)]
-        gsz = [Point(x, x, x) for x in range(10)]
-        geometry1 = points_from_xy(df['x'], df['y'])
-        geometry2 = points_from_xy(df['x'], df['y'], df['z'])
-        assert geometry1 == gs
-        assert geometry2 == gsz
-
-        # using GeoSeries or numpy arrays or lists
-        for s in [GeoSeries(range(10)), np.arange(10), list(range(10))]:
-            geometry1 = points_from_xy(s, s)
-            geometry2 = points_from_xy(s, s, s)
-            assert geometry1 == gs
-            assert geometry2 == gsz
-
-        # using different lengths should throw error
-        arr_10 = np.arange(10)
-        arr_20 = np.arange(20)
-        with pytest.raises(ValueError):
-            points_from_xy(x=arr_10, y=arr_20)
-            points_from_xy(x=arr_10, y=arr_10, z=arr_20)
-
-        # Using incomplete arguments should throw error
-        with pytest.raises(TypeError):
-            points_from_xy(x=s)
-            points_from_xy(y=s)
-            points_from_xy(z=s)
 
 
 def check_geodataframe(df, geometry_column='geometry'):


### PR DESCRIPTION
Another preparation PR for moving to ExtensionArrays (WKB will be useful for factorizing, WKT for repr), and those methods will also be useful in general.

For now not exposed top-level, only in the `array` module (except for the already existing `points_from_xy` which I moved there).