### PR TITLE
DOC: update data structure docs with links to classes/methods

### DIFF
--- a/doc/source/data_structures.rst
+++ b/doc/source/data_structures.rst
@@ -55,27 +55,27 @@ in :doc:`geometric manipulations <geometric_manipulations>`.
 
 Attributes
 ^^^^^^^^^^^^^^^
-* :attr:`~geopandas.GeoSeries.area`: shape area (units of projection -- see :doc:`projections <projections>`)
-* :attr:`~geopandas.GeoSeries.bounds`: tuple of max and min coordinates on each axis for each shape
-* :attr:`~geopandas.GeoSeries.total_bounds`: tuple of max and min coordinates on each axis for entire GeoSeries
-* :attr:`~geopandas.GeoSeries.geom_type`: type of geometry.
-* :attr:`~geopandas.GeoSeries.is_valid`: tests if coordinates make a shape that is reasonable geometric shape (`according to this <http://www.opengeospatial.org/standards/sfa>`_).
+* :attr:`~GeoSeries.area`: shape area (units of projection -- see :doc:`projections <projections>`)
+* :attr:`~GeoSeries.bounds`: tuple of max and min coordinates on each axis for each shape
+* :attr:`~GeoSeries.total_bounds`: tuple of max and min coordinates on each axis for entire GeoSeries
+* :attr:`~GeoSeries.geom_type`: type of geometry.
+* :attr:`~GeoSeries.is_valid`: tests if coordinates make a shape that is reasonable geometric shape (`according to this <http://www.opengeospatial.org/standards/sfa>`_).
 
 Basic Methods
 ^^^^^^^^^^^^^^
 
-* :meth:`~geopandas.GeoSeries.distance`: returns ``Series`` with minimum distance from each entry to ``other``
-* :attr:`~geopandas.GeoSeries.centroid`: returns :class:`GeoSeries` of centroids
-* :meth:`~geopandas.GeoSeries.representative_point`:  returns :class:`GeoSeries` of points that are guaranteed to be within each geometry. It does **NOT** return centroids.
-* :meth:`~geopandas.GeoSeries.to_crs`: change coordinate reference system. See :doc:`projections <projections>`
-* :meth:`~geopandas.GeoSeries.plot`: plot :class:`GeoSeries`. See :doc:`mapping <mapping>`.
+* :meth:`~GeoSeries.distance`: returns ``Series`` with minimum distance from each entry to ``other``
+* :attr:`~GeoSeries.centroid`: returns :class:`GeoSeries` of centroids
+* :meth:`~GeoSeries.representative_point`:  returns :class:`GeoSeries` of points that are guaranteed to be within each geometry. It does **NOT** return centroids.
+* :meth:`~GeoSeries.to_crs`: change coordinate reference system. See :doc:`projections <projections>`
+* :meth:`~GeoSeries.plot`: plot :class:`GeoSeries`. See :doc:`mapping <mapping>`.
 
 Relationship Tests
 ^^^^^^^^^^^^^^^^^^^
 
-* :meth:`~geopandas.GeoSeries.geom_almost_equals`: is shape almost the same as ``other`` (good when floating point precision issues make shapes slightly different)
-* :meth:`~geopandas.GeoSeries.contains`: is shape contained within ``other``
-* :meth:`~geopandas.GeoSeries.intersects`: does shape intersect ``other``
+* :meth:`~GeoSeries.geom_almost_equals`: is shape almost the same as ``other`` (good when floating point precision issues make shapes slightly different)
+* :meth:`~GeoSeries.contains`: is shape contained within ``other``
+* :meth:`~GeoSeries.intersects`: does shape intersect ``other``
 
 
 GeoDataFrame
