### PR TITLE
REF: remove unnecessary fixes for older pandas, use pandas is_list_like

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -108,7 +108,7 @@ Additionally, the following methods are implemented:
 Methods of pandas ``Series`` objects are also available, although not
 all are applicable to geometric objects and some may return a
 ``Series`` rather than a ``GeoSeries`` result.  The methods
-``align()``, ``isnull()`` and ``fillna()`` have been
+``isna()`` and ``fillna()`` have been
 implemented specifically for ``GeoSeries`` and are expected to work
 correctly.
 

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -108,7 +108,7 @@ Additionally, the following methods are implemented:
 Methods of pandas ``Series`` objects are also available, although not
 all are applicable to geometric objects and some may return a
 ``Series`` rather than a ``GeoSeries`` result.  The methods
-``copy()``, ``align()``, ``isnull()`` and ``fillna()`` have been
+``align()``, ``isnull()`` and ``fillna()`` have been
 implemented specifically for ``GeoSeries`` and are expected to work
 correctly.
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -52,12 +52,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         column on GeoDataFrame.
     """
 
-    # XXX: This will no longer be necessary in pandas 0.17
-    _internal_names = ['_data', '_cacher', '_item_cache', '_cache',
-                       'is_copy', '_subtyp', '_index',
-                       '_default_kind', '_default_fill_value', '_metadata',
-                       '__array_struct__', '__array_interface__']
-
     _metadata = ['crs', '_geometry_column_name']
 
     _geometry_column_name = DEFAULT_GEO_COLUMN_NAME
@@ -90,13 +84,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
 
-    # Serialize metadata (will no longer be necessary in pandas 0.17+)
-    # See https://github.com/pydata/pandas/pull/10557
-    def __getstate__(self):
-        meta = dict((k, getattr(self, k, None)) for k in self._metadata)
-        return dict(_data=self._data, _typ=self._typ,
-                    _metadata=self._metadata, **meta)
-
     def __setattr__(self, attr, val):
         # have to special case geometry b/c pandas tries to use as column...
         if attr == 'geometry':
@@ -111,8 +98,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return self[self._geometry_column_name]
 
     def _set_geometry(self, col):
-        # TODO: Use pandas' core.common.is_list_like() here.
-        if not isinstance(col, (list, np.ndarray, Series)):
+        if not pd.api.types.is_list_like(col):
             raise ValueError("Must use a list-like to set the geometry"
                              " property")
         self.set_geometry(col, inplace=True)
@@ -586,25 +572,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
         return self
-
-    def copy(self, deep=True):
-        """
-        Make a copy of this GeoDataFrame object
-
-        Parameters
-        ----------
-        deep : boolean, default True
-            Make a deep copy, i.e. also copy data
-
-        Returns
-        -------
-        copy : GeoDataFrame
-        """
-        # FIXME: this will likely be unnecessary in pandas >= 0.13
-        data = self._data
-        if deep:
-            data = data.copy()
-        return GeoDataFrame(data).__finalize__(self)
 
     def plot(self, *args, **kwargs):
         """Generate a plot of the geometries in the ``GeoDataFrame``.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -253,23 +253,6 @@ class GeoSeries(GeoPandasBase, Series):
             object.__setattr__(self, name, getattr(other, name, None))
         return self
 
-    def copy(self, order='C'):
-        """
-        Make a copy of this GeoSeries object
-
-        Parameters
-        ----------
-        deep : boolean, default True
-            Make a deep copy, i.e. also copy data
-
-        Returns
-        -------
-        copy : GeoSeries
-        """
-        # FIXME: this will likely be unnecessary in pandas >= 0.13
-        return GeoSeries(self.values.copy(order), index=self.index,
-                      name=self.name).__finalize__(self)
-
     def isna(self):
         """
         Detect missing values.


### PR DESCRIPTION
I have cleaned code a bit by removing which were necessary for older pandas (<0.17). Everything seems to work without these pieces. I have also implemented `pd.api.types.is_list_like` in `_set_geometry` which I found as a TODO in the code during the cleaning. I can split it into two PRs, but it seems not necessary as all edits are basically keeping up with pandas development.

Closes #1070

