### PR TITLE
PROPOSAL: Parquet metadata specification for geospatial vector data

### DIFF
--- a/doc/source/parquet.rst
+++ b/doc/source/parquet.rst
@@ -1,0 +1,112 @@
+.. _parquet:
+
+Parquet Metadata Schema - Version 1.0
+========================================
+
+*geopandas* can read and write *parquet* files, a binary file format that supports fast file-based I/O.
+Geometry columns are encoded to Well-Known Binary (WKB) within the *parquet* file.
+
+In order to save a *GeoDataFrame* to a *parquet* file, *geopandas* needs to store additional metadata that
+describes the geometry columns.  This information includes:
+- name of primary geometry column
+- list of geometry columns
+- Coordinate Reference System (CRS) of each geometry column
+
+This information is stored using a combination of file-level and column level metadata within the *parquet* file.
+
+
+File-Level Metadata
+-------------------
+
+The file-level metadata is stored as a JSON-encoded UTF-8 string under the "geo" key.
+For clarity, the following shows the unencoded JSON / `dict` structure:
+
+.. ipython:: python
+
+    "geo": {
+    "columns": [...],  # JSON array of geometry columns
+    "creator": {
+        "library": "geopandas",
+          "version": "0.7.0",
+    },
+    "primary_column": "...",  # name of primary geometry column
+    "schema_version": "1.0.0"
+    }
+
+
+Column-Level Metadata
+---------------------
+
+The CRS information is stored within a JSON-encoded UTF-8 string for each geometry column, under the "crs" key.
+
+Multiple options exist for storing CRS information.
+The current guidance is to use
+`WKT <https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems>`_.
+or SRIDs (e.g., EPSG codes),
+whereas `PROJJSON <https://proj.org/usage/projjson.html#projjson>`_.
+is a promising new portable representation that may take some time to fully adopt across other languages and toolkits.
+
+The following approach requires that at least one representation of CRS be present in the file:
+- "srid"
+- "json" (PROJJSON)
+- "wkt"
+
+If multiple are present, they would follow this order of precedence.
+
+
+For clarity, the following shows the unencoded JSON / `dict` structure:
+
+.. ipython:: python
+
+    "crs": {
+        "srid": {  # optional
+            "authority": "EPSG",
+            "code": 4326
+        },
+        "json": {  # optional
+            "$schema": "https://proj.org/schemas/v0.1/projjson.schema.json",
+            "type": "GeographicCRS",
+            "name": "WGS 84",
+            "datum": {
+                "type": "GeodeticReferenceFrame",
+                "name": "World Geodetic System 1984",
+                "ellipsoid": {
+                    "name": "WGS 84",
+                    "semi_major_axis": 6378137,
+                    "inverse_flattening": 298.257223563
+                }
+            },
+            "coordinate_system": {
+                "subtype": "ellipsoidal",
+                "axis": [
+                {
+                    "name": "Geodetic latitude",
+                    "abbreviation": "Lat",
+                    "direction": "north",
+                    "unit": "degree"
+                },
+                {
+                    "name": "Geodetic longitude",
+                    "abbreviation": "Lon",
+                    "direction": "east",
+                    "unit": "degree"
+                }
+                ]
+            },
+            "area": "World",
+            "bbox": {
+                "south_latitude": -90,
+                "west_longitude": -180,
+                "north_latitude": 90,
+                "east_longitude": 180
+            },
+            "id": {
+                "authority": "EPSG",
+                "code": 4326
+            }
+        },
+        "wkt": {  # optional
+            "version": "WKT2_2018",
+            "value": "..."  # omitted for brevity
+        }
+    }

--- a/doc/source/parquet.rst
+++ b/doc/source/parquet.rst
@@ -39,11 +39,23 @@ Each of the column entries in the ``"columns"`` field above has the following co
 .. code-block:: none
 
     {
-        "bounds": [<xmin>, <ymin>, <xmax>, <ymax>],  # OPTIONAL: total bounds of all geometries in column, in CRS of column
+        "bounds": [<xmin>, <ymin>, (zmin), <xmax>, <ymax>, (zmax)],  # OPTIONAL: total bounds of all geometries in column, in CRS of column
         "crs": "<WKT representation of CRS>",
         "encoding: "WKB",  # encoding identifier, see below
         "name": "<column name>",
     }
