### PR TITLE
CI: disable 27-latest-defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 
     # Python 2.7 and 3.6 test all supported Pandas versions
     - env: ENV_FILE="ci/travis/27-pd023.yaml"
-    - env: ENV_FILE="ci/travis/27-latest-defaults.yaml"
+    # - env: ENV_FILE="ci/travis/27-latest-defaults.yaml"
     - env: ENV_FILE="ci/travis/27-latest-conda-forge.yaml"
 
     - env: ENV_FILE="ci/travis/36-pd023.yaml"


### PR DESCRIPTION
Temporarily disabling `27-latest-defaults`. It currently fails, due to the error I was not able to track back (no idea what has changed), but which is out of our hands.

```
from urllib2 import urlopen as _urlopen    
url = ("https://raw.githubusercontent.com/geopandas/geopandas/master/examples/null_geom.geojson")       
_urlopen(url)
```

Fails with
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 429, in open
    response = self._open(req, data)
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 447, in _open
    '_open', req)
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 1241, in https_open
    context=self._context)
  File "/Users/martin/anaconda3/envs/test/lib/python2.7/urllib2.py", line 1198, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)>
```