### PR TITLE
Don't convert to absolute path in to_file to preserve VFS paths

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,4 +1,3 @@
-import os
 from distutils.version import LooseVersion
 
 import fiona
@@ -36,14 +35,6 @@ def _is_url(url):
     try:
         return parse_url(url).scheme in _VALID_URLS
     except:
-        return False
-
-
-def _is_vsi(url):
-    """Check if a filepath/url is using a fiona vsi scheme."""
-    try:
-        return fiona.vfs.valid_vsi(parse_url(url).scheme)
-    except AttributeError:
         return False
 
 
@@ -133,8 +124,6 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None,
     """
     if schema is None:
         schema = infer_schema(df)
-    if not _is_vsi(filename):
-        filename = os.path.abspath(os.path.expanduser(filename))
     with fiona_env():
         with fiona.open(filename, 'w', driver=driver, crs=df.crs,
                         schema=schema, **kwargs) as colxn:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -39,6 +39,14 @@ def _is_url(url):
         return False
 
 
+def _is_vsi(url):
+    """Check if a filepath/url is using a fiona vsi scheme."""
+    try:
+        return fiona.vfs.valid_vsi(parse_url(url).scheme)
+    except:
+        return False
+
+
 def read_file(filename, bbox=None, **kwargs):
     """
     Returns a GeoDataFrame from a file or URL.
@@ -121,10 +129,12 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None,
 
     The *kwargs* are passed to fiona.open and can be used to write
     to multi-layer data, store data within archives (zip files), etc.
+    The path may specify a fiona VSI scheme.
     """
     if schema is None:
         schema = infer_schema(df)
-    filename = os.path.abspath(os.path.expanduser(filename))
+    if not _is_vsi(filename):
+        filename = os.path.abspath(os.path.expanduser(filename))
     with fiona_env():
         with fiona.open(filename, 'w', driver=driver, crs=df.crs,
                         schema=schema, **kwargs) as colxn:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,5 +1,4 @@
 from distutils.version import LooseVersion
-import os
 
 import numpy as np
 import six

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -43,7 +43,7 @@ def _is_vsi(url):
     """Check if a filepath/url is using a fiona vsi scheme."""
     try:
         return fiona.vfs.valid_vsi(parse_url(url).scheme)
-    except:
+    except AttributeError:
         return False
 
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from collections import OrderedDict
 import datetime
 from distutils.version import LooseVersion
-import pkg_resources
 import os
 import sys
 
@@ -14,7 +13,7 @@ from shapely.geometry import Point, Polygon, box
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
-from geopandas.io.file import fiona_env, _is_vsi
+from geopandas.io.file import fiona_env
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
@@ -275,20 +274,3 @@ def test_read_file_empty_shapefile(tmpdir):
     empty = read_file(fname)
     assert isinstance(empty, geopandas.GeoDataFrame)
     assert all(empty.columns == ['A', 'Z', 'geometry'])
-
-# -----------------------------------------------------------------------------
-# utility tests
-# -----------------------------------------------------------------------------
-
-
-dist = pkg_resources.get_distribution('fiona')
-fiona_version = pkg_resources.parse_version(dist.version)
-@pytest.mark.skipif(
-    fiona_version < pkg_resources.parse_version('1.8.0'),
-    reason="Fiona VSI check not enabled for version < 1.8",
-)
-def test_vsi_check():
-    assert _is_vsi('https://test/path')
-    assert _is_vsi('zip+s3://test/path')
-    assert not _is_vsi('zip+s33://test/path')
-    assert not _is_vsi('tarr://test/path')

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from collections import OrderedDict
 import datetime
 from distutils.version import LooseVersion
+import pkg_resources
 import os
 import sys
 
@@ -280,6 +281,12 @@ def test_read_file_empty_shapefile(tmpdir):
 # -----------------------------------------------------------------------------
 
 
+dist = pkg_resources.get_distribution('fiona')
+fiona_version = pkg_resources.parse_version(dist.version)
+@pytest.mark.skipif(
+    fiona_version < pkg_resources.parse_version('1.8.0'),
+    reason="Fiona VSI check not enabled for version < 1.8",
+)
 def test_vsi_check():
     assert _is_vsi('https://test/path')
     assert _is_vsi('zip+s3://test/path')

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -13,7 +13,7 @@ from shapely.geometry import Point, Polygon, box
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
-from geopandas.io.file import fiona_env
+from geopandas.io.file import fiona_env, _is_vsi
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
@@ -274,3 +274,14 @@ def test_read_file_empty_shapefile(tmpdir):
     empty = read_file(fname)
     assert isinstance(empty, geopandas.GeoDataFrame)
     assert all(empty.columns == ['A', 'Z', 'geometry'])
+
+# -----------------------------------------------------------------------------
+# utility tests
+# -----------------------------------------------------------------------------
+
+
+def test_vsi_check():
+    assert _is_vsi('https://test/path')
+    assert _is_vsi('zip+s3://test/path')
+    assert not _is_vsi('zip+s33://test/path')
+    assert not _is_vsi('tarr://test/path')


### PR DESCRIPTION
Fixes #1118.

I tried to add a better test, but couldn't come up with anything that didn't require cloud storage credentials in the test suite (the `zip` and `tar` VSIs don't support output like this, apparently). So I've settled for testing that the utility works as expected, and verified locally that this allows, e.g., writing GeoJSON to s3.