### PR TITLE
Use shapely repr instead of WKT in repr of GeometryArray

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -850,7 +850,9 @@ class GeometryArray(ExtensionArray):
             when ``boxed=False`` and :func:`str` is used when
             ``boxed=True``.
         """
-        return str
+        if boxed:
+            return str
+        return repr
 
     @classmethod
     def _concat_same_type(cls, to_concat):


### PR DESCRIPTION
Currently, the GeometryArray is not that useful if you have big (Multi)Polygons, because the default implementation does not do any truncation of the WKT strings.

Eg 

```
df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
df.geometry.array
```

gives a huge unusable repr. 

So therefore falling back to the shapely reprs (ala `<shapely.geometry.multipolygon.MultiPolygon object at 0x7f8abec050b8>`), until we have a better solution for truncating the strings, if we want that (the `Series/DataFrame` repr already does this automatically, so this is only for `GeometryArray`, so not super high priority)