### PR TITLE
ENH: optionally ignore errors from shapely in from_features

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -14,7 +14,7 @@ Reading Spatial Data
 
 which returns a GeoDataFrame object. (This is possible because *geopandas* makes use of the great `fiona <http://fiona.readthedocs.io/en/latest/manual.html>`_ library, which in turn makes use of a massive open-source program called `GDAL/OGR <http://www.gdal.org/>`_ designed to facilitate spatial data transformations).
 
-Any arguments passed to ``read_file()`` after the file name will be passed directly to ``fiona.open``, which does the actual data importation. In general, ``read_file`` is pretty smart and should do what you want without extra arguments, but for more help, type::
+Most arguments passed to ``read_file()`` after the file name will be passed directly to ``fiona.open``, which does the actual data importation. The exception is the ``ignore_errors`` argument, which when True will cause GeoPandas to ignore errors from Shapely when processing features from an input file and skip invalid features.  In general, ``read_file`` is pretty smart and should do what you want without extra arguments, but for more help, type::
 
     import fiona; help(fiona.open)
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -39,7 +39,7 @@ def _is_url(url):
         return False
 
 
-def read_file(filename, bbox=None, **kwargs):
+def read_file(filename, bbox=None, ignore_errors=False, **kwargs):
     """
     Returns a GeoDataFrame from a file or URL.
 
@@ -51,6 +51,9 @@ def read_file(filename, bbox=None, **kwargs):
     bbox : tuple | GeoDataFrame or GeoSeries, default None
         Filter features by given bounding box, GeoSeries, or GeoDataFrame.
         CRS mis-matches are resolved if given a GeoSeries or GeoDataFrame.
+    ignore_errors : boolean (optional)
+        Optionally ignore errors converting features into shapes. Instead,
+        ignore the errors and drop the erroneous features.
     **kwargs:
         Keyword args to be passed to the `open` or `BytesCollection` method
         in the fiona library when opening the file. For more information on
@@ -93,7 +96,8 @@ def read_file(filename, bbox=None, **kwargs):
                 f_filt = features
 
             columns = list(features.meta["schema"]["properties"]) + ["geometry"]
-            gdf = GeoDataFrame.from_features(f_filt, crs=crs, columns=columns)
+            gdf = GeoDataFrame.from_features(f_filt, crs=crs, columns=columns,
+                                             ignore_errors=ignore_errors)
 
     return gdf
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -538,6 +538,49 @@ class TestDataFrame:
         assert_frame_equal(self.df, unpickled)
         assert self.df.crs == unpickled.crs
 
+    def test_ignore_errors(self):
+        bad_input_raw = '''
+            {
+              "type": "FeatureCollection",
+              "name": "tracks",
+              "crs": {
+                "type": "name",
+                "properties": {
+                  "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+                }
+              },
+              "features": [
+                {
+                  "type": "Feature",
+                  "properties": {
+                    "name": "ACTIVE LOG091609"
+                  },
+                  "geometry": {
+                    "type": "MultiLineString",
+                    "coordinates": [
+                      [
+                        [
+                          -42.0,
+                          42.0
+                        ]
+                      ]
+                    ]
+                  }
+                }
+              ]
+            }
+        '''
+
+        bad_input = json.loads(bad_input_raw)
+
+        with pytest.raises(ValueError):
+            # This should raise a ValueError.
+            geopandas.GeoDataFrame.from_features(bad_input)
+
+        # This should not.
+        geopandas.GeoDataFrame.from_features(bad_input,
+                                             ignore_errors=True)
+
 
 def check_geodataframe(df, geometry_column='geometry'):
     assert isinstance(df, GeoDataFrame)


### PR DESCRIPTION
Introduce an `ignore_errors` option for geopandas.read_file that when True will simply ignore features that cause a ValueError exception.

---

I'm using GeoPandas to process a bunch of GPX files generated from a Garmin Vista HCx. Many of these seem to contain track segments that look something like this:

```
  <trkseg>
   <trkpt lat="42.384411" lon="-71.162963">
    <ele>12.134</ele>
    <time>2019-05-29T12:56:44Z</time>
   </trkpt>
  </trkseg>
```

Shapely doesn't like lines with a single point (who does?), so trying to use `geopandas.read_file` with these files will often result in:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lars/.local/share/virtualenvs/gps-TT0qNP_P/lib/python3.7/site-packages/geopandas/io/file.py", line 96, in read_file
    gdf = GeoDataFrame.from_features(f_filt, crs=crs, columns=columns)
  File "/home/lars/.local/share/virtualenvs/gps-TT0qNP_P/lib/python3.7/site-packages/geopandas/geodataframe.py", line 233, in from_features
    d = {'geometry': shape(f['geometry']) if f['geometry'] else None}
  File "/home/lars/.local/share/virtualenvs/gps-TT0qNP_P/lib/python3.7/site-packages/shapely/geometry/geo.py", line 42, in shape
    return MultiLineString(ob["coordinates"])
  File "/home/lars/.local/share/virtualenvs/gps-TT0qNP_P/lib/python3.7/site-packages/shapely/geometry/multilinestring.py", line 52, in __init__
    self._geom, self._ndim = geos_multilinestring_from_py(lines)
  File "/home/lars/.local/share/virtualenvs/gps-TT0qNP_P/lib/python3.7/site-packages/shapely/geometry/multilinestring.py", line 134, in geos_multilinestring_from_py
    geom, ndims = linestring.geos_linestring_from_py(obs[l])
  File "shapely/speedups/_speedups.pyx", line 152, in shapely.speedups._speedups.geos_linestring_from_py
ValueError: LineStrings must have at least 2 coordinate tuples
```

With this PR, you can set `ignore_errors` to `True` and geopandas will simply skip features that result in a ValueError:

```
data = geopandas.read_file('filename.gpx', ignore_errors=True)
```