@@ -85,7 +85,7 @@ A :class:`GeoDataFrame` is a tabular data structure that contains a :class:`GeoS
 
 The most important property of a :class:`GeoDataFrame` is that it always has one :class:`GeoSeries` column that holds a special status. This :class:`GeoSeries` is referred to as the :class:`GeoDataFrame`'s "geometry". When a spatial method is applied to a :class:`GeoDataFrame` (or a spatial attribute like ``area`` is called), this commands will always act on the "geometry" column.
 
-The "geometry" column -- no matter its name -- can be accessed through the :attr:`GeoDataFrame.geometry` attribute (``gdf.geometry``), and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name``.
+The "geometry" column -- no matter its name -- can be accessed through the :attr:`~GeoDataFrame.geometry` attribute (``gdf.geometry``), and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name``.
 
 A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the :meth:`GeoDataFrame.set_geometry` method.
 
@@ -129,7 +129,7 @@ Now, we create centroids and make it the geometry:
 
     gdf = gdf.rename(columns={'old_name': 'new_name'}).set_geometry('new_name')
 
-**Note 2:** Somewhat confusingly, by default when you use the ``read_file`` command, the column containing spatial objects from the file is named "geometry" by default, and will be set as the active geometry column. However, despite using the same term for the name of the column and the name of the special attribute that keeps track of the active column, they are distinct. You can easily shift the active geometry column to a different :class:`GeoSeries` with the :meth:`GeoDataFrame.set_geometry` command. Further, ``gdf.geometry`` will always return the active geometry column, *not* the column named ``geometry``. If you wish to call a column named "geometry", and a different column is the active geometry column, use ``gdf['geometry']``, not ``gdf.geometry``.
+**Note 2:** Somewhat confusingly, by default when you use the ``read_file`` command, the column containing spatial objects from the file is named "geometry" by default, and will be set as the active geometry column. However, despite using the same term for the name of the column and the name of the special attribute that keeps track of the active column, they are distinct. You can easily shift the active geometry column to a different :class:`GeoSeries` with the :meth:`~GeoDataFrame.set_geometry` command. Further, ``gdf.geometry`` will always return the active geometry column, *not* the column named ``geometry``. If you wish to call a column named "geometry", and a different column is the active geometry column, use ``gdf['geometry']``, not ``gdf.geometry``.
 
 Attributes and Methods
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/data_structures.rst
+++ b/doc/source/data_structures.rst
@@ -13,14 +13,14 @@
 Data Structures
 =========================================
 
-GeoPandas implements two main data structures, a ``GeoSeries`` and a
-``GeoDataFrame``.  These are subclasses of pandas ``Series`` and
+GeoPandas implements two main data structures, a :class:`GeoSeries` and a
+:class:`GeoDataFrame`.  These are subclasses of pandas ``Series`` and
 ``DataFrame``, respectively.
 
 GeoSeries
 ---------
 
-A ``GeoSeries`` is essentially a vector where each entry in the vector
+A :class:`GeoSeries` is essentially a vector where each entry in the vector
 is a set of shapes corresponding to one observation. An entry may consist
 of only one shape (like a single polygon) or multiple shapes that are
 meant to be thought of as one observation (like the many polygons that
@@ -32,20 +32,20 @@ make up the State of Hawaii or a country like Indonesia).
 * Lines / Multi-Lines
 * Polygons / Multi-Polygons
 
-Note that all entries in  a ``GeoSeries`` need not be of the same geometric type, although certain export operations will fail if this is not the case.
+Note that all entries in  a :class:`GeoSeries` need not be of the same geometric type, although certain export operations will fail if this is not the case.
 
 Overview of Attributes and Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``GeoSeries`` class implements nearly all of the attributes and
-methods of Shapely objects.  When applied to a ``GeoSeries``, they
+The :class:`GeoSeries` class implements nearly all of the attributes and
+methods of Shapely objects.  When applied to a :class:`GeoSeries`, they
 will apply elementwise to all geometries in the series.  Binary
-operations can be applied between two ``GeoSeries``, in which case the
+operations can be applied between two :class:`GeoSeries`, in which case the
 operation is carried out elementwise.  The two series will be aligned
 by matching indices.  Binary operations can also be applied to a
 single geometry, in which case the operation is carried out for each
 element of the series with that geometry.  In either case, a
-``Series`` or a ``GeoSeries`` will be returned, as appropriate.
+``Series`` or a :class:`GeoSeries` will be returned, as appropriate.
 
 A short summary of a few attributes and methods for GeoSeries is
 presented here, and a full list can be found in the :doc:`all attributes and methods page <reference>`.
@@ -55,39 +55,39 @@ in :doc:`geometric manipulations <geometric_manipulations>`.
 
 Attributes
 ^^^^^^^^^^^^^^^
-* ``area``: shape area (units of projection -- see :doc:`projections <projections>`)
-* ``bounds``: tuple of max and min coordinates on each axis for each shape
-* ``total_bounds``: tuple of max and min coordinates on each axis for entire GeoSeries
-* ``geom_type``: type of geometry.
-* ``is_valid``: tests if coordinates make a shape that is reasonable geometric shape (`according to this <http://www.opengeospatial.org/standards/sfa>`_).
+* :attr:`~geopandas.GeoSeries.area`: shape area (units of projection -- see :doc:`projections <projections>`)
+* :attr:`~geopandas.GeoSeries.bounds`: tuple of max and min coordinates on each axis for each shape
+* :attr:`~geopandas.GeoSeries.total_bounds`: tuple of max and min coordinates on each axis for entire GeoSeries
+* :attr:`~geopandas.GeoSeries.geom_type`: type of geometry.
+* :attr:`~geopandas.GeoSeries.is_valid`: tests if coordinates make a shape that is reasonable geometric shape (`according to this <http://www.opengeospatial.org/standards/sfa>`_).
 
 Basic Methods
 ^^^^^^^^^^^^^^
 
