### PR TITLE
CI: add zstd as dependency to fix conda-forge problem with latest fiona / gdal

### DIFF
--- a/ci/travis/27-latest-conda-forge.yaml
+++ b/ci/travis/27-latest-conda-forge.yaml
@@ -23,6 +23,8 @@ dependencies:
   - SQLalchemy
   - psycopg2
   - libspatialite
+  # TEMP: workaround until conda-forge fixes the issues with gdal
+  - zstd
   - pip:
     - codecov
     - geopy

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -22,3 +22,5 @@ dependencies:
   - SQLalchemy
   - psycopg2
   - libspatialite
+  # TEMP: workaround until conda-forge fixes the issues with gdal
+  - zstd


### PR DESCRIPTION
For context, see https://github.com/conda-forge/segregation-feedstock/pull/2#issuecomment-514687151

Example failing build: https://travis-ci.org/geopandas/geopandas/jobs/564925601#L514