### PR TITLE
CI: use defaults for py36 build

### DIFF
--- a/ci/travis/36-pd023.yaml
+++ b/ci/travis/36-pd023.yaml
@@ -1,6 +1,6 @@
 name: test
 channels:
-  - conda-forge
+  - defaults
 dependencies:
   - python=3.6
   - six

--- a/ci/travis/36-pd023.yaml
+++ b/ci/travis/36-pd023.yaml
@@ -3,6 +3,7 @@ channels:
   - defaults
 dependencies:
   - python=3.6
+  - pip
   - six
   # required
   - pandas==0.23.4
@@ -14,13 +15,16 @@ dependencies:
   # testing
   - pytest
   - pytest-cov
-  - codecov
+  #- codecov
   # optional
   - rtree
   - matplotlib=2
   - descartes
   - mapclassify
-  - geopy
+  #- geopy
   - SQLalchemy
   - psycopg2
   - libspatialite
+  - pip:
+    - geopy
+    - codecov


### PR DESCRIPTION
Test to see if this fixed the travis build, see also https://github.com/conda-forge/fiona-feedstock/issues/135