-* ``distance(other)``: returns ``Series`` with minimum distance from each entry to ``other``
-* ``centroid``: returns ``GeoSeries`` of centroids
-* ``representative_point()``:  returns ``GeoSeries`` of points that are guaranteed to be within each geometry. It does **NOT** return centroids.
-* ``to_crs()``: change coordinate reference system. See :doc:`projections <projections>`
-* ``plot()``: plot ``GeoSeries``. See :doc:`mapping <mapping>`.
+* :meth:`~geopandas.GeoSeries.distance`: returns ``Series`` with minimum distance from each entry to ``other``
+* :attr:`~geopandas.GeoSeries.centroid`: returns :class:`GeoSeries` of centroids
+* :meth:`~geopandas.GeoSeries.representative_point`:  returns :class:`GeoSeries` of points that are guaranteed to be within each geometry. It does **NOT** return centroids.
+* :meth:`~geopandas.GeoSeries.to_crs`: change coordinate reference system. See :doc:`projections <projections>`
+* :meth:`~geopandas.GeoSeries.plot`: plot :class:`GeoSeries`. See :doc:`mapping <mapping>`.
 
 Relationship Tests
 ^^^^^^^^^^^^^^^^^^^
 
-* ``geom_almost_equals(other)``: is shape almost the same as ``other`` (good when floating point precision issues make shapes slightly different)
-* ``contains(other)``: is shape contained within ``other``
-* ``intersects(other)``: does shape intersect ``other``
+* :meth:`~geopandas.GeoSeries.geom_almost_equals`: is shape almost the same as ``other`` (good when floating point precision issues make shapes slightly different)
+* :meth:`~geopandas.GeoSeries.contains`: is shape contained within ``other``
+* :meth:`~geopandas.GeoSeries.intersects`: does shape intersect ``other``
 
 
 GeoDataFrame
 ------------
 
-A ``GeoDataFrame`` is a tabular data structure that contains a ``GeoSeries``.
+A :class:`GeoDataFrame` is a tabular data structure that contains a :class:`GeoSeries`.
 
-The most important property of a ``GeoDataFrame`` is that it always has one ``GeoSeries`` column that holds a special status. This ``GeoSeries`` is referred to as the ``GeoDataFrame``'s "geometry". When a spatial method is applied to a ``GeoDataFrame`` (or a spatial attribute like ``area`` is called), this commands will always act on the "geometry" column.
+The most important property of a :class:`GeoDataFrame` is that it always has one :class:`GeoSeries` column that holds a special status. This :class:`GeoSeries` is referred to as the :class:`GeoDataFrame`'s "geometry". When a spatial method is applied to a :class:`GeoDataFrame` (or a spatial attribute like ``area`` is called), this commands will always act on the "geometry" column.
 
