### PR TITLE
ENH: pass legend_kwds to colorbar when relevant

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -78,7 +78,7 @@ However, the default appearance of the legend and plot axes may not be desirable
     world.plot(column='pop_est', ax=ax, legend=True, cax=cax)
 
 
-The following example plots the color bar below the map and adds a label.
+And the following example plots the color bar below the map and adds its label using ``legend_kwds``:
 
 .. ipython:: python
 
@@ -89,7 +89,7 @@ The following example plots the color bar below the map and adds a label.
     world.plot(column='pop_est',
                ax=ax,
                legend=True,
-               legend_kwds={'label': Population by Country,
+               legend_kwds={'label': "Population by Country",
                             'orientation': "horizontal"})
 
 

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -78,6 +78,21 @@ However, the default appearance of the legend and plot axes may not be desirable
     world.plot(column='pop_est', ax=ax, legend=True, cax=cax)
 
 
+The following example plots the color bar below the map and adds a label.
+
+.. ipython:: python
+
+    # Plot population estimates with an accurate legend
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(1, 1)
+    @savefig world_pop_est_horizontal.png
+    world.plot(column='pop_est',
+               ax=ax,
+               legend=True,
+               legend_kwds={'label': Population by Country,
+                            'orientation': "horizontal"})
+
+
 Choosing colors
 ~~~~~~~~~~~~~~~~
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -316,7 +316,8 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
 def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                    categorical=False, legend=False, scheme=None, k=5,
                    vmin=None, vmax=None, markersize=None, figsize=None,
-                   legend_kwds=None, classification_kwds=None, cbar_kwds=None, **style_kwds):
+                   legend_kwds=None, classification_kwds=None, cbar_kwds=None,
+                   **style_kwds):
     """
     Plot a GeoDataFrame.
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -376,8 +376,9 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         Size of the resulting matplotlib.figure.Figure. If the argument
         axes is given explicitly, figsize is ignored.
     legend_kwds : dict (default None)
-        Keyword arguments to pass to matplotlib.pyplot.legend(), respectively
-        matplotlib.pyplot.colorbar()
+        Keyword arguments to pass to matplotlib.pyplot.legend() in case of legend=True and
+        categorical=True), respectively matplotlib.pyplot.colorbar() in case of legend=True 
+        and categorical=False.
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -495,11 +495,11 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                               markersize=markersize, cmap=cmap,
                               **style_kwds)
 
-
-    if legend_kwds is None:
-        legend_kwds = {}
-
     if legend and not color:
+        
+        if legend_kwds is None:
+            legend_kwds = {}
+
         from matplotlib.lines import Line2D
         from matplotlib.colors import Normalize
         from matplotlib import cm

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -377,7 +377,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         axes is given explicitly, figsize is ignored.
     legend_kwds : dict (default None)
         Keyword arguments to pass to matplotlib.pyplot.legend() in case of legend=True and
-        categorical=True), respectively matplotlib.pyplot.colorbar() in case of legend=True 
+        categorical=True, respectively matplotlib.pyplot.colorbar() in case of legend=True 
         and categorical=False.
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -376,9 +376,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         Size of the resulting matplotlib.figure.Figure. If the argument
         axes is given explicitly, figsize is ignored.
     legend_kwds : dict (default None)
-        Keyword arguments to pass to matplotlib.pyplot.legend() in case of legend=True and
-        categorical=True, respectively matplotlib.pyplot.colorbar() in case of legend=True 
-        and categorical=False.
+        Keyword arguments to pass to matplotlib.pyplot.legend() or
+        matplotlib.pyplot.colorbar().
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -316,7 +316,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
 def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                    categorical=False, legend=False, scheme=None, k=5,
                    vmin=None, vmax=None, markersize=None, figsize=None,
-                   legend_kwds=None, classification_kwds=None, **style_kwds):
+                   legend_kwds=None, classification_kwds=None, cbar_kwds=None, **style_kwds):
     """
     Plot a GeoDataFrame.
 
@@ -379,6 +379,8 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         Keyword arguments to pass to ax.legend()
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
+    cbar_kwds : dict (default None)
+        Keyword arguments to pass to matplotlib.pyplot.colorbar()
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -484,10 +486,13 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         plot_linestring_collection(ax, lines, values[line_idx],
                                    vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
 
+    if cbar_kwds is None:
+        cbar_kwds = {}
+
     if cax is not None:
-        cbar_kwargs = {"cax": cax}
+        cbar_kwds.update({"cax": cax})
     else:
-        cbar_kwargs = {"ax": ax}
+        cbar_kwds.update({"ax": ax})
 
     # plot all Points in the same collection
     points = df.geometry[point_idx]
@@ -520,7 +525,7 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
             ax.legend(patches, categories, **legend_kwds)
         else:
             n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap, **cbar_kwargs)
+            ax.get_figure().colorbar(n_cmap, **cbar_kwds)
 
     plt.draw()
     return ax

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -316,8 +316,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
 def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                    categorical=False, legend=False, scheme=None, k=5,
                    vmin=None, vmax=None, markersize=None, figsize=None,
