### PR TITLE
BUG: fix sjoin with empty geometry

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -106,7 +106,7 @@ def sjoin(
     # get rtree spatial index
     if tree_idx_right:
         idxmatch = left_df.geometry.apply(lambda x: x.bounds).apply(
-            lambda x: list(tree_idx.intersection(x))
+            lambda x: list(tree_idx.intersection(x)) if not x == () else []
         )
         idxmatch = idxmatch[idxmatch.apply(len) > 0]
         # indexes of overlapping boundaries
@@ -116,7 +116,7 @@ def sjoin(
     else:
         # tree_idx_df == 'left'
         idxmatch = right_df.geometry.apply(lambda x: x.bounds).apply(
-            lambda x: list(tree_idx.intersection(x))
+            lambda x: list(tree_idx.intersection(x)) if not x == () else []
         )
         idxmatch = idxmatch[idxmatch.apply(len) > 0]
         if idxmatch.shape[0] > 0:

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -319,7 +319,8 @@ class TestSpatialJoinNYBB:
         df = sjoin(self.pointdf, self.polydf, how="outer")
         assert df.shape == (21, 8)
 
-    def test_sjoin_empty(self):
+    def test_sjoin_empty_geometries(self):
+        # https://github.com/geopandas/geopandas/issues/944
         empty = GeoDataFrame(geometry=[GeometryCollection()] * 3)
         df = sjoin(self.pointdf.append(empty), self.polydf, how="left")
         assert df.shape == (24, 8)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -319,6 +319,13 @@ class TestSpatialJoinNYBB:
         df = sjoin(self.pointdf, self.polydf, how="outer")
         assert df.shape == (21, 8)
 
+    def test_sjoin_empty(self):
+        empty = gpd.GeoDataFrame(geometry=[GeometryCollection()] * 3)
+        df = sjoin(self.pointdf.append(empty), self.polydf, how="left")
+        assert df.shape == (24, 8)
+        df2 = sjoin(self.pointdf, self.polydf.append(empty), how="left")
+        assert df2.shape == (21, 8)
+
 
 @pytest.mark.skipif(not base.HAS_SINDEX, reason="Rtree absent, skipping")
 class TestSpatialJoinNaturalEarth:

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import numpy as np
 import pandas as pd
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Point, Polygon, GeometryCollection
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, base, read_file, sjoin
@@ -320,7 +320,7 @@ class TestSpatialJoinNYBB:
         assert df.shape == (21, 8)
 
     def test_sjoin_empty(self):
-        empty = gpd.GeoDataFrame(geometry=[GeometryCollection()] * 3)
+        empty = GeoDataFrame(geometry=[GeometryCollection()] * 3)
         df = sjoin(self.pointdf.append(empty), self.polydf, how="left")
         assert df.shape == (24, 8)
         df2 = sjoin(self.pointdf, self.polydf.append(empty), how="left")


### PR DESCRIPTION
Fixes #944

Takes care of intersection with empty geometry. I will add tests for this specific case tomorrow.