### PR TITLE
BUG: norm not persisting when using subplots 

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -108,7 +108,7 @@ def plot_polygon_collection(
     if values is not None:
         collection.set_array(np.asarray(values))
         collection.set_cmap(cmap)
-        if 'norm' not in kwargs:
+        if "norm" not in kwargs:
             collection.set_clim(vmin, vmax)
 
     ax.add_collection(collection, autolim=True)
@@ -164,7 +164,7 @@ def plot_linestring_collection(
     if values is not None:
         collection.set_array(np.asarray(values))
         collection.set_cmap(cmap)
-        if 'norm' not in kwargs:
+        if "norm" not in kwargs:
             collection.set_clim(vmin, vmax)
 
     ax.add_collection(collection, autolim=True)
@@ -220,12 +220,12 @@ def plot_point_collection(
     if markersize is not None:
         kwargs["s"] = markersize
 
-    if 'norm' not in kwargs:
-        collection = ax.scatter(x, y, color=color, vmin=vmin, vmax=vmax,
-                                cmap=cmap, marker=marker, **kwargs)
+    if "norm" not in kwargs:
+        collection = ax.scatter(
+            x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap, marker=marker, **kwargs
+        )
     else:
-        collection = ax.scatter(x, y, color=color, cmap=cmap,
-                                marker=marker, **kwargs)
+        collection = ax.scatter(x, y, color=color, cmap=cmap, marker=marker, **kwargs)
     return collection
 
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -207,8 +207,12 @@ def plot_point_collection(ax, geoms, values=None, color=None,
     if markersize is not None:
         kwargs['s'] = markersize
 
-    collection = ax.scatter(x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap,
-                            marker=marker, **kwargs)
+    if 'norm' not in kwargs:
+        collection = ax.scatter(x, y, color=color, vmin=vmin, vmax=vmax,
+                                cmap=cmap, marker=marker, **kwargs)
+    else:
+        collection = ax.scatter(x, y, color=color, cmap=cmap,
+                                marker=marker, **kwargs)
     return collection
 
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -105,7 +105,8 @@ def plot_polygon_collection(ax, geoms, values=None, color=None,
     if values is not None:
         collection.set_array(np.asarray(values))
         collection.set_cmap(cmap)
-        collection.set_clim(vmin, vmax)
+        if 'norm' not in kwargs:
+            collection.set_clim(vmin, vmax)
 
     ax.add_collection(collection, autolim=True)
     ax.autoscale_view()
@@ -159,7 +160,8 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
     if values is not None:
         collection.set_array(np.asarray(values))
         collection.set_cmap(cmap)
-        collection.set_clim(vmin, vmax)
+        if 'norm' not in kwargs:
+            collection.set_clim(vmin, vmax)
 
     ax.add_collection(collection, autolim=True)
     ax.autoscale_view()

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -230,7 +230,7 @@ def plot_point_collection(
         kwargs["c"] = values
     if markersize is not None:
         kwargs["s"] = markersize
- 
+
     if color is not None:
         if pd.api.types.is_list_like(color):
             color = np.take(color, multiindex)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -172,15 +172,14 @@ class TestPointPlotting:
         # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
-        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        ax = self.df.plot(column="values", cmap=cmap, norm=norm)
         actual_colors_orig = ax.collections[0].get_facecolors()
         exp_colors = cmap(np.arange(10) / (20))
         np.testing.assert_array_equal(exp_colors, actual_colors_orig)
         fig, ax = plt.subplots()
-        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        self.df[1:].plot(column="values", ax=ax, norm=norm, cmap=cmap)
         actual_colors_sub = ax.collections[0].get_facecolors()
-        np.testing.assert_array_equal(actual_colors_orig[1],
-                                      actual_colors_sub[0])
+        np.testing.assert_array_equal(actual_colors_orig[1], actual_colors_sub[0])
 
     def test_empty_plot(self):
         s = GeoSeries([])
@@ -264,15 +263,14 @@ class TestLineStringPlotting:
         # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
-        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        ax = self.df.plot(column="values", cmap=cmap, norm=norm)
         actual_colors_orig = ax.collections[0].get_edgecolors()
         exp_colors = cmap(np.arange(10) / (20))
         np.testing.assert_array_equal(exp_colors, actual_colors_orig)
         fig, ax = plt.subplots()
-        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        self.df[1:].plot(column="values", ax=ax, norm=norm, cmap=cmap)
         actual_colors_sub = ax.collections[0].get_edgecolors()
-        np.testing.assert_array_equal(actual_colors_orig[1],
-                                      actual_colors_sub[0])
+        np.testing.assert_array_equal(actual_colors_orig[1], actual_colors_sub[0])
 
 
 class TestPolygonPlotting:
@@ -404,15 +402,14 @@ class TestPolygonPlotting:
         # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=10)
-        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        ax = self.df.plot(column="values", cmap=cmap, norm=norm)
         actual_colors_orig = ax.collections[0].get_facecolors()
         exp_colors = cmap(np.arange(2) / (10))
         np.testing.assert_array_equal(exp_colors, actual_colors_orig)
         fig, ax = plt.subplots()
-        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        self.df[1:].plot(column="values", ax=ax, norm=norm, cmap=cmap)
         actual_colors_sub = ax.collections[0].get_facecolors()
-        np.testing.assert_array_equal(actual_colors_orig[1],
-                                      actual_colors_sub[0])
+        np.testing.assert_array_equal(actual_colors_orig[1], actual_colors_sub[0])
 
 
 class TestPolygonZPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -166,7 +166,7 @@ class TestPointPlotting:
         np.testing.assert_array_equal(point_colors[-1], cbar_colors[-1])
 
     def test_subplots_norm(self):
-
+        # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
         ax = self.df.plot(column='values', cmap=cmap, norm=norm)
@@ -262,7 +262,7 @@ class TestLineStringPlotting:
             assert ls[1] == exp_ls[1]
 
     def test_subplots_norm(self):
-
+        # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
         ax = self.df.plot(column='values', cmap=cmap, norm=norm)
@@ -374,7 +374,7 @@ class TestPolygonPlotting:
         _check_colors(4, ax.collections[0].get_facecolors(), expected_colors)
 
     def test_subplots_norm(self):
-
+        # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r
         norm = matplotlib.colors.Normalize(vmin=0, vmax=10)
         ax = self.df.plot(column='values', cmap=cmap, norm=norm)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -165,6 +165,20 @@ class TestPointPlotting:
         # last point == top of colorbar
         np.testing.assert_array_equal(point_colors[-1], cbar_colors[-1])
 
+    def test_subplots_norm(self):
+
+        cmap = matplotlib.cm.viridis_r
+        norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
+        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        actual_colors_orig = ax.collections[0].get_facecolors()
+        exp_colors = cmap(np.arange(10) / (20))
+        np.testing.assert_array_equal(exp_colors, actual_colors_orig)
+        fig, ax = plt.subplots()
+        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        actual_colors_sub = ax.collections[0].get_facecolors()
+        np.testing.assert_array_equal(actual_colors_orig[1],
+                                      actual_colors_sub[0])
+
     def test_empty_plot(self):
         s = GeoSeries([])
         with pytest.warns(UserWarning):
@@ -246,6 +260,20 @@ class TestLineStringPlotting:
         for ls in ax.collections[0].get_linestyles():
             assert ls[0] == exp_ls[0]
             assert ls[1] == exp_ls[1]
+
+    def test_subplots_norm(self):
+
+        cmap = matplotlib.cm.viridis_r
+        norm = matplotlib.colors.Normalize(vmin=0, vmax=20)
+        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        actual_colors_orig = ax.collections[0].get_edgecolors()
+        exp_colors = cmap(np.arange(10) / (20))
+        np.testing.assert_array_equal(exp_colors, actual_colors_orig)
+        fig, ax = plt.subplots()
+        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        actual_colors_sub = ax.collections[0].get_edgecolors()
+        np.testing.assert_array_equal(actual_colors_orig[1],
+                                      actual_colors_sub[0])
 
 
 class TestPolygonPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -345,6 +345,20 @@ class TestPolygonPlotting:
         expected_colors = [cmap(0), cmap(0), cmap(1), cmap(1)]
         _check_colors(4, ax.collections[0].get_facecolors(), expected_colors)
 
+    def test_subplots_norm(self):
+
+        cmap = matplotlib.cm.viridis_r
+        norm = matplotlib.colors.Normalize(vmin=0, vmax=10)
+        ax = self.df.plot(column='values', cmap=cmap, norm=norm)
+        actual_colors_orig = ax.collections[0].get_facecolors()
+        exp_colors = cmap(np.arange(2) / (10))
+        np.testing.assert_array_equal(exp_colors, actual_colors_orig)
+        fig, ax = plt.subplots()
+        self.df[1:].plot(column='values', ax=ax, norm=norm, cmap=cmap)
+        actual_colors_sub = ax.collections[0].get_facecolors()
+        np.testing.assert_array_equal(actual_colors_orig[1],
+                                      actual_colors_sub[0])
+
 
 class TestPolygonZPlotting:
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -432,7 +432,7 @@ class TestPolygonPlotting:
         # colors are repeated for all components within a MultiPolygon
         expected_colors = [cmap(0), cmap(0), cmap(1), cmap(1)]
         _check_colors(4, ax.collections[0].get_facecolors(), expected_colors)
-        
+
         ax = self.df2.plot(color=["r", "b"])
         # colors are repeated for all components within a MultiPolygon
         _check_colors(4, ax.collections[0].get_facecolors(), ["r", "r", "b", "b"])


### PR DESCRIPTION
Fixes #869

`norm` keyword currently doesn't persist for all subplots (see original issue). This behaviour should be fixed now.

Implements solution by @ImportanceOfBeingErnest outlined in the issue.