### PR TITLE
ENH: show_versions including GDAL, GEOS, PROJ

### DIFF
--- a/geopandas/tests/test_show_versions.py
+++ b/geopandas/tests/test_show_versions.py
@@ -20,7 +20,7 @@ def test_get_c_info():
     assert 'GDAL' in C_info
     assert 'GDAL dir' in C_info
     assert 'PROJ' in C_info
-    assert 'PROJ dir' in C_info
+    assert 'PROJ data dir' in C_info
 
 
 def test_get_deps_info():
@@ -29,7 +29,6 @@ def test_get_deps_info():
     assert 'geopandas' in deps_info
     assert 'pandas' in deps_info
     assert 'fiona' in deps_info
-    assert 'osgeo.gdal' in deps_info
     assert 'numpy' in deps_info
     assert 'shapely' in deps_info
     assert 'rtree' in deps_info
@@ -46,4 +45,5 @@ def test_show_versions(capsys):
     out, err = capsys.readouterr()
 
     assert 'python' in out
+    assert 'GEOS' in out
     assert 'geopandas' in out

--- a/geopandas/tests/test_show_versions.py
+++ b/geopandas/tests/test_show_versions.py
@@ -1,5 +1,6 @@
 from geopandas.tools._show_versions import _get_sys_info
 from geopandas.tools._show_versions import _get_deps_info
+from geopandas.tools._show_versions import _get_C_info
 from geopandas.tools._show_versions import show_versions
 
 
@@ -9,6 +10,17 @@ def test_get_sys_info():
     assert 'python' in sys_info
     assert 'executable' in sys_info
     assert 'machine' in sys_info
+
+
+def test_get_c_info():
+    C_info = _get_C_info()
+
+    assert 'GEOS' in C_info
+    assert 'GEOS lib' in C_info
+    assert 'GDAL' in C_info
+    assert 'GDAL dir' in C_info
+    assert 'PROJ' in C_info
+    assert 'PROJ dir' in C_info
 
 
 def test_get_deps_info():

--- a/geopandas/tools/_show_versions.py
+++ b/geopandas/tools/_show_versions.py
@@ -37,7 +37,7 @@ def _get_C_info():
             proj_dir = pyproj.datadir.get_data_dir()
         except DataDirError:
             proj_dir = None
-    except ImportError:
+    except Exception:
         proj = None
         proj_dir = None
 
@@ -45,7 +45,7 @@ def _get_C_info():
         import shapely._buildcfg
         geos = '{}.{}.{}'.format(*shapely._buildcfg.geos_version)
         geos_dir = shapely._buildcfg.geos_library_path
-    except ImportError:
+    except Exception:
         geos = None
         geos_dir = None
 
@@ -53,7 +53,7 @@ def _get_C_info():
         import fiona
         gdal = fiona.env.get_gdal_release_name()
         gdal_dir = fiona.env.GDALDataFinder().search()
-    except ImportError:
+    except Exception:
         gdal = None
         gdal_dir = None
 
@@ -63,7 +63,7 @@ def _get_C_info():
             ("GDAL", gdal),
             ("GDAL dir", gdal_dir),
             ("PROJ", proj),
-            ("PROJ dir", proj_dir)
+            ("PROJ data dir", proj_dir)
             ]
 
     return dict(blob)
@@ -89,8 +89,7 @@ def _get_deps_info():
         "mapclassify",
         "pysal",
         "geopy",
-        "psycopg2",
-        "descartes"
+        "psycopg2"
     ]
 
     def get_version(module):
@@ -106,9 +105,7 @@ def _get_deps_info():
                 mod = importlib.import_module(modname)
             ver = get_version(mod)
             deps_info[modname] = ver
-        except ImportError:
-            deps_info[modname] = None
-        except AttributeError:
+        except Exception:
             deps_info[modname] = None
 
     return deps_info

