### PR TITLE
ENH: allow pysal alongside mapclassify for plotting scheme

### DIFF
--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -17,7 +17,7 @@ dependencies:
   - rtree
   - matplotlib
   - descartes
-  - mapclassify
+  - pysal
   - geopy
   - SQLalchemy
   - psycopg2

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -555,15 +555,18 @@ def _mapclassify_choro(values, scheme, **classification_kwds):
 
     """
     try:
-        import mapclassify.classifiers
+        import mapclassify.classifiers as classifiers
     except ImportError:
-        raise ImportError(
-            "The 'mapclassify' package is required to use the 'scheme' "
-            "keyword")
+        try:
+            import pysal.viz.mapclassify.classifiers as classifiers
+        except ImportError:
+            raise ImportError(
+                "The 'mapclassify' or 'pysal' package is required to use the"
+                " 'scheme' keyword")
 
     schemes = {}
-    for classifier in mapclassify.classifiers.CLASSIFIERS:
-        schemes[classifier.lower()] = getattr(mapclassify.classifiers,
+    for classifier in classifiers.CLASSIFIERS:
+        schemes[classifier.lower()] = getattr(classifiers,
                                               classifier)
 
     scheme = scheme.lower()

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -402,7 +402,13 @@ class TestMapclassifyPlotting:
 
     @classmethod
     def setup_class(cls):
-        pytest.importorskip('mapclassify')
+        try:
+            import mapclassify
+        except ImportError:
+            try:
+                import pysal
+            except ImportError:
+                pytest.importorskip('mapclassify')
         pth = get_path('naturalearth_lowres')
         cls.df = read_file(pth)
         cls.df['NEGATIVES'] = np.linspace(-10, 10, len(cls.df.index))


### PR DESCRIPTION
As pointed out in #1081, `pysal` package includes codebase of `mapclassify`. If `pysal` is installed but `mapclassify` not, this PR will use `pysal.viz.mapclassify` to get scheme in plotting.

Not sure how to test it though, maybe having mapclassify in one env and pysal in other?

Closes #1081