### PR TITLE
ENH: support for missing data plotting

### DIFF
--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -121,7 +121,7 @@ In some cases one may want to plot data which contains missing values - for some
 .. ipython:: python
 
     import numpy as np
-    gdf.loc[np.random.choice(gdf.index, 40), 'pop_est'] = np.nan
+    world.loc[np.random.choice(world.index, 40), 'pop_est'] = np.nan
     @savefig missing_vals.png
     world.plot(column='pop_est');
 
@@ -137,6 +137,7 @@ However, passing ``missing_kwds`` one can specify the style and label of feature
         column="pop_est",
         legend=True,
         scheme="quantiles",
+        figsize=(15, 10),
         missing_kwds={
             "color": "lightgrey",
             "edgecolor": "red",

--- a/doc/source/mapping.rst
+++ b/doc/source/mapping.rst
@@ -113,6 +113,38 @@ The way color maps are scaled can also be manipulated with the ``scheme`` option
     world.plot(column='gdp_per_cap', cmap='OrRd', scheme='quantiles');
 
 
+Missing data
+~~~~~~~~~~~~
+
+In some cases one may want to plot data which contains missing values - for some features one simply does not know the value. Geopandas (from the version 0.7) by defaults ignores such features.
+
+.. ipython:: python
+
+    import numpy as np
+    gdf.loc[np.random.choice(gdf.index, 40), 'pop_est'] = np.nan
+    @savefig missing_vals.png
+    world.plot(column='pop_est');
+
+However, passing ``missing_kwds`` one can specify the style and label of features containing None or NaN.
+
+.. ipython:: python
+
+    @savefig missing_vals_grey.png
+    world.plot(column='pop_est', missing_kwds={'color': 'lightgrey'});
+
+    @savefig missing_vals_hatch.png
+    world.plot(
+        column="pop_est",
+        legend=True,
+        scheme="quantiles",
+        missing_kwds={
+            "color": "lightgrey",
+            "edgecolor": "red",
+            "hatch": "///",
+            "label": "Missing values",
+        },
+    );
+
 Maps with Layers
 -----------------
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -442,6 +442,9 @@ def plot_dataframe(
         matplotlib.pyplot.colorbar().
     classification_kwds : dict (default None)
         Keyword arguments to pass to mapclassify
+    missing_kwds : dict (default None)
+        Keyword arguments specifying color options (as style_kwds)
+        to be passed on to geometries with missing values.
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -517,9 +520,7 @@ def plot_dataframe(
     if values.dtype is np.dtype("O"):
         categorical = True
 
-    nan_idx = np.array(
-        [True if str(n) == "nan" or n is None else False for n in values]
-    )
+    nan_idx = pd.isna(values)
 
     # Define `values` as a Series
     if categorical:
@@ -536,18 +537,18 @@ def plot_dataframe(
         if "k" not in classification_kwds:
             classification_kwds["k"] = k
 
-        binning = _mapclassify_choro(
-            values[~np.isnan(values)], scheme, **classification_kwds
-        )
+        binning = _mapclassify_choro(values[~nan_idx], scheme, **classification_kwds)
         # set categorical to True for creating the legend
         categorical = True
-        binedges = [values[~np.isnan(values)].min()] + binning.bins.tolist()
+        binedges = [values[~nan_idx].min()] + binning.bins.tolist()
         categories = [
             "{0:.2f} - {1:.2f}".format(binedges[i], binedges[i + 1])
             for i in range(len(binedges) - 1)
         ]
         values = np.array(binning.yb)
 
+    # fill values with placeholder where were NaNs originally to map them properly
+    # (after removing them in categorical or scheme)
     if categorical:
         for n in np.where(nan_idx)[0]:
             values = np.insert(values, n, values[0])
@@ -563,40 +564,31 @@ def plot_dataframe(
     point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
 
     # plot all Polygons and all MultiPolygon components in the same collection
-    polys = df.geometry[poly_idx * np.invert(nan_idx)]
+    polys = df.geometry[poly_idx & np.invert(nan_idx)]
+    subset = values[poly_idx & np.invert(nan_idx)]
     if not polys.empty:
         plot_polygon_collection(
-            ax,
-            polys,
-            values[poly_idx * np.invert(nan_idx)],
-            vmin=mn,
-            vmax=mx,
-            cmap=cmap,
-            **style_kwds
+            ax, polys, subset, vmin=mn, vmax=mx, cmap=cmap, **style_kwds
         )
 
     # plot all LineStrings and MultiLineString components in same collection
-    lines = df.geometry[line_idx * np.invert(nan_idx)]
+    lines = df.geometry[line_idx & np.invert(nan_idx)]
+    subset = values[line_idx & np.invert(nan_idx)]
     if not lines.empty:
         plot_linestring_collection(
-            ax,
-            lines,
-            values[line_idx * np.invert(nan_idx)],
-            vmin=mn,
-            vmax=mx,
-            cmap=cmap,
-            **style_kwds
+            ax, lines, subset, vmin=mn, vmax=mx, cmap=cmap, **style_kwds
         )
 
     # plot all Points in the same collection
-    points = df.geometry[point_idx * np.invert(nan_idx)]
+    points = df.geometry[point_idx & np.invert(nan_idx)]
+    subset = values[point_idx & np.invert(nan_idx)]
     if not points.empty:
         if isinstance(markersize, np.ndarray):
-            markersize = markersize[point_idx * np.invert(nan_idx)]
+            markersize = markersize[point_idx & np.invert(nan_idx)]
         plot_point_collection(
             ax,
             points,
-            values[point_idx * np.invert(nan_idx)],
+            subset,
             vmin=mn,
             vmax=mx,
             markersize=markersize,
@@ -605,7 +597,14 @@ def plot_dataframe(
         )
 
     if missing_kwds is not None:
-        plot_series(df.geometry[nan_idx], ax=ax, **missing_kwds)
+        if color:
+            if "color" not in missing_kwds:
+                missing_kwds["color"] = color
+
+        merged_kwds = style_kwds.copy()
+        merged_kwds.update(missing_kwds)
+
+        plot_series(df.geometry[nan_idx], ax=ax, **merged_kwds)
 
     if legend and not color:
 
@@ -636,25 +635,24 @@ def plot_dataframe(
                     )
                 )
             if missing_kwds is not None:
-                if "color" in missing_kwds:
-                    missing_kwds["facecolor"] = missing_kwds["color"]
+                if "color" in merged_kwds:
+                    merged_kwds["facecolor"] = merged_kwds["color"]
                 patches.append(
                     Line2D(
                         [0],
                         [0],
                         linestyle="none",
                         marker="o",
-                        alpha=missing_kwds.get("alpha", 1),
+                        alpha=merged_kwds.get("alpha", 1),
                         markersize=10,
-                        markerfacecolor=missing_kwds.get("facecolor", None),
-                        markeredgecolor=missing_kwds.get("edgecolor", None),
-                        markeredgewidth=missing_kwds.get(
-                            "linewidth",
-                            1 if missing_kwds.get("edgecolor", False) else 0,
+                        markerfacecolor=merged_kwds.get("facecolor", None),
+                        markeredgecolor=merged_kwds.get("edgecolor", None),
+                        markeredgewidth=merged_kwds.get(
+                            "linewidth", 1 if merged_kwds.get("edgecolor", False) else 0
                         ),
                     )
                 )
-                categories.append(missing_kwds.get("label", "NaN"))
+                categories.append(merged_kwds.get("label", "NaN"))
             legend_kwds.setdefault("numpoints", 1)
             legend_kwds.setdefault("loc", "best")
             ax.legend(patches, categories, **legend_kwds)

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -596,7 +596,7 @@ def plot_dataframe(
         plot_point_collection(
             ax,
             points,
-            values[point_idx],
+            values[point_idx * np.invert(nan_idx)],
             vmin=mn,
             vmax=mx,
             markersize=markersize,

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -444,7 +444,9 @@ def plot_dataframe(
         Keyword arguments to pass to mapclassify
     missing_kwds : dict (default None)
         Keyword arguments specifying color options (as style_kwds)
-        to be passed on to geometries with missing values.
+        to be passed on to geometries with missing values in addition to
+        or overwriting other style kwds. If None, geometries with missing
+        values are not plotted.
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -254,11 +254,6 @@ class TestPointPlotting:
         leg_colors1 = ax.get_legend().axes.collections[1].get_facecolors()
         np.testing.assert_array_equal(point_colors[0], leg_colors[0])
         np.testing.assert_array_equal(nan_color[0], leg_colors1[0])
-        # ax = self.df.plot(column="values", categorical=True, legend=True)
-        # point_colors = ax.collections[0].get_facecolors()
-        # cbar_colors = ax.get_legend().axes.collections[0].get_facecolors()
-        # # first point == bottom of colorbar
-        # np.testing.assert_array_equal(point_colors[0], cbar_colors[0])
 
 
 class TestPointZPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -231,6 +231,35 @@ class TestPointPlotting:
         # colors are repeated for all components within a MultiPolygon
         _check_colors(2, ax.collections[0].get_facecolors(), ["r"] * 10 + ["b"] * 10)
 
+    def test_misssing(self):
+        self.df.loc[0, "values"] = np.nan
+        ax = self.df.plot("values")
+        cmap = plt.get_cmap()
+        expected_colors = cmap(np.arange(self.N - 1) / (self.N - 2))
+        _check_colors(self.N - 1, ax.collections[0].get_facecolors(), expected_colors)
+
+        ax = self.df.plot("values", missing_kwds={"color": "r"})
+        cmap = plt.get_cmap()
+        expected_colors = cmap(np.arange(self.N - 1) / (self.N - 2))
+        _check_colors(1, ax.collections[1].get_facecolors(), ["r"])
+        _check_colors(self.N - 1, ax.collections[0].get_facecolors(), expected_colors)
+
+        ax = self.df.plot(
+            "values", missing_kwds={"color": "r"}, categorical=True, legend=True
+        )
+        _check_colors(1, ax.collections[1].get_facecolors(), ["r"])
+        point_colors = ax.collections[0].get_facecolors()
+        nan_color = ax.collections[1].get_facecolors()
+        leg_colors = ax.get_legend().axes.collections[0].get_facecolors()
+        leg_colors1 = ax.get_legend().axes.collections[1].get_facecolors()
+        np.testing.assert_array_equal(point_colors[0], leg_colors[0])
+        np.testing.assert_array_equal(nan_color[0], leg_colors1[0])
+        # ax = self.df.plot(column="values", categorical=True, legend=True)
+        # point_colors = ax.collections[0].get_facecolors()
+        # cbar_colors = ax.get_legend().axes.collections[0].get_facecolors()
+        # # first point == bottom of colorbar
+        # np.testing.assert_array_equal(point_colors[0], cbar_colors[0])
+
 
 class TestPointZPlotting:
     def setup_method(self):


### PR DESCRIPTION
I have added support for missing data to the `plot_dataframe`. It does change the default behaviour because I believe that our current handling of missing data is wrong. 

It mirrors what QGIS does by default. Features with missing values are ignored as we do not know which style they should have. Currently we assign the first colour of cmap, but that is incorrect. You can set the style for missing values in newly introduced `missing_kwds`, including a label for the legend.

Examples of proposed behaviour are here https://gist.github.com/martinfleis/62d48a607d1cf4dc7d67841b3f3e8792.

I have not added tests and docs yet, as I want to make sure that we are okay with this change as it is not fully backward compatible (you get different plot). Unlike on master, mapclassify also ignores missing values, so e.g., `quantiles` are different (but correct, I'd say).

Questions to discuss:
- are we okay with ignoring missing values in the plot?
- are we okay with ignoring missing values in `scheme`? 
- how to include missing data legend alongside with colorbar?

Closes #695