### PR TITLE
API: deprecate GeoSeries fallback to return Series for non-geometry data

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1,6 +1,7 @@
 from distutils.version import LooseVersion
 from functools import partial
 import json
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -29,6 +30,28 @@ def _is_empty(x):
         return x.is_empty
     except:
         return False
+
+
+_SERIES_WARNING_MSG = """\
+    You are passing non-geometry data to the GeoSeries constructor. Currently,
+    it falls back to returning a pandas Series. But in the future, we will start
+    to raise a TypeError instead."""
+
+
+def _geoseries_constructor_with_fallback(data=None, index=None, crs=None, **kwargs):
+    """
+    A flexible constructor for GeoSeries._constructor, which needs to be able
+    to fall back to a Series (if a certain operation does not produce
+    geometries)
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message=_SERIES_WARNING_MSG,
+                category=FutureWarning, module="geopandas[.*]")
+            return GeoSeries(data=data, index=index, crs=crs, **kwargs)
+    except TypeError:
+        return Series(data=data, index=index, **kwargs)
 
 
 class GeoSeries(GeoPandasBase, Series):
@@ -87,6 +110,7 @@ class GeoSeries(GeoPandasBase, Series):
                 super(GeoSeries, self).__init__(data, index=index, **kwargs)
                 self.crs = crs
                 return self
+            warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
             return Series(data, index=index, **kwargs)
 
         if isinstance(data, BaseGeometry):
@@ -109,11 +133,14 @@ class GeoSeries(GeoPandasBase, Series):
                 if s.empty:
                     s = s.astype(object)
                 else:
+                    warnings.warn(
+                        _SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
                     return s
             # try to convert to GeometryArray, if fails return plain Series
             try:
                 data = from_shapely(s.values)
             except TypeError:
+                warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
                 return s
             index = s.index
             name = s.name
@@ -196,7 +223,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def _constructor(self):
-        return GeoSeries
+        return _geoseries_constructor_with_fallback
 
     def _wrapped_pandas_method(self, mtd, *args, **kwargs):
         """Wrap a generic pandas method to ensure it returns a GeoSeries"""

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -252,15 +252,18 @@ class TestConstructor:
                 assert x is g
 
     def test_no_geometries_fallback(self):
-        s = GeoSeries([True, False, True])
+        with pytest.warns(FutureWarning):
+            s = GeoSeries([True, False, True])
         assert not isinstance(s, GeoSeries)
         assert type(s) == pd.Series
 
-        s = GeoSeries(['a', 'b', 'c'])
+        with pytest.warns(FutureWarning):
+            s = GeoSeries(['a', 'b', 'c'])
         assert not isinstance(s, GeoSeries)
         assert type(s) == pd.Series
 
-        s = GeoSeries([[1, 2], [3, 4]])
+        with pytest.warns(FutureWarning):
+            s = GeoSeries([[1, 2], [3, 4]])
         assert not isinstance(s, GeoSeries)
         assert type(s) == pd.Series
 


### PR DESCRIPTION
Related to the "strict GeoSeries constructor" bullet point in https://github.com/geopandas/geopandas/issues/1000  and also related to https://github.com/geopandas/geopandas/issues/53

This *seems* to work (I am not 100% sure that pandas does not expect an actual class in `_constructor`, but our tests seem to indicate it works)