+
+
+Bounding boxes
+--------------
+
+Bounding boxes are used to help define the spatial extent of each geometry column.
+Implementations of this schema may choose to use those bounding boxes to filter
+partitions (sub-datasets) within a *parquet* dataset.
+
+These must be encoded with the minimum and maximum values of each dimension:
+- 2D: [<xmin>, <ymin>, <xmax>, <ymax>]
+- 3D: [<xmin>, <ymin>, <zmin>, <xmax>, <ymax>, <zmax>]
 
 
 CRS encoding

--- a/doc/source/parquet.rst
+++ b/doc/source/parquet.rst
@@ -1,14 +1,15 @@
 .. _parquet:
 
 Parquet Metadata Schema - Version 1.0
-========================================
+=====================================
 
-*geopandas* can read and write *parquet* files, a binary file format that supports fast file-based I/O.
+*geopandas* can read and write *parquet* files, a binary columnar file format that supports fast file-based I/O.
 Geometry columns are encoded to Well-Known Binary (WKB) within the *parquet* file.
 
 In order to save a *GeoDataFrame* to a *parquet* file, *geopandas* needs to store additional metadata that
 describes the geometry columns.  This information includes:
-- name of primary geometry column
+
+- name of the primary geometry column
 - list of geometry columns
 - Coordinate Reference System (CRS) of each geometry column
 
@@ -21,29 +22,37 @@ File-Level Metadata
 The file-level metadata is stored as a JSON-encoded UTF-8 string under the "geo" key.
 For clarity, the following shows the unencoded JSON / `dict` structure:
 
-.. ipython:: python
+.. code-block:: none
 
     "geo": {
-    "columns": [...],  # JSON array of geometry columns
-    "creator": {
-        "library": "geopandas",
-          "version": "0.7.0",
-    },
-    "primary_column": "...",  # name of primary geometry column
-    "schema_version": "1.0.0"
+        "columns": [...],  # JSON array of geometry columns, see below
+        "creator": {
+            "library": "geopandas",
+            "version": "0.7.0",
+        },
+        "primary_column": "...",  # name of primary geometry column
+        "version": "1.0.0"
     }
 
 
 Column-Level Metadata
 ---------------------
 
+Each of the column entries in the ``"columns"`` field of the file-level metadata (see above)
+is another key-value object with following content:
+
+.. code-block:: none
+
+    {
+        "name": "<geometry column name>",
+        "crs": "...",  # CRS description, see below
+    }
+
 The CRS information is stored within a JSON-encoded UTF-8 string for each geometry column, under the "crs" key.
 
-Multiple options exist for storing CRS information.
-The current guidance is to use
+Multiple options exist for storing CRS information. The current guidance is to use
 `WKT <https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems>`_.
-or SRIDs (e.g., EPSG codes),
-whereas `PROJJSON <https://proj.org/usage/projjson.html#projjson>`_.
+or SRIDs (e.g., EPSG codes), whereas `PROJJSON <https://proj.org/usage/projjson.html#projjson>`_.
 is a promising new portable representation that may take some time to fully adopt across other languages and toolkits.
 
 The following approach requires that at least one representation of CRS be present in the file:


### PR DESCRIPTION
This PR is proposing a metadata specification for saving geospatial vector data in [Parquet files](https://parquet.apache.org/). To use it in GeoPandas, but we want to describe it so it can potentially also be recognized / used by other packages / software.

Currently, this proposes to save the following metadata in a `"geo"` key in the parquet's file key-value metadata:

- For all geometry columns: the name of the column and its CRS
- The name of the primary geometry column
- Some additional information about the version and the library that created this file / metadata

---

Per comments in #1180, this is a separate PR for reviewing the metadata specification to be used for saving `parquet` files with appropriate details to read back into a `GeoDataFrame`.

For those following along, there are comments in #1180 that shaped this.  See [this comment](https://github.com/geopandas/geopandas/pull/1180#issuecomment-548784939) for more details about the goals of this metadata.

Once the spec is approved here, we'll implement it in #1180

I was not sure where this documentation belonged, so it is currently in an orphaned RST page.  I need guidance on where this should be placed in the docs.  Under `Developers` section?  It felt too specific to add to `io.rst` (we can add general usage of read / write for parquet there).

(I'm not able to build RST previews locally, so hopefully no RST issues here)