--- a/geopandas/tools/_show_versions.py
+++ b/geopandas/tools/_show_versions.py
@@ -29,28 +29,40 @@ def _get_C_info():
     c_info: dict
         system PROJ information
     """
-    import pyproj
-    from pyproj.exceptions import DataDirError
-    import shapely._buildcfg
-    import fiona
-
     try:
-        proj_dir = pyproj.datadir.get_data_dir()
-    except DataDirError:
+        import pyproj
+        from pyproj.exceptions import DataDirError
+        proj = pyproj.proj_version_str
+        try:
+            proj_dir = pyproj.datadir.get_data_dir()
+        except DataDirError:
+            proj_dir = None
+    except ImportError:
+        proj = None
         proj_dir = None
 
-    geos_dir = shapely._buildcfg.geos_library_path
+    try:
+        import shapely._buildcfg
+        geos = '{}.{}.{}'.format(*shapely._buildcfg.geos_version)
+        geos_dir = shapely._buildcfg.geos_library_path
+    except ImportError:
+        geos = None
+        geos_dir = None
 
-    gdal = fiona.env.get_gdal_release_name()
-    gdal_dir = fiona.env.GDALDataFinder().search()
+    try:
+        import fiona
+        gdal = fiona.env.get_gdal_release_name()
+        gdal_dir = fiona.env.GDALDataFinder().search()
+    except ImportError:
+        gdal = None
+        gdal_dir = None
 
-    geos = '{}.{}.{}'.format(*shapely._buildcfg.geos_version)
     blob = [
             ("GEOS", geos),
             ("GEOS lib", geos_dir),
             ("GDAL", gdal),
             ("GDAL dir", gdal_dir),
-            ("PROJ", pyproj.proj_version_str),
+            ("PROJ", proj),
             ("PROJ dir", proj_dir)
             ]
 

--- a/geopandas/tools/_show_versions.py
+++ b/geopandas/tools/_show_versions.py
@@ -22,6 +22,41 @@ def _get_sys_info():
     return dict(blob)
 
 
+def _get_C_info():
+    """Information on system PROJ, GDAL, GEOS
+    Returns
+    -------
+    c_info: dict
+        system PROJ information
+    """
+    import pyproj
+    from pyproj.exceptions import DataDirError
+    import shapely._buildcfg
+    import fiona
+
+    try:
+        proj_dir = pyproj.datadir.get_data_dir()
+    except DataDirError:
+        proj_dir = None
+
+    geos_dir = shapely._buildcfg.geos_library_path
+
+    gdal = fiona.env.get_gdal_release_name()
+    gdal_dir = fiona.env.GDALDataFinder().search()
+
+    geos = '{}.{}.{}'.format(*shapely._buildcfg.geos_version)
+    blob = [
+            ("GEOS", geos),
+            ("GEOS lib", geos_dir),
+            ("GDAL", gdal),
+            ("GDAL dir", gdal_dir),
+            ("PROJ", pyproj.proj_version_str),
+            ("PROJ dir", proj_dir)
+            ]
+
+    return dict(blob)
+
+
 def _get_deps_info():
     """Overview of the installed version of main dependencies
 
@@ -34,7 +69,6 @@ def _get_deps_info():
         "geopandas",
         "pandas",
         "fiona",
-        "osgeo.gdal",
         "numpy",
         "shapely",
         "rtree",
@@ -78,12 +112,17 @@ def show_versions():
     """
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()
+    proj_info = _get_C_info()
 
     maxlen = max(len(x) for x in deps_info)
     tpl = "{{k:<{maxlen}}}: {{stat}}".format(maxlen=maxlen)
     print("\nSYSTEM INFO")
     print("-----------")
     for k, stat in sys_info.items():
+        print(tpl.format(k=k, stat=stat))
+    print("\nGEOS, GDAL, PROJ INFO")
+    print("---------------------")
+    for k, stat in proj_info.items():
         print(tpl.format(k=k, stat=stat))
     print("\nPYTHON DEPENDENCIES")
     print("-------------------")


### PR DESCRIPTION
Closes #899 

Added info on GDAL, GEOS and PROJ to show_versions.

I have to admit that merge of #918 was a bit premature as I decided to extend it shortly after that. Nevermind. show_versions in this PR:

```
SYSTEM INFO
-----------
python     : 3.7.3 | packaged by conda-forge | (default, Jul  1 2019, 14:38:56)  [Clang 4.0.1 (tags/RELEASE_401/final)]
executable : /Users/martin/anaconda3/envs/guide/bin/python
machine    : Darwin-18.6.0-x86_64-i386-64bit

GEOS, GDAL, PROJ INFO
---------------------
GEOS       : 3.7.2
GEOS lib   : /Users/martin/anaconda3/envs/guide/lib/libgeos_c.dylib
GDAL       : 2.4.2
GDAL dir   : /Users/martin/anaconda3/envs/guide/share/gdal
PROJ       : 6.1.0
PROJ dir   : /Users/martin/anaconda3/envs/guide/share/proj

PYTHON DEPENDENCIES
-------------------
geopandas  : 0.5.0+40.g638768c
pandas     : 0.25.0
fiona      : 1.8.6
numpy      : 1.17.0
shapely    : 1.6.4.post2
rtree      : 0.8.3
pyproj     : 2.2.1
matplotlib : 3.1.1
mapclassify: 2.1.1
pysal      : 2.0.0
geopy      : 1.20.0
psycopg2   : None
descartes  : None
```

 