### PR TITLE
BUG: spatial join error for MultiIndex

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -90,10 +90,26 @@ def sjoin(
     # and store references to the original indices, to be reaffixed later.
     # GH 352
     left_df = left_df.copy(deep=True)
-    left_df.index = left_df.index.rename(index_left)
+    try:
+        left_df_orig_index = left_df.index.name
+        left_df.index = left_df.index.rename(index_left)
+    except TypeError:
+        index_left = [
+            "index_%s" % lsuffix + str(l) for l, ix in enumerate(left_df.index.names)
+        ]
+        left_df_orig_index = left_df.index.names
+        left_df.index = left_df.index.rename(index_left)
     left_df = left_df.reset_index()
     right_df = right_df.copy(deep=True)
-    right_df.index = right_df.index.rename(index_right)
+    try:
+        right_df_orig_index = right_df.index.name
+        right_df.index = right_df.index.rename(index_right)
+    except TypeError:
+        index_right = [
+            "index_%s" % rsuffix + str(l) for l, ix in enumerate(right_df.index.names)
+        ]
+        right_df_orig_index = right_df.index.names
+        right_df.index = right_df.index.rename(index_right)
     right_df = right_df.reset_index()
 
     if op == "within":
@@ -178,7 +194,10 @@ def sjoin(
             suffixes=("_%s" % lsuffix, "_%s" % rsuffix),
         )
         joined = joined.set_index(index_left).drop(["_key_right"], axis=1)
-        joined.index.name = None
+        if isinstance(index_left, list):
+            joined.index.names = left_df_orig_index
+        else:
+            joined.index.name = left_df_orig_index
     elif how == "left":
         result = result.set_index("_key_left")
         joined = left_df.merge(
@@ -191,7 +210,10 @@ def sjoin(
             suffixes=("_%s" % lsuffix, "_%s" % rsuffix),
         )
         joined = joined.set_index(index_left).drop(["_key_right"], axis=1)
-        joined.index.name = None
+        if isinstance(index_left, list):
+            joined.index.names = left_df_orig_index
+        else:
+            joined.index.name = left_df_orig_index
     else:  # how == 'right':
         joined = (
             left_df.drop(left_df.geometry.name, axis=1)
@@ -206,5 +228,9 @@ def sjoin(
             .set_index(index_right)
         )
         joined = joined.drop(["_key_left", "_key_right"], axis=1)
+        if isinstance(index_right, list):
+            joined.index.names = right_df_orig_index
+        else:
+            joined.index.name = right_df_orig_index
 
     return joined

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -199,7 +199,6 @@ def sjoin(
             .set_index(index_left)
             .drop(["_key_right"], axis=1)
         )
-        joined = joined.set_index(index_left).drop(["_key_right"], axis=1)
         if isinstance(index_left, list):
             joined.index.names = left_index_name
         else:
@@ -219,7 +218,6 @@ def sjoin(
             .set_index(index_left)
             .drop(["_key_right"], axis=1)
         )
-        joined = joined.set_index(index_left).drop(["_key_right"], axis=1)
         if isinstance(index_left, list):
             joined.index.names = left_index_name
         else:
@@ -239,7 +237,6 @@ def sjoin(
             .set_index(index_right)
             .drop(["_key_left", "_key_right"], axis=1)
         )
-        joined = joined.drop(["_key_left", "_key_right"], axis=1)
         if isinstance(index_right, list):
             joined.index.names = right_index_name
         else:

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -100,7 +100,7 @@ def sjoin(
         left_index_name = left_df.index.names
         left_df.index = left_df.index.rename(index_left)
     left_df = left_df.reset_index()
-    
+
     right_df = right_df.copy(deep=True)
     try:
         right_index_name = right_df.index.name
@@ -244,6 +244,5 @@ def sjoin(
             joined.index.names = right_index_name
         else:
             joined.index.name = right_index_name
-
 
     return joined

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -40,6 +40,16 @@ def dfs(request):
         df1.index = ["a", "b", "c"]
         df2.index = ["d", "e", "f"]
 
+    if request.param == "named-index":
+        df1.index.name = "df1_ix"
+        df2.index.name = "df2_ix"
+
+    if request.param == "multi-index":
+        i1 = ["a", "b", "c"]
+        i2 = ["d", "e", "f"]
+        df1 = df1.set_index([i1, i2])
+        df2 = df2.set_index([i2, i1])
+
     # construction expected frames
     expected = {}
 
@@ -79,7 +89,11 @@ class TestSpatialJoin:
         with pytest.warns(UserWarning):
             sjoin(df1, df2)
 
-    @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
+    @pytest.mark.parametrize(
+        "dfs",
+        ["default-index", "string-index", "named-index", "multi-index"],
+        indirect=True,
+    )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
     def test_inner(self, op, dfs):
         index, df1, df2, expected = dfs
@@ -93,27 +107,54 @@ class TestSpatialJoin:
             exp[["index_left", "index_right"]] = exp[
                 ["index_left", "index_right"]
             ].astype("int64")
-        exp = exp.set_index("index_left")
-        exp.index.name = None
+        if index == "named-index":
+            exp[["df1_ix", "df2_ix"]] = exp[["df1_ix", "df2_ix"]].astype("int64")
+            exp = exp.set_index("df1_ix").rename(columns={"df2_ix": "index_right"})
+        if index in ["default-index", "string-index"]:
+            exp = exp.set_index("index_left")
+            exp.index.name = None
+        if index == "multi-index":
+            exp = exp.set_index(["level_0_x", "level_1_x"]).rename(
+                columns={"level_0_y": "index_right0", "level_1_y": "index_right1"}
+            )
+            exp.index.names = df1.index.names
 
         assert_frame_equal(res, exp)
 
-    @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
+    @pytest.mark.parametrize(
+        "dfs",
+        ["default-index", "string-index", "named-index", "multi-index"],
+        indirect=True,
+    )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
     def test_left(self, op, dfs):
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how="left", op=op)
 
-        exp = expected[op].dropna(subset=["index_left"]).copy()
+        if index in ["default-index", "string-index"]:
+            exp = expected[op].dropna(subset=["index_left"]).copy()
+        elif index == "named-index":
+            exp = expected[op].dropna(subset=["df1_ix"]).copy()
+        elif index == "multi-index":
+            exp = expected[op].dropna(subset=["level_0_x"]).copy()
         exp = exp.drop("geometry_y", axis=1).rename(columns={"geometry_x": "geometry"})
         exp["df1"] = exp["df1"].astype("int64")
         if index == "default-index":
             exp["index_left"] = exp["index_left"].astype("int64")
             # TODO: in result the dtype is object
             res["index_right"] = res["index_right"].astype(float)
-        exp = exp.set_index("index_left")
-        exp.index.name = None
+        if index == "named-index":
+            exp[["df1_ix"]] = exp[["df1_ix"]].astype("int64")
+            exp = exp.set_index("df1_ix").rename(columns={"df2_ix": "index_right"})
+        if index in ["default-index", "string-index"]:
+            exp = exp.set_index("index_left")
+            exp.index.name = None
+        if index == "multi-index":
+            exp = exp.set_index(["level_0_x", "level_1_x"]).rename(
+                columns={"level_0_y": "index_right0", "level_1_y": "index_right1"}
+            )
+            exp.index.names = df1.index.names
 
         assert_frame_equal(res, exp)
 
@@ -146,21 +187,40 @@ class TestSpatialJoin:
         with pytest.raises(ValueError, match="'right_df' should be GeoDataFrame"):
             sjoin(df1, df2.geometry)
 
-    @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
+    @pytest.mark.parametrize(
+        "dfs",
+        ["default-index", "string-index", "named-index", "multi-index"],
+        indirect=True,
+    )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
     def test_right(self, op, dfs):
         index, df1, df2, expected = dfs
 
         res = sjoin(df1, df2, how="right", op=op)
 
-        exp = expected[op].dropna(subset=["index_right"]).copy()
+        if index in ["default-index", "string-index"]:
+            exp = expected[op].dropna(subset=["index_right"]).copy()
+        elif index == "named-index":
+            exp = expected[op].dropna(subset=["df2_ix"]).copy()
+        elif index == "multi-index":
+            exp = expected[op].dropna(subset=["level_0_y"]).copy()
         exp = exp.drop("geometry_x", axis=1).rename(columns={"geometry_y": "geometry"})
         exp["df2"] = exp["df2"].astype("int64")
         if index == "default-index":
             exp["index_right"] = exp["index_right"].astype("int64")
             res["index_left"] = res["index_left"].astype(float)
-        exp = exp.set_index("index_right")
-        exp = exp.reindex(columns=res.columns)
+        if index == "named-index":
+            exp[["df2_ix"]] = exp[["df2_ix"]].astype("int64")
+            exp = exp.set_index("df2_ix").rename(columns={"df1_ix": "index_left"})
+        if index in ["default-index", "string-index"]:
+            exp = exp.set_index("index_right")
+            exp = exp.reindex(columns=res.columns)
+            exp.index.name = None
+        if index == "multi-index":
+            exp = exp.set_index(["level_0_y", "level_1_y"]).rename(
+                columns={"level_0_x": "index_left0", "level_1_x": "index_left1"}
+            )
+            exp.index.names = df2.index.names
 
         assert_frame_equal(res, exp, check_index_type=False)
 

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -94,7 +94,6 @@ class TestSpatialJoin:
         "dfs",
         ["default-index", "string-index", "named-index", "multi-index"],
         indirect=True,
-
     )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
     def test_inner(self, op, dfs):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -51,6 +51,14 @@ def dfs(request):
         df1 = df1.set_index([i1, i2])
         df2 = df2.set_index([i2, i1])
 
+    if request.param == "named-multi-index":
+        i1 = ["a", "b", "c"]
+        i2 = ["d", "e", "f"]
+        df1 = df1.set_index([i1, i2])
+        df2 = df2.set_index([i2, i1])
+        df1.index.names = ["df1_ix1", "df1_ix2"]
+        df2.index.names = ["df2_ix1", "df2_ix2"]
+
     # construction expected frames
     expected = {}
 
@@ -92,7 +100,13 @@ class TestSpatialJoin:
 
     @pytest.mark.parametrize(
         "dfs",
-        ["default-index", "string-index", "named-index", "multi-index"],
+        [
+            "default-index",
+            "string-index",
+            "named-index",
+            "multi-index",
+            "named-multi-index",
+        ],
         indirect=True,
     )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
@@ -119,12 +133,23 @@ class TestSpatialJoin:
                 columns={"level_0_y": "index_right0", "level_1_y": "index_right1"}
             )
             exp.index.names = df1.index.names
+        if index == "named-multi-index":
+            exp = exp.set_index(["df1_ix1", "df1_ix2"]).rename(
+                columns={"df2_ix1": "index_right0", "df2_ix2": "index_right1"}
+            )
+            exp.index.names = df1.index.names
 
         assert_frame_equal(res, exp)
 
     @pytest.mark.parametrize(
         "dfs",
-        ["default-index", "string-index", "named-index", "multi-index"],
+        [
+            "default-index",
+            "string-index",
+            "named-index",
+            "multi-index",
+            "named-multi-index",
+        ],
         indirect=True,
     )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
@@ -139,6 +164,8 @@ class TestSpatialJoin:
             exp = expected[op].dropna(subset=["df1_ix"]).copy()
         elif index == "multi-index":
             exp = expected[op].dropna(subset=["level_0_x"]).copy()
+        elif index == "named-multi-index":
+            exp = expected[op].dropna(subset=["df1_ix1"]).copy()
         exp = exp.drop("geometry_y", axis=1).rename(columns={"geometry_x": "geometry"})
         exp["df1"] = exp["df1"].astype("int64")
         if index == "default-index":
@@ -154,6 +181,11 @@ class TestSpatialJoin:
         if index == "multi-index":
             exp = exp.set_index(["level_0_x", "level_1_x"]).rename(
                 columns={"level_0_y": "index_right0", "level_1_y": "index_right1"}
+            )
+            exp.index.names = df1.index.names
+        if index == "named-multi-index":
+            exp = exp.set_index(["df1_ix1", "df1_ix2"]).rename(
+                columns={"df2_ix1": "index_right0", "df2_ix2": "index_right1"}
             )
             exp.index.names = df1.index.names
 
@@ -190,7 +222,13 @@ class TestSpatialJoin:
 
     @pytest.mark.parametrize(
         "dfs",
-        ["default-index", "string-index", "named-index", "multi-index"],
+        [
+            "default-index",
+            "string-index",
+            "named-index",
+            "multi-index",
+            "named-multi-index",
+        ],
         indirect=True,
     )
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
@@ -205,6 +243,8 @@ class TestSpatialJoin:
             exp = expected[op].dropna(subset=["df2_ix"]).copy()
         elif index == "multi-index":
             exp = expected[op].dropna(subset=["level_0_y"]).copy()
+        elif index == "named-multi-index":
+            exp = expected[op].dropna(subset=["df2_ix1"]).copy()
         exp = exp.drop("geometry_x", axis=1).rename(columns={"geometry_y": "geometry"})
         exp["df2"] = exp["df2"].astype("int64")
         if index == "default-index":
@@ -220,6 +260,11 @@ class TestSpatialJoin:
         if index == "multi-index":
             exp = exp.set_index(["level_0_y", "level_1_y"]).rename(
                 columns={"level_0_x": "index_left0", "level_1_x": "index_left1"}
+            )
+            exp.index.names = df2.index.names
+        if index == "named-multi-index":
+            exp = exp.set_index(["df2_ix1", "df2_ix2"]).rename(
+                columns={"df1_ix1": "index_left0", "df1_ix2": "index_left1"}
             )
             exp.index.names = df2.index.names
 


### PR DESCRIPTION
Fixes #1074 

Fixed missing support for MultiIndex in `sjoin`.

~As a bonus, `sjoin` now returns the name of the original index instead of None, so the index is preserved intact. In master we have hard-coded `joined.index.name = None` even though we claim than index of left (or right) df is preserved. So this is a slight change of behaviour, but it seems to be fixing what was initially intended but never implemented.~ merged in #1150 