### PR TITLE
DOC: fix plotting in 'pandas to geopandas' example

### DIFF
--- a/examples/create_geopandas_from_pandas.py
+++ b/examples/create_geopandas_from_pandas.py
@@ -83,6 +83,9 @@ print(gdf.head())
 
 #################################################################################
 # Again, we can plot our ``GeoDataFrame``.
+ax = world[world.continent == 'South America'].plot(
+    color='white', edgecolor='black')
+
 gdf.plot(ax=ax, color='red')
 
 plt.show()


### PR DESCRIPTION
Fixes empty plot object being shown in example page for the documentation, introduced in PR #1105. See: https://geopandas.readthedocs.io/en/latest/gallery/create_geopandas_from_pandas.html#from-wkt-format