### PR TITLE
BUG: Incorrect color for the legend in case of unique value

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -518,7 +518,7 @@ def plot_dataframe(
 
     if len(set(values[~np.isnan(values)])) == 1:
         categorical = True
-        
+
     # Define `values` as a Series
     if categorical:
         if cmap is None:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -516,6 +516,9 @@ def plot_dataframe(
     if values.dtype is np.dtype("O"):
         categorical = True
 
+    if len(set(values[~np.isnan(values)])) == 1:
+        categorical = True
+        
     # Define `values` as a Series
     if categorical:
         if cmap is None:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -516,9 +516,6 @@ def plot_dataframe(
     if values.dtype is np.dtype("O"):
         categorical = True
 
-    if len(set(values[~np.isnan(values)])) == 1:
-        categorical = True
-
     # Define `values` as a Series
     if categorical:
         if cmap is None:
@@ -597,6 +594,9 @@ def plot_dataframe(
         if not norm:
             norm = Normalize(vmin=mn, vmax=mx)
         n_cmap = cm.ScalarMappable(norm=norm, cmap=cmap)
+        if len(set(values[~np.isnan(values)])) == 1:
+            categorical = True
+            categories = list(set(values[~np.isnan(values)]))
         if categorical:
             patches = []
             for value, cat in enumerate(categories):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -193,6 +193,16 @@ class TestPointPlotting:
         # colorbar generated proper long transition
         assert cbar_colors.shape == (256, 4)
 
+        # specifying values with single value (GH1162)
+        self.df["one"] = 1
+        ax = self.df.plot(column="one", legend=True)
+        _check_colors(
+            self.N, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR] * self.N
+        )
+        point_colors = ax.collections[0].get_facecolors()
+        legend_colors = ax.get_legend().axes.collections[0].get_facecolors()
+        np.testing.assert_array_equal(point_colors, legend_colors)
+
     def test_subplots_norm(self):
         # colors of subplots are the same as for plot (norm is applied)
         cmap = matplotlib.cm.viridis_r

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -196,9 +196,6 @@ class TestPointPlotting:
         # specifying values with single value (GH1162)
         self.df["one"] = 1
         ax = self.df.plot(column="one", legend=True)
-        _check_colors(
-            self.N, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR] * self.N
-        )
         point_colors = ax.collections[0].get_facecolors()
         legend_colors = ax.get_legend().axes.collections[0].get_facecolors()
         np.testing.assert_array_equal(point_colors, legend_colors)


### PR DESCRIPTION
Fixes #1162 

Fixes incorrect legend. When there is only one value, there is no way to put correct colorbar (no way to set min/max). In that case, categorical legend is used instead. Used colormap is the same as before (as it would be categorical=False).

```py
N = 10
points = gpd.GeoSeries(Point(i, i) for i in range(N))
values = np.arange(N)
df = gpd.GeoDataFrame({"geometry": points, "values": values})
df['one'] = 6
df.plot('one', legend=True)
```

Current (wrong) behaviour:
![Unknown-5](https://user-images.githubusercontent.com/36797143/66847381-30c0ed80-ef6b-11e9-8a64-eb142e7e7b68.png)


Fixed behaviour:
![Unknown-4](https://user-images.githubusercontent.com/36797143/66847214-ed667f00-ef6a-11e9-8f7d-7e3520de9e9a.png)