-The "geometry" column -- no matter its name -- can be accessed through the ``geometry`` attribute (``gdf.geometry``), and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name``.
+The "geometry" column -- no matter its name -- can be accessed through the :attr:`GeoDataFrame.geometry` attribute (``gdf.geometry``), and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name``.
 
-A ``GeoDataFrame`` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the ``set_geometry`` method.
+A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the :meth:`GeoDataFrame.set_geometry` method.
 
 An example using the ``worlds`` GeoDataFrame:
 
@@ -125,16 +125,16 @@ Now, we create centroids and make it the geometry:
     world.plot();
 
 
-**Note:** A ``GeoDataFrame`` keeps track of the active column by name, so if you rename the active geometry column, you must also reset the geometry::
+**Note:** A :class:`GeoDataFrame` keeps track of the active column by name, so if you rename the active geometry column, you must also reset the geometry::
 
     gdf = gdf.rename(columns={'old_name': 'new_name'}).set_geometry('new_name')
 
-**Note 2:** Somewhat confusingly, by default when you use the ``read_file`` command, the column containing spatial objects from the file is named "geometry" by default, and will be set as the active geometry column. However, despite using the same term for the name of the column and the name of the special attribute that keeps track of the active column, they are distinct. You can easily shift the active geometry column to a different ``GeoSeries`` with the ``set_geometry`` command. Further, ``gdf.geometry`` will always return the active geometry column, *not* the column named ``geometry``. If you wish to call a column named "geometry", and a different column is the active geometry column, use ``gdf['geometry']``, not ``gdf.geometry``.
+**Note 2:** Somewhat confusingly, by default when you use the ``read_file`` command, the column containing spatial objects from the file is named "geometry" by default, and will be set as the active geometry column. However, despite using the same term for the name of the column and the name of the special attribute that keeps track of the active column, they are distinct. You can easily shift the active geometry column to a different :class:`GeoSeries` with the :meth:`GeoDataFrame.set_geometry` command. Further, ``gdf.geometry`` will always return the active geometry column, *not* the column named ``geometry``. If you wish to call a column named "geometry", and a different column is the active geometry column, use ``gdf['geometry']``, not ``gdf.geometry``.
 
 Attributes and Methods
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Any of the attributes calls or methods described for a ``GeoSeries`` will work on a ``GeoDataFrame`` -- effectively, they are just applied to the "geometry" ``GeoSeries``.
+Any of the attributes calls or methods described for a :class:`GeoSeries` will work on a :class:`GeoDataFrame` -- effectively, they are just applied to the "geometry" :class:`GeoSeries`.
 
 However, ``GeoDataFrames`` also have a few extra methods for input and output which are described on the :doc:`Input and Output <io>` page and for geocoding with are described in :doc:`Geocoding <geocoding>`.
 
@@ -156,7 +156,7 @@ option to control:
     import geopandas
     geopandas.options
 
-The ``geopandas.options.display_precision` option can control the number of
+The ``geopandas.options.display_precision`` option can control the number of
 decimals to show in the display of coordinates in the geometry column. 
 In the ``world`` example of above, the default is to show 5 decimals for
 geographic coordinates:

--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -134,6 +134,8 @@ Currently, the following methods are implemented for a ``GeoDataFrame``:
 
 .. automethod:: geopandas.GeoDataFrame.rename_geometry
 
+.. automethod:: geopandas.GeoDataFrame.set_geometry
+
 .. autoattribute:: geopandas.GeoDataFrame.__geo_interface__
 
 All pandas ``DataFrame`` methods are also available, although they may


### PR DESCRIPTION
Also added autodoc for `set_geometry` method as it was missing and needed for data sructure docs.