### PR TITLE
CLN: Remove Python 2 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,6 @@ is a great way to get started if you'd like to make a contribution.
 Style
 -----
 
-- GeoPandas supports Python 2 (2.7+) and Python 3 (3.5+) with a single
-  code base. Use modern Python idioms when possible that are
-  compatible with both major versions, and use the
-  [six](https://pythonhosted.org/six) library where helpful to smooth
-  over the differences. Use `from __future__ import` statements where
-  appropriate. Test code locally in both Python 2 and Python 3 when
-  possible (all supported versions will be automatically tested on
-  Travis CI).
-
 - GeoPandas follows [the PEP 8
   standard](http://www.python.org/dev/peps/pep-0008/) and uses
   [Black](https://black.readthedocs.io/en/stable/) and

--- a/ci/travis/35-minimal.yaml
+++ b/ci/travis/35-minimal.yaml
@@ -4,7 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.5
-  - six
   # required
   - numpy=1.12
   - pandas==0.23.4

--- a/ci/travis/36-pd023.yaml
+++ b/ci/travis/36-pd023.yaml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - python=3.6
   - pip
-  - six
   # required
   - pandas==0.23.4
   - nomkl

--- a/ci/travis/36-pd024.yaml
+++ b/ci/travis/36-pd024.yaml
@@ -3,7 +3,6 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - six
   # required
   - pandas=0.24
   - shapely

--- a/ci/travis/37-dev.yaml
+++ b/ci/travis/37-dev.yaml
@@ -3,7 +3,6 @@ channels:
   - defaults
 dependencies:
   - python=3.7.3
-  - six
   - cython
   # required
   - pandas

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - six
   # required
   - pandas
   - shapely

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -3,7 +3,6 @@ channels:
   - defaults
 dependencies:
   - python=3.7.3
-  - six
   # required
   - pandas
   - shapely

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -8,7 +8,6 @@ dependencies:
 - fiona=1.8.6
 - pyproj=1.9.6
 - rtree=0.8.3
-- six=1.12.0
 - geopy=1.20.0
 - matplotlib=3.1.1
 - descartes=1.1.0

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -34,15 +34,6 @@ In particular, when submitting a pull request:
   line of a docstring should be a standalone summary.  Parameters and
   return values should be documented explicitly.
 
-- GeoPandas supports python 2 (2.7+) and python 3 (3.5+) with a single
-  code base.  Use modern python idioms when possible that are
-  compatible with both major versions, and use the
-  `six <https://pythonhosted.org/six>`_ library where helpful to smooth
-  over the differences.  Use ``from __future__ import`` statements where
-  appropriate.  Test code locally in both python 2 and python 3 when
-  possible (all supported versions will be automatically tested on
-  Travis CI).
-
 - Follow PEP 8 when possible. We use `Black
   <https://black.readthedocs.io/en/stable/>`_ and `Flake8
   <http://flake8.pycqa.org/en/latest/>`_ to ensure a consistent code

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -1,20 +1,9 @@
 from distutils.version import LooseVersion
 
 import pandas as pd
-import six
 
 # -----------------------------------------------------------------------------
 # pandas compat
 # -----------------------------------------------------------------------------
 
 PANDAS_GE_024 = str(pd.__version__) >= LooseVersion("0.24.0")
-
-
-# -----------------------------------------------------------------------------
-# Python 2/3 compat
-# -----------------------------------------------------------------------------
-
-if six.PY2:
-    from collections import Iterable  # noqa
-else:
-    from collections.abc import Iterable  # noqa

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -13,7 +13,9 @@ from shapely.geometry.base import BaseGeometry
 import shapely.ops
 import shapely.wkt
 
-from ._compat import PANDAS_GE_024, Iterable
+from collections.abc import Iterable
+
+from ._compat import PANDAS_GE_024
 
 
 class GeometryDtype(ExtensionDtype):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,7 +3,6 @@ import json
 import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
-from six import PY3, string_types
 
 from shapely.geometry import mapping, shape
 
@@ -545,7 +544,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         result = super(GeoDataFrame, self).__getitem__(key)
         geo_col = self._geometry_column_name
-        if isinstance(key, string_types) and key == geo_col:
+        if isinstance(key, str) and key == geo_col:
             result.__class__ = GeoSeries
             result.crs = self.crs
             result._invalidate_sindex()
@@ -728,9 +727,4 @@ def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
     return gf.set_geometry(col, drop=drop, inplace=False, crs=crs)
 
 
-if PY3:
-    DataFrame.set_geometry = _dataframe_set_geometry
-else:
-    import types
-
-    DataFrame.set_geometry = types.MethodType(_dataframe_set_geometry, None, DataFrame)
+DataFrame.set_geometry = _dataframe_set_geometry

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,7 +1,6 @@
 from distutils.version import LooseVersion
 
 import numpy as np
-import six
 
 import fiona
 
@@ -11,20 +10,13 @@ try:
     from fiona import Env as fiona_env
 except ImportError:
     from fiona import drivers as fiona_env
-
+# Adapted from pandas.io.common
+from urllib.request import urlopen as _urlopen
+from urllib.parse import urlparse as parse_url
+from urllib.parse import uses_relative, uses_netloc, uses_params
 
 _FIONA18 = LooseVersion(fiona.__version__) >= LooseVersion("1.8")
 
-
-# Adapted from pandas.io.common
-if six.PY3:
-    from urllib.request import urlopen as _urlopen
-    from urllib.parse import urlparse as parse_url
-    from urllib.parse import uses_relative, uses_netloc, uses_params
-else:
-    from urllib2 import urlopen as _urlopen
-    from urlparse import urlparse as parse_url
-    from urlparse import uses_relative, uses_netloc, uses_params
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import OrderedDict
 import datetime
 from distutils.version import LooseVersion

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -5,8 +5,6 @@ configuration. postGIS tests require a test database to have been setup;
 see geopandas.tests.util for more information.
 """
 
-from __future__ import absolute_import
-
 import geopandas
 from geopandas import read_file, read_postgis
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import warnings
 
 import numpy as np

--- a/geopandas/tests/test_datasets.py
+++ b/geopandas/tests/test_datasets.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from geopandas import GeoDataFrame, read_file
 from geopandas.datasets import get_path
 

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import numpy as np
 import pandas as pd
 

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import numpy as np
 import pandas as pd
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import os
 import shutil

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import string
 
 import numpy as np

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import os
 import random

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pandas as pd
 
 from shapely.geometry import Point

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 
 import pandas as pd

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -1,11 +1,8 @@
-from __future__ import absolute_import
-
 import os
 
 import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
-from six import PY2, PY3
 
 import shapely
 from shapely.geometry import Point, GeometryCollection
@@ -210,10 +207,8 @@ def test_numerical_operations(s, df):
     with pytest.raises(TypeError):
         s.sum()
 
-    if PY3:
-        # in python 2, objects are still orderable
-        with pytest.raises(TypeError):
-            s.max()
+    with pytest.raises(TypeError):
+        s.max()
 
     with pytest.raises(TypeError):
         s.idxmax()
@@ -304,7 +299,6 @@ def test_any_all():
 # Groupby / algos
 
 
-@pytest.mark.skipif(PY2, reason="pd.unique buggy with WKB values on py2")
 def test_unique():
     s = GeoSeries([Point(0, 0), Point(0, 0), Point(2, 2)])
     exp = from_shapely([Point(0, 0), Point(2, 2)])

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import itertools
 import warnings
 

--- a/geopandas/tests/test_types.py
+++ b/geopandas/tests/test_types.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pandas import DataFrame, Series
 
 from shapely.geometry import Point

--- a/geopandas/tools/__init__.py
+++ b/geopandas/tools/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .crs import explicit_crs_from_epsg
 from .geocoding import geocode, reverse_geocode
 from .overlay import overlay

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -3,7 +3,6 @@ import time
 
 import numpy as np
 import pandas as pd
-from six import iteritems, string_types
 
 from fiona.crs import from_epsg
 from shapely.geometry import Point
@@ -139,12 +138,12 @@ def _query(data, forward, provider, throttle_time, **kwargs):
     if not isinstance(data, pd.Series):
         data = pd.Series(data)
 
-    if isinstance(provider, string_types):
+    if isinstance(provider, str):
         provider = get_geocoder_for_service(provider)
 
     coder = provider(**kwargs)
     results = {}
-    for i, s in iteritems(data):
+    for i, s in data.items():
         try:
             if forward:
                 results[i] = coder.geocode(s)
@@ -170,7 +169,7 @@ def _prepare_geocode_result(results):
     d = defaultdict(list)
     index = []
 
-    for i, s in iteritems(results):
+    for i, s in results.items():
         address, loc = s
 
         # loc is lat, lon and we want lon, lat

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import numpy as np
 import pandas as pd
 
@@ -10,10 +8,6 @@ from geopandas import GeoDataFrame, GeoSeries, base, read_file, sjoin
 
 from pandas.util.testing import assert_frame_equal
 import pytest
-
-pandas_0_18_problem = (
-    "fails under pandas < 0.19 due to pandas issue 15692, not problem with sjoin."
-)
 
 
 @pytest.fixture()

--- a/geopandas/tools/tests/test_tools.py
+++ b/geopandas/tools/tests/test_tools.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from distutils.version import LooseVersion
 
 import pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ Cython>=0.16
 shapely>=1.2.18
 fiona>=1.0.1
 pyproj>=1.9.3
-six>=1.3.0


### PR DESCRIPTION
Following the decision done in #1031, GeoPandas 0.6 is the last version supporting Python 2.

This PR removes code which is not needed. All cases of `six` use as well as `__future__`.

I'll remove python 2 from CI in the next commit, I just want to see if it properly fails :). I'll also add mention of Python 3 only support to contributing docs. 