### PR TITLE
CI: use conda environment files for Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,6 @@ install:
   - conda env create --file="${ENV_FILE}"
 
 test_script:
-  - activate test-environment
+  - conda activate test
   - conda list
   - pytest geopandas -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,11 @@ environment:
   matrix:
     - PYTHON_VERSION: "2.7"
       MINICONDA: C:\Miniconda-x64
+      ENV_FILE: "ci/travis/27-latest-defaults.yaml"
 
     - PYTHON_VERSION: "3.7"
       MINICONDA: C:\Miniconda37-x64
+      ENV_FILE: "ci/travis/37-latest-conda-forge.yaml"
 
 # all our python builds have to happen in tests_script...
 build: false
@@ -28,9 +30,8 @@ install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set show_channel_urls true --set changeps1 no
   - conda install conda=4.6
-  - conda config --add channels conda-forge
   - conda info -a
-  - "conda create --quiet --name test-environment python=%PYTHON_VERSION% pandas --file requirements.txt --file requirements.test.txt"
+  - conda env create --file="${ENV_FILE}"
 
 test_script:
   - activate test-environment

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,6 @@ install:
   - conda env create --file="${ENV_FILE}"
 
 test_script:
-  - conda activate test
+  - CALL conda.bat activate test
   - conda list
   - pytest geopandas -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,6 @@ install:
   - conda env create --file="${ENV_FILE}"
 
 test_script:
-  - CALL conda.bat activate test
+  - activate test
   - conda list
   - pytest geopandas -v


### PR DESCRIPTION
Attempt to fix https://github.com/geopandas/geopandas/issues/1022, and something we should do anyway to make the approach similar as on Travis (for now trying to use the same env files as for travis, but could make specific ones for appveyor if needed)