### PR TITLE
DOC: update geoplot version for rtd environment

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -22,6 +22,6 @@ dependencies:
 - cartopy=0.17.0
 - contextily=1.0rc1
 - rasterio=1.0.21
-- geoplot=0.2.4
+- geoplot=0.3.0
 - sphinx-gallery=0.2.0
 - jinja2=2.10


### PR DESCRIPTION
Readthedocs is failing currently due to the update of geoplot example, which was not reflected in the environment file.
It may fail for some time anyway as GDAL on conda-forge is broken at this moment. (https://github.com/conda-forge/gdal-feedstock/issues/303) Travis for this PR will probably fail as well.