### PR TITLE
BUG: pass list-like colors to Multi- geometry

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -94,15 +94,12 @@ def plot_polygon_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
-        if None in values:
-            values = None
 
     # PatchCollection does not accept some kwargs.
     if "markersize" in kwargs:
         del kwargs["markersize"]
-
-    # color=None overwrites specified facecolor/edgecolor with default color
     if color is not None:
+        kwargs["color"] = color
         if pd.api.types.is_list_like(color):
             kwargs["color"] = [color[i] for i in multiindex]
         else:
@@ -158,8 +155,6 @@ def plot_linestring_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
-        if None in values:
-            values = None
 
     # LineCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -224,8 +219,6 @@ def plot_point_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
-        if None in values:
-            values = None
 
     x = [p.x for p in geoms]
     y = [p.y for p in geoms]
@@ -337,6 +330,8 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
         facecolor = style_kwds.pop("facecolor", None)
         if color is not None:
             facecolor = color
+        # if "edgecolor" not in style_kwds:
+        #     style_kwds["edgecolor"] = facecolor
         values_ = values[poly_idx] if cmap else None
         plot_polygon_collection(
             ax, polys, values_, facecolor=facecolor, cmap=cmap, **style_kwds

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -103,18 +103,17 @@ def plot_polygon_collection(
     if color is not None:
         if pd.api.types.is_list_like(color):
             _, colors = _flatten_multi_geoms(geoms, color)
-            kwargs['color'] = colors
+            kwargs["color"] = colors
         else:
-            kwargs['color'] = color
+            kwargs["color"] = color
     else:
-        for att in ['facecolor', 'edgecolor']:
+        for att in ["facecolor", "edgecolor"]:
             if att in kwargs:
                 if pd.api.types.is_list_like(kwargs[att]):
                     _, colors = _flatten_multi_geoms(geoms, kwargs[att])
                     kwargs[att] = colors
 
-    collection = PatchCollection([PolygonPatch(poly) for poly in geoms_],
-                                 **kwargs)
+    collection = PatchCollection([PolygonPatch(poly) for poly in geoms_], **kwargs)
 
     if values is not None:
         collection.set_array(np.asarray(values))
@@ -168,9 +167,9 @@ def plot_linestring_collection(
     if color is not None:
         if pd.api.types.is_list_like(color):
             _, colors = _flatten_multi_geoms(geoms, color)
-            kwargs['color'] = colors
+            kwargs["color"] = colors
         else:
-            kwargs['color'] = color
+            kwargs["color"] = color
 
     segments = [np.array(linestring)[:, :2] for linestring in geoms_]
     collection = LineCollection(segments, **kwargs)
@@ -238,8 +237,9 @@ def plot_point_collection(
             _, colors = _flatten_multi_geoms(geoms, color)
             color = colors
 
-    collection = ax.scatter(x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap,
-                            marker=marker, **kwargs)
+    collection = ax.scatter(
+        x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap, marker=marker, **kwargs
+    )
 
     return collection
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -91,9 +91,11 @@ def plot_polygon_collection(
         )
     from matplotlib.collections import PatchCollection
 
-    geoms_, values = _flatten_multi_geoms(geoms, values)
-    if None in values:
-        values = None
+    geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
+    if values is not None:
+        values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
 
     # PatchCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -102,18 +104,16 @@ def plot_polygon_collection(
     # color=None overwrites specified facecolor/edgecolor with default color
     if color is not None:
         if pd.api.types.is_list_like(color):
-            _, colors = _flatten_multi_geoms(geoms, color)
-            kwargs["color"] = colors
+            kwargs["color"] = [color[i] for i in multiindex]
         else:
             kwargs["color"] = color
     else:
         for att in ["facecolor", "edgecolor"]:
             if att in kwargs:
                 if pd.api.types.is_list_like(kwargs[att]):
-                    _, colors = _flatten_multi_geoms(geoms, kwargs[att])
-                    kwargs[att] = colors
+                    kwargs[att] = [kwargs[att][i] for i in multiindex]
 
-    collection = PatchCollection([PolygonPatch(poly) for poly in geoms_], **kwargs)
+    collection = PatchCollection([PolygonPatch(poly) for poly in geoms], **kwargs)
 
     if values is not None:
         collection.set_array(np.asarray(values))
@@ -155,9 +155,11 @@ def plot_linestring_collection(
     """
     from matplotlib.collections import LineCollection
 
-    geoms_, values = _flatten_multi_geoms(geoms, values)
-    if None in values:
-        values = None
+    geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
+    if values is not None:
+        values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
 
     # LineCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -166,12 +168,11 @@ def plot_linestring_collection(
     # color=None gives black instead of default color cycle
     if color is not None:
         if pd.api.types.is_list_like(color):
-            _, colors = _flatten_multi_geoms(geoms, color)
-            kwargs["color"] = colors
+            kwargs["color"] = [color[i] for i in multiindex]
         else:
             kwargs["color"] = color
 
-    segments = [np.array(linestring)[:, :2] for linestring in geoms_]
+    segments = [np.array(linestring)[:, :2] for linestring in geoms]
     collection = LineCollection(segments, **kwargs)
 
     if values is not None:
@@ -220,11 +221,14 @@ def plot_point_collection(
     if values is not None and color is not None:
         raise ValueError("Can only specify one of 'values' and 'color' kwargs")
 
-    geoms_, values = _flatten_multi_geoms(geoms, values)
-    if None in values:
-        values = None
-    x = [p.x for p in geoms_]
-    y = [p.y for p in geoms_]
+    geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
+    if values is not None:
+        values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
+
+    x = [p.x for p in geoms]
+    y = [p.y for p in geoms]
 
     # matplotlib 1.4 does not support c=None, and < 2.0 does not support s=None
     if values is not None:
@@ -234,8 +238,7 @@ def plot_point_collection(
 
     if color is not None:
         if pd.api.types.is_list_like(color):
-            _, colors = _flatten_multi_geoms(geoms, color)
-            color = colors
+            color = [color[i] for i in multiindex]
 
     collection = ax.scatter(
         x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap, marker=marker, **kwargs

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -164,8 +164,6 @@ def plot_linestring_collection(ax, geoms, values=None, color=None,
     if color is not None:
         if pd.api.types.is_list_like(color):
             _, colors = _flatten_multi_geoms(geoms, color)
-            if None in colors:
-                colors = None
             kwargs['color'] = colors
         else:
             kwargs['color'] = color
@@ -225,8 +223,6 @@ def plot_point_collection(ax, geoms, values=None, color=None,
     if color is not None:
         if pd.api.types.is_list_like(color):
             _, colors = _flatten_multi_geoms(geoms, color)
-            if None in colors:
-                colors = None
             color = colors
 
     collection = ax.scatter(x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap,

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -94,8 +94,6 @@ def plot_polygon_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = np.take(values, multiindex)
-        if None in values:
-            values = None
 
     # PatchCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -157,8 +155,6 @@ def plot_linestring_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = np.take(values, multiindex)
-        if None in values:
-            values = None
 
     # LineCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -223,8 +219,6 @@ def plot_point_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = np.take(values, multiindex)
-        if None in values:
-            values = None
 
     x = [p.x for p in geoms]
     y = [p.y for p in geoms]

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -93,7 +93,7 @@ def plot_polygon_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = [values[i] for i in multiindex]
+        values = np.take(values, multiindex)
         if None in values:
             values = None
 
@@ -103,14 +103,14 @@ def plot_polygon_collection(
     if color is not None:
         kwargs["color"] = color
         if pd.api.types.is_list_like(color):
-            kwargs["color"] = [color[i] for i in multiindex]
+            kwargs["color"] = np.take(color, multiindex)
         else:
             kwargs["color"] = color
     else:
         for att in ["facecolor", "edgecolor"]:
             if att in kwargs:
                 if pd.api.types.is_list_like(kwargs[att]):
-                    kwargs[att] = [kwargs[att][i] for i in multiindex]
+                    kwargs[att] = np.take(kwargs[att], multiindex)
 
     collection = PatchCollection([PolygonPatch(poly) for poly in geoms], **kwargs)
 
@@ -156,7 +156,7 @@ def plot_linestring_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = [values[i] for i in multiindex]
+        values = np.take(values, multiindex)
         if None in values:
             values = None
 
@@ -167,7 +167,7 @@ def plot_linestring_collection(
     # color=None gives black instead of default color cycle
     if color is not None:
         if pd.api.types.is_list_like(color):
-            kwargs["color"] = [color[i] for i in multiindex]
+            kwargs["color"] = np.take(color, multiindex)
         else:
             kwargs["color"] = color
 
@@ -222,7 +222,7 @@ def plot_point_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = [values[i] for i in multiindex]
+        values = np.take(values, multiindex)
         if None in values:
             values = None
 
@@ -237,7 +237,7 @@ def plot_point_collection(
 
     if color is not None:
         if pd.api.types.is_list_like(color):
-            color = [color[i] for i in multiindex]
+            color = np.take(color, multiindex)
 
     collection = ax.scatter(
         x, y, color=color, vmin=vmin, vmax=vmax, cmap=cmap, marker=marker, **kwargs
@@ -336,8 +336,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
         facecolor = style_kwds.pop("facecolor", None)
         if color is not None:
             facecolor = color
-        # if "edgecolor" not in style_kwds:
-        #     style_kwds["edgecolor"] = facecolor
+
         values_ = values[poly_idx] if cmap else None
         plot_polygon_collection(
             ax, polys, values_, facecolor=facecolor, cmap=cmap, **style_kwds

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -94,6 +94,8 @@ def plot_polygon_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
 
     # PatchCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -155,6 +157,8 @@ def plot_linestring_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
 
     # LineCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -219,6 +223,8 @@ def plot_point_collection(
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
         values = [values[i] for i in multiindex]
+        if None in values:
+            values = None
 
     x = [p.x for p in geoms]
     y = [p.y for p in geoms]

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -712,6 +712,12 @@ class TestPlotCollections:
         _check_colors(self.N, coll.get_edgecolor(), ["g"] * self.N)
         ax.cla()
 
+        # default: color can be passed as a list
+        coll = plot_polygon_collection(ax, self.polygons, color=["g", "b", "r"])
+        _check_colors(self.N, coll.get_facecolor(), ["g", "b", "r"])
+        _check_colors(self.N, coll.get_edgecolor(), ["g", "b", "r"])
+        ax.cla()
+
         # only setting facecolor keeps default for edgecolor
         coll = plot_polygon_collection(ax, self.polygons, facecolor="g")
         _check_colors(self.N, coll.get_facecolor(), ["g"] * self.N)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -197,10 +197,9 @@ class TestPointPlotting:
         expected_colors = [cmap(0)] * self.N + [cmap(1)] * self.N
         _check_colors(2, ax.collections[0].get_facecolors(), expected_colors)
 
-        ax = self.df2.plot(color=['r', 'b'])
+        ax = self.df2.plot(color=["r", "b"])
         # colors are repeated for all components within a MultiPolygon
-        _check_colors(2, ax.collections[0].get_facecolors(),
-                      ['r'] * 10 + ['b'] * 10)
+        _check_colors(2, ax.collections[0].get_facecolors(), ["r"] * 10 + ["b"] * 10)
 
 
 class TestPointZPlotting:
@@ -225,10 +224,11 @@ class TestLineStringPlotting:
         )
         self.df = GeoDataFrame({"geometry": self.lines, "values": values})
 
-        multiline1 = MultiLineString(self.lines.loc['A':'B'].values)
-        multiline2 = MultiLineString(self.lines.loc['C':'D'].values)
-        self.df2 = GeoDataFrame({'geometry': [multiline1, multiline2],
-                                 'values': [0, 1]})
+        multiline1 = MultiLineString(self.lines.loc["A":"B"].values)
+        multiline2 = MultiLineString(self.lines.loc["C":"D"].values)
+        self.df2 = GeoDataFrame(
+            {"geometry": [multiline1, multiline2], "values": [0, 1]}
+        )
 
     def test_single_color(self):
 
@@ -269,18 +269,18 @@ class TestLineStringPlotting:
         # MultiLineStrings
         ax = self.df2.plot()
         assert len(ax.collections[0].get_paths()) == 4
-        _check_colors(4, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR]*4)
+        _check_colors(4, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR] * 4)
 
-        ax = self.df2.plot('values')
+        ax = self.df2.plot("values")
         cmap = plt.get_cmap(lut=2)
         # colors are repeated for all components within a MultiLineString
         expected_colors = [cmap(0), cmap(0), cmap(1), cmap(1)]
         _check_colors(4, ax.collections[0].get_facecolors(), expected_colors)
 
-        ax = self.df2.plot(color=['r', 'b'])
+        ax = self.df2.plot(color=["r", "b"])
         # colors are repeated for all components within a MultiLineString
-        _check_colors(4, ax.collections[0].get_facecolors(),
-                      ['r', 'r', 'b', 'b'])
+        _check_colors(4, ax.collections[0].get_facecolors(), ["r", "r", "b", "b"])
+
 
 class TestPolygonPlotting:
     def setup_method(self):
@@ -407,10 +407,9 @@ class TestPolygonPlotting:
         expected_colors = [cmap(0), cmap(0), cmap(1), cmap(1)]
         _check_colors(4, ax.collections[0].get_facecolors(), expected_colors)
 
-        ax = self.df2.plot(color=['r', 'b'])
+        ax = self.df2.plot(color=["r", "b"])
         # colors are repeated for all components within a MultiPolygon
-        _check_colors(4, ax.collections[0].get_facecolors(),
-                      ['r', 'r', 'b', 'b'])
+        _check_colors(4, ax.collections[0].get_facecolors(), ["r", "r", "b", "b"])
 
 
 class TestPolygonZPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -186,7 +186,7 @@ class TestPointPlotting:
 
         # MultiPoints
         ax = self.df2.plot()
-        _check_colors(1, ax.collections[0].get_facecolors(),
+        _check_colors(4, ax.collections[0].get_facecolors(),
                       [MPL_DFT_COLOR] * 4)
 
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -624,6 +624,12 @@ class TestPlotCollections:
         # edgecolor depends on matplotlib version
         # _check_colors(self.N, coll.get_edgecolors(), expected_colors)
 
+        # handle None
+        coll = plot_point_collection(ax, self.points, [0, None, 3])
+        fig.canvas.draw_idle()
+        _check_colors(self.N, coll.get_facecolors(), [MPL_DFT_COLOR] * self.N)
+        ax.cla()
+
     def test_linestrings(self):
         from geopandas.plotting import plot_linestring_collection
         from matplotlib.collections import LineCollection
@@ -689,6 +695,12 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         expected_colors = cmap([0])
         _check_colors(self.N, coll.get_color(), expected_colors)
+        ax.cla()
+
+        # handle None
+        coll = plot_linestring_collection(ax, self.lines, [0, None, 3])
+        fig.canvas.draw_idle()
+        _check_colors(self.N, coll.get_color(), [MPL_DFT_COLOR] * self.N)
         ax.cla()
 
     def test_polygons(self):
@@ -768,6 +780,12 @@ class TestPlotCollections:
         exp_colors = cmap(np.arange(self.N) / (self.N - 1))
         _check_colors(self.N, coll.get_facecolor(), exp_colors)
         _check_colors(self.N, coll.get_edgecolor(), ["g"] * self.N)
+        ax.cla()
+
+        # handle None
+        coll = plot_polygon_collection(ax, self.polygons, [0, None, 3])
+        fig.canvas.draw_idle()
+        _check_colors(self.N, coll.get_facecolor(), [MPL_DFT_COLOR] * self.N)
         ax.cla()
 
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -624,12 +624,6 @@ class TestPlotCollections:
         # edgecolor depends on matplotlib version
         # _check_colors(self.N, coll.get_edgecolors(), expected_colors)
 
-        # handle None
-        coll = plot_point_collection(ax, self.points, [0, None, 3])
-        fig.canvas.draw_idle()
-        _check_colors(self.N, coll.get_facecolors(), [MPL_DFT_COLOR] * self.N)
-        ax.cla()
-
     def test_linestrings(self):
         from geopandas.plotting import plot_linestring_collection
         from matplotlib.collections import LineCollection
@@ -695,12 +689,6 @@ class TestPlotCollections:
         cmap = plt.get_cmap()
         expected_colors = cmap([0])
         _check_colors(self.N, coll.get_color(), expected_colors)
-        ax.cla()
-
-        # handle None
-        coll = plot_linestring_collection(ax, self.lines, [0, None, 3])
-        fig.canvas.draw_idle()
-        _check_colors(self.N, coll.get_color(), [MPL_DFT_COLOR] * self.N)
         ax.cla()
 
     def test_polygons(self):
@@ -780,12 +768,6 @@ class TestPlotCollections:
         exp_colors = cmap(np.arange(self.N) / (self.N - 1))
         _check_colors(self.N, coll.get_facecolor(), exp_colors)
         _check_colors(self.N, coll.get_edgecolor(), ["g"] * self.N)
-        ax.cla()
-
-        # handle None
-        coll = plot_polygon_collection(ax, self.polygons, [0, None, 3])
-        fig.canvas.draw_idle()
-        _check_colors(self.N, coll.get_facecolor(), [MPL_DFT_COLOR] * self.N)
         ax.cla()
 
 


### PR DESCRIPTION
As reported earlier, passing a list-like of colors to gdf.plot() will not match rows if there are multipart geometries. That should be fixed now. 

Fixes #1075, fixes #730