-                   legend_kwds=None, classification_kwds=None, cbar_kwds=None,
-                   **style_kwds):
+                   legend_kwds=None, classification_kwds=None, **style_kwds):
     """
     Plot a GeoDataFrame.
 
@@ -377,11 +376,10 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         Size of the resulting matplotlib.figure.Figure. If the argument
         axes is given explicitly, figsize is ignored.
     legend_kwds : dict (default None)
-        Keyword arguments to pass to ax.legend()
+        Keyword arguments to pass to matplotlib.pyplot.legend(), respectively
+        matplotlib.pyplot.colorbar()
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
-    cbar_kwds : dict (default None)
-        Keyword arguments to pass to matplotlib.pyplot.colorbar()
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -487,13 +485,6 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         plot_linestring_collection(ax, lines, values[line_idx],
                                    vmin=mn, vmax=mx, cmap=cmap, **style_kwds)
 
-    if cbar_kwds is None:
-        cbar_kwds = {}
-
-    if cax is not None:
-        cbar_kwds.update({"cax": cax})
-    else:
-        cbar_kwds.update({"ax": ax})
 
     # plot all Points in the same collection
     points = df.geometry[point_idx]
@@ -503,6 +494,10 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
         plot_point_collection(ax, points, values[point_idx], vmin=mn, vmax=mx,
                               markersize=markersize, cmap=cmap,
                               **style_kwds)
+
+
+    if legend_kwds is None:
+        legend_kwds = {}
 
     if legend and not color:
         from matplotlib.lines import Line2D
@@ -519,14 +514,19 @@ def plot_dataframe(df, column=None, cmap=None, color=None, ax=None, cax=None,
                            alpha=style_kwds.get('alpha', 1), markersize=10,
                            markerfacecolor=n_cmap.to_rgba(value),
                            markeredgewidth=0))
-            if legend_kwds is None:
-                legend_kwds = {}
+
             legend_kwds.setdefault('numpoints', 1)
             legend_kwds.setdefault('loc', 'best')
             ax.legend(patches, categories, **legend_kwds)
         else:
+
+            if cax is not None:
+                legend_kwds.setdefault("cax", cax)
+            else:
+                legend_kwds.setdefault("ax", ax)
+
             n_cmap.set_array([])
-            ax.get_figure().colorbar(n_cmap, **cbar_kwds)
+            ax.get_figure().colorbar(n_cmap, **legend_kwds)
 
     plt.draw()
     return ax

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -332,6 +332,21 @@ class TestPolygonPlotting:
                           legend_kwds={'frameon': False})
         assert ax.get_legend().get_frame_on() is False
 
+    def test_colorbar_kwargs(self):
+        # Test if kwargs are passed to colorbar
+        
+        label_txt = 'colorbar test'
+
+        ax = self.df.plot(column='values', categorical=False, legend=True,
+                          legend_kwds={'legend': label_txt})
+        
+        assert ax.get_figure().axes[1].get_ylabel() == label_txt
+
+        ax = self.df.plot(column='values', categorical=False, legend=True,
+                          legend_kwds={'legend': label_txt, "orientation": "horizontal"})
+    
+        assert ax.get_figure().axes[1].get_xlabel() == label_txt
+
     def test_multipolygons(self):
 
         # MultiPolygons

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -338,12 +338,12 @@ class TestPolygonPlotting:
         label_txt = 'colorbar test'
 
         ax = self.df.plot(column='values', categorical=False, legend=True,
-                          legend_kwds={'legend': label_txt})
+                          legend_kwds={'label': label_txt})
         
         assert ax.get_figure().axes[1].get_ylabel() == label_txt
 
         ax = self.df.plot(column='values', categorical=False, legend=True,
-                          legend_kwds={'legend': label_txt, "orientation": "horizontal"})
+                          legend_kwds={'label': label_txt, "orientation": "horizontal"})
     
         assert ax.get_figure().axes[1].get_xlabel() == label_txt
 


### PR DESCRIPTION
This PR exposes the kwargs of matplotlib.pyplot.colorbar to plot().  The following example demonstrates its use for horizontal colorbars located at the bottom.

```
from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
import geopandas as gp
import matplotlib.pyplot as plt

df = gp.read_file("g2g14vz.shp")


cmap = "inferno"

fig, (ax1, ax2) = plt.subplots(1, 2)

# With horizontal colorbar
divider = make_axes_locatable(ax1)
cax1 = divider.append_axes("bottom", size="5%", pad=0)

df.plot(column="AREA_HA", cmap=cmap, ax=ax1, cax=cax1, legend=True, cbar_kwds={"orientation": "horizontal"}, vmin=0, vmax=2000)

# With vertical colorbar
divider2 = make_axes_locatable(ax2)
cax2 = divider2.append_axes("bottom", size="5%", pad=0)

df.plot(column="AREA_HA", cmap=cmap, ax=ax2, cax=cax2, legend=True, vmin=0, vmax=2000)

plt.savefig("colorbar_test.png")
```
![colorbar_test](https://user-images.githubusercontent.com/259530/63091501-d2719180-bf5e-11e9-93c5-3933dec15bf6.png)
