### PR TITLE
Register dtype with Dask

### DIFF
--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -21,6 +21,8 @@ dependencies:
   - SQLalchemy
   - psycopg2
   - libspatialite
+  # dask
+  - dask
   - pip:
     - codecov
     - geopy

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -19,6 +19,7 @@ import pandas as pd  # noqa
 import numpy as np  # noqa
 
 from ._version import get_versions
+
 try:
     # register with dask
     from . import _dask  # noqa

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -19,6 +19,11 @@ import pandas as pd  # noqa
 import numpy as np  # noqa
 
 from ._version import get_versions
+try:
+    # register with dask
+    from . import _dask  # noqa
+except ImportError:
+    pass
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/geopandas/_dask.py
+++ b/geopandas/_dask.py
@@ -1,0 +1,16 @@
+from dask.dataframe.extensions import make_array_nonempty, make_scalar
+import numpy as np
+import shapely.geometry
+
+from .array import GeometryDtype, from_shapely
+
+
+@make_array_nonempty.register(GeometryDtype)
+def _(dtype):
+    a = np.array([shapely.geometry.Point(i, i) for i in range(2)], dtype=object)
+    return from_shapely(a)
+
+
+@make_scalar.register(GeometryDtype.type)
+def _(x):
+    return shapely.geometry.Point(0, 0)

--- a/geopandas/tests/test_dask.py
+++ b/geopandas/tests/test_dask.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+from geopandas.array import from_shapely
+from shapely.geometry import Point
+
+dd = pytest.importorskip("dask.dataframe")
+
+
+def test_from_pandas():
+    s = pd.Series(from_shapely([Point(0, 0), Point(1, 1)]))
+    ds = dd.from_pandas(s, 2)
+
+    assert ds.dtype == s.dtype
+    dd.utils.assert_eq(s, ds)
+
+    df = pd.DataFrame({'A': s})
+    ddf = dd.from_pandas(df, 2)
+    assert ddf.dtypes['A'] == s.dtype
+    dd.utils.assert_eq(df, ddf)

--- a/geopandas/tests/test_dask.py
+++ b/geopandas/tests/test_dask.py
@@ -13,7 +13,7 @@ def test_from_pandas():
     assert ds.dtype == s.dtype
     dd.utils.assert_eq(s, ds)
 
-    df = pd.DataFrame({'A': s})
+    df = pd.DataFrame({"A": s})
     ddf = dd.from_pandas(df, 2)
-    assert ddf.dtypes['A'] == s.dtype
+    assert ddf.dtypes["A"] == s.dtype
     dd.utils.assert_eq(df, ddf)


### PR DESCRIPTION
This let's you put geometries inside a dask dataframe.

```python
In [3]: import geopandas
wo
In [4]: import dask.dataframe as dd

In [5]: world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))

In [6]: ddf = dd.from_pandas(world, 2)

In [7]: ddf
Out[7]:
Dask DataFrame Structure:
              pop_est continent    name  iso_a3 gdp_md_est  geometry
npartitions=2
0               int64    object  object  object    float64  geometry
89                ...       ...     ...     ...        ...       ...
176               ...       ...     ...     ...        ...       ...
Dask Name: from_pandas, 2 tasks

In [8]: ddf['geometry']
Out[8]:
Dask Series Structure:
npartitions=2
0      geometry
89          ...
176         ...
Name: geometry, dtype: geometry
Dask Name: getitem, 4 tasks

In [9]: ddf['geometry'].head()
Out[9]:
0    MULTIPOLYGON (((180.00000 -16.06713, 180.00000...
1    POLYGON ((33.90371 -0.95000, 34.07262 -1.05982...
2    POLYGON ((-8.66559 27.65643, -8.66512 27.58948...
3    MULTIPOLYGON (((-122.84000 49.00000, -122.9742...
4    MULTIPOLYGON (((-122.84000 49.00000, -120.0000...
Name: geometry, dtype: geometry
```

xref #461. I don't think it can close it. There's an open API discussion

1. Adding a `.geo` accessor to DataFrame / Dask DataFrame (implementation wise, this is quite easy for pandas. For dask, things using map_partitions is easy. Something other operations may be trickier).
2. There may be value in using the spatial data to partition the dask dataframe.