### PR TITLE
BUG: colorbar did not match normalised colors

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -590,10 +590,9 @@ def plot_dataframe(
         from matplotlib.colors import Normalize
         from matplotlib import cm
 
-        if "norm" not in style_kwds:
+        norm = style_kwds.get("norm", None)
+        if not norm:
             norm = Normalize(vmin=mn, vmax=mx)
-        else:
-            norm = style_kwds["norm"]
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
         if categorical:
             patches = []

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -568,10 +568,10 @@ def plot_dataframe(
         from matplotlib.colors import Normalize
         from matplotlib import cm
 
-        if 'norm' not in style_kwds:
+        if "norm" not in style_kwds:
             norm = Normalize(vmin=mn, vmax=mx)
         else:
-            norm = style_kwds['norm']
+            norm = style_kwds["norm"]
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
         if categorical:
             patches = []
@@ -604,7 +604,6 @@ def plot_dataframe(
 
     plt.draw()
     return ax
-
 
 
 def _mapclassify_choro(values, scheme, **classification_kwds):

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -503,7 +503,10 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         from matplotlib.colors import Normalize
         from matplotlib import cm
 
-        norm = Normalize(vmin=mn, vmax=mx)
+        if 'norm' not in style_kwds:
+            norm = Normalize(vmin=mn, vmax=mx)
+        else:
+            norm = style_kwds['norm']
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
         if categorical:
             patches = []
@@ -524,6 +527,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
 
     plt.draw()
     return ax
+
 
 
 def _mapclassify_choro(values, scheme, **classification_kwds):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -165,6 +165,18 @@ class TestPointPlotting:
         # last point == top of colorbar
         np.testing.assert_array_equal(point_colors[-1], cbar_colors[-1])
 
+        # # Normalized legend
+        # the colorbar matches the Point colors
+        norm = matplotlib.colors.DivergingNorm(vmin=0, vcenter=8, vmax=10)
+        ax = self.df.plot(column='values', cmap='RdYlGn', legend=True,
+                          norm=norm)
+        point_colors = ax.collections[0].get_facecolors()
+        cbar_colors = ax.get_figure().axes[1].collections[0].get_facecolors()
+        # first point == bottom of colorbar
+        np.testing.assert_array_equal(point_colors[0], cbar_colors[0])
+        # colorbar generated proper long transition
+        assert cbar_colors.shape == (256, 4)
+
     def test_empty_plot(self):
         s = GeoSeries([])
         with pytest.warns(UserWarning):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -39,7 +39,7 @@ class TestPointPlotting:
         values = np.arange(self.N)
 
         self.df = GeoDataFrame({"geometry": self.points, "values": values})
-        self.df['exp'] = (values * 10)**3
+        self.df["exp"] = (values * 10) ** 3
 
         multipoint1 = MultiPoint(self.points)
         multipoint2 = rotate(multipoint1, 90)
@@ -172,10 +172,8 @@ class TestPointPlotting:
 
         # # Normalized legend
         # the colorbar matches the Point colors
-        norm = matplotlib.colors.LogNorm(vmin=self.df.exp.min(),
-                                         vmax=self.df.exp.max())
-        ax = self.df[1:].plot(column='exp', cmap='RdYlGn', legend=True,
-                              norm=norm)
+        norm = matplotlib.colors.LogNorm(vmin=self.df.exp.min(), vmax=self.df.exp.max())
+        ax = self.df[1:].plot(column="exp", cmap="RdYlGn", legend=True, norm=norm)
         point_colors = ax.collections[0].get_facecolors()
         cbar_colors = ax.get_figure().axes[1].collections[0].get_facecolors()
         # first point == bottom of colorbar

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -180,7 +180,9 @@ class TestPointPlotting:
 
         # # Normalized legend
         # the colorbar matches the Point colors
-        norm = matplotlib.colors.LogNorm(vmin=self.df.exp.min(), vmax=self.df.exp.max())
+        norm = matplotlib.colors.LogNorm(
+            vmin=self.df[1:].exp.min(), vmax=self.df[1:].exp.max()
+        )
         ax = self.df[1:].plot(column="exp", cmap="RdYlGn", legend=True, norm=norm)
         point_colors = ax.collections[0].get_facecolors()
         cbar_colors = ax.get_figure().axes[1].collections[0].get_facecolors()

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -39,7 +39,7 @@ class TestPointPlotting:
 
         values = np.arange(self.N)
         self.df = GeoDataFrame({'geometry': self.points, 'values': values})
-
+        self.df['exp'] = (values * 10)**3
         multipoint1 = MultiPoint(self.points)
         multipoint2 = rotate(multipoint1, 90)
         self.df2 = GeoDataFrame({'geometry': [multipoint1, multipoint2],
@@ -167,13 +167,16 @@ class TestPointPlotting:
 
         # # Normalized legend
         # the colorbar matches the Point colors
-        norm = matplotlib.colors.DivergingNorm(vmin=0, vcenter=8, vmax=10)
-        ax = self.df.plot(column='values', cmap='RdYlGn', legend=True,
-                          norm=norm)
+        norm = matplotlib.colors.LogNorm(vmin=self.df.exp.min(),
+                                         vmax=self.df.exp.max())
+        ax = self.df[1:].plot(column='exp', cmap='RdYlGn', legend=True,
+                              norm=norm)
         point_colors = ax.collections[0].get_facecolors()
         cbar_colors = ax.get_figure().axes[1].collections[0].get_facecolors()
         # first point == bottom of colorbar
         np.testing.assert_array_equal(point_colors[0], cbar_colors[0])
+        # last point == top of colorbar
+        np.testing.assert_array_equal(point_colors[-1], cbar_colors[-1])
         # colorbar generated proper long transition
         assert cbar_colors.shape == (256, 4)
 


### PR DESCRIPTION
In current version, if you use normalisation, colorbar does not represent true color scheme as it is always normalized linear between min and max. This PR fixes the behaviour and normalises colorbar using the same scheme, so the results should match. 

It should resolve issue like https://github.com/geopandas/geopandas/issues/697#issuecomment-515499696 . 


```
gdf = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
gdf['random'] = np.random.gamma(2, 2, len(gdf)) - 2

vmin, vmax, vcenter = gdf.random.min(), gdf.random.max(), 0
divnorm = colors.DivergingNorm(vmin=vmin, vcenter=vcenter, vmax=vmax)

gdf.plot(column='random', cmap='RdBu', legend=True, norm=divnorm)
```
Before:
![before](https://user-images.githubusercontent.com/36797143/62839290-183d0a00-bc80-11e9-9a90-085a6c7595c4.png)
After:
![after](https://user-images.githubusercontent.com/36797143/62839291-1d9a5480-bc80-11e9-872b-fdde276bd04a.png)

Closes #697 