### PR TITLE
BUG: Passing RGBA tuple to color parameter in .plot() throws error

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -100,9 +100,12 @@ def plot_polygon_collection(
     if color is not None:
         if is_color_like(color):
             kwargs["color"] = color
+        elif pd.api.types.is_list_like(color):
+            kwargs["color"] = np.take(color, multiindex)
         else:
-            if pd.api.types.is_list_like(color):
-                kwargs["color"] = np.take(color, multiindex)
+            raise TypeError(
+                "Color attribute has to be a single color or sequence of colors."
+            )
 
     else:
         for att in ["facecolor", "edgecolor"]:
@@ -110,6 +113,11 @@ def plot_polygon_collection(
                 if not is_color_like(kwargs[att]):
                     if pd.api.types.is_list_like(kwargs[att]):
                         kwargs[att] = np.take(kwargs[att], multiindex)
+                    elif kwargs[att] is not None:
+                        raise TypeError(
+                            "Color attribute has to be a single color or sequence "
+                            "of colors."
+                        )
 
     collection = PatchCollection([PolygonPatch(poly) for poly in geoms], **kwargs)
 
@@ -167,9 +175,12 @@ def plot_linestring_collection(
     if color is not None:
         if is_color_like(color):
             kwargs["color"] = color
+        elif pd.api.types.is_list_like(color):
+            kwargs["color"] = np.take(color, multiindex)
         else:
-            if pd.api.types.is_list_like(color):
-                kwargs["color"] = np.take(color, multiindex)
+            raise TypeError(
+                "Color attribute has to be a single color or sequence of colors."
+            )
 
     segments = [np.array(linestring)[:, :2] for linestring in geoms]
     collection = LineCollection(segments, **kwargs)
@@ -240,6 +251,10 @@ def plot_point_collection(
         if not is_color_like(color):
             if pd.api.types.is_list_like(color):
                 color = np.take(color, multiindex)
+            else:
+                raise TypeError(
+                    "Color attribute has to be a single color or sequence of colors."
+                )
 
     if "norm" not in kwargs:
         collection = ax.scatter(

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -88,6 +88,7 @@ def plot_polygon_collection(
             "The descartes package is required for plotting polygons in geopandas."
         )
     from matplotlib.collections import PatchCollection
+    from matplotlib.colors import is_color_like
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
@@ -97,16 +98,20 @@ def plot_polygon_collection(
     if "markersize" in kwargs:
         del kwargs["markersize"]
     if color is not None:
-        kwargs["color"] = color
-        if pd.api.types.is_list_like(color):
-            kwargs["color"] = np.take(color, multiindex)
+        if not is_color_like(color):
+            if pd.api.types.is_list_like(color):
+                kwargs["color"] = np.take(color, multiindex)
+            else:
+                kwargs["color"] = color
         else:
             kwargs["color"] = color
+
     else:
         for att in ["facecolor", "edgecolor"]:
             if att in kwargs:
-                if pd.api.types.is_list_like(kwargs[att]):
-                    kwargs[att] = np.take(kwargs[att], multiindex)
+                if not is_color_like(kwargs[att]):
+                    if pd.api.types.is_list_like(kwargs[att]):
+                        kwargs[att] = np.take(kwargs[att], multiindex)
 
     collection = PatchCollection([PolygonPatch(poly) for poly in geoms], **kwargs)
 
@@ -150,6 +155,7 @@ def plot_linestring_collection(
 
     """
     from matplotlib.collections import LineCollection
+    from matplotlib.colors import is_color_like
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
@@ -161,8 +167,11 @@ def plot_linestring_collection(
 
     # color=None gives black instead of default color cycle
     if color is not None:
-        if pd.api.types.is_list_like(color):
-            kwargs["color"] = np.take(color, multiindex)
+        if not is_color_like(color):
+            if pd.api.types.is_list_like(color):
+                kwargs["color"] = np.take(color, multiindex)
+            else:
+                kwargs["color"] = color
         else:
             kwargs["color"] = color
 
@@ -213,6 +222,8 @@ def plot_point_collection(
     -------
     collection : matplotlib.collections.Collection that was plotted
     """
+    from matplotlib.colors import is_color_like
+
     if values is not None and color is not None:
         raise ValueError("Can only specify one of 'values' and 'color' kwargs")
 
@@ -230,8 +241,9 @@ def plot_point_collection(
         kwargs["s"] = markersize
 
     if color is not None:
-        if pd.api.types.is_list_like(color):
-            color = np.take(color, multiindex)
+        if not is_color_like(color):
+            if pd.api.types.is_list_like(color):
+                color = np.take(color, multiindex)
 
     if "norm" not in kwargs:
         collection = ax.scatter(

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -98,13 +98,11 @@ def plot_polygon_collection(
     if "markersize" in kwargs:
         del kwargs["markersize"]
     if color is not None:
-        if not is_color_like(color):
+        if is_color_like(color):
+            kwargs["color"] = color
+        else:
             if pd.api.types.is_list_like(color):
                 kwargs["color"] = np.take(color, multiindex)
-            else:
-                kwargs["color"] = color
-        else:
-            kwargs["color"] = color
 
     else:
         for att in ["facecolor", "edgecolor"]:
@@ -167,13 +165,11 @@ def plot_linestring_collection(
 
     # color=None gives black instead of default color cycle
     if color is not None:
-        if not is_color_like(color):
+        if is_color_like(color):
+            kwargs["color"] = color
+        else:
             if pd.api.types.is_list_like(color):
                 kwargs["color"] = np.take(color, multiindex)
-            else:
-                kwargs["color"] = color
-        else:
-            kwargs["color"] = color
 
     segments = [np.array(linestring)[:, :2] for linestring in geoms]
     collection = LineCollection(segments, **kwargs)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -122,6 +122,12 @@ class TestPointPlotting:
         _check_colors(
             self.N, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * self.N
         )
+        ax = self.df.plot(color=(0.5, 0.5, 0.5, 0.5))
+        _check_colors(
+            self.N, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5, 0.5)] * self.N
+        )
+        with pytest.raises(TypeError):
+            self.df.plot(color="not color")
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
@@ -273,10 +279,16 @@ class TestLineStringPlotting:
         _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
 
         # check rgba tuple GH1178
-        ax = self.df.plot(color=(0.5, 0.5, 0.5))
+        ax = self.df.plot(color=(0.5, 0.5, 0.5, 0.5))
         _check_colors(
-            self.N, ax.collections[0].get_colors(), [(0.5, 0.5, 0.5)] * self.N
+            self.N, ax.collections[0].get_colors(), [(0.5, 0.5, 0.5, 0.5)] * self.N
         )
+        ax = self.df.plot(color=(0.5, 0.5, 0.5, 0.5))
+        _check_colors(
+            self.N, ax.collections[0].get_colors(), [(0.5, 0.5, 0.5, 0.5)] * self.N
+        )
+        with pytest.raises(TypeError):
+            self.df.plot(color="not color")
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
@@ -367,6 +379,10 @@ class TestPolygonPlotting:
         # check rgba tuple GH1178
         ax = self.df.plot(color=(0.5, 0.5, 0.5))
         _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * 2)
+        ax = self.df.plot(color=(0.5, 0.5, 0.5, 0.5))
+        _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5, 0.5)] * 2)
+        with pytest.raises(TypeError):
+            self.df.plot(color="not color")
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'values'
@@ -422,6 +438,12 @@ class TestPolygonPlotting:
         ax = self.df.plot(facecolor=(0.5, 0.5, 0.5), edgecolor=(0.4, 0.5, 0.6))
         _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * 2)
         _check_colors(2, ax.collections[0].get_edgecolors(), [(0.4, 0.5, 0.6)] * 2)
+
+        ax = self.df.plot(
+            facecolor=(0.5, 0.5, 0.5, 0.5), edgecolor=(0.4, 0.5, 0.6, 0.5)
+        )
+        _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5, 0.5)] * 2)
+        _check_colors(2, ax.collections[0].get_edgecolors(), [(0.4, 0.5, 0.6, 0.5)] * 2)
 
     def test_legend_kwargs(self):
 
@@ -686,6 +708,10 @@ class TestPlotCollections:
         _check_colors(self.N, coll.get_edgecolors(), ["r", "g", "b"])
         ax.cla()
 
+        # not a color
+        with pytest.raises(TypeError):
+            plot_point_collection(ax, self.points, color="not color")
+
     def test_points_values(self):
         from geopandas.plotting import plot_point_collection
 
@@ -736,6 +762,10 @@ class TestPlotCollections:
         assert res_ls[0] == exp_ls[0]
         assert res_ls[1] == exp_ls[1]
         ax.cla()
+
+        # not a color
+        with pytest.raises(TypeError):
+            plot_linestring_collection(ax, self.lines, color="not color")
 
     def test_linestrings_values(self):
         from geopandas.plotting import plot_linestring_collection
@@ -804,6 +834,10 @@ class TestPlotCollections:
         _check_colors(self.N, coll.get_facecolor(), ["g"] * self.N)
         _check_colors(self.N, coll.get_edgecolor(), ["r"] * self.N)
         ax.cla()
+
+        # not a color
+        with pytest.raises(TypeError):
+            plot_polygon_collection(ax, self.polygons, color="not color")
 
     def test_polygons_values(self):
         from geopandas.plotting import plot_polygon_collection

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -117,6 +117,12 @@ class TestPointPlotting:
         ax = self.df.plot(color="green")
         _check_colors(self.N, ax.collections[0].get_facecolors(), ["green"] * self.N)
 
+        # check rgba tuple GH1178
+        ax = self.df.plot(color=(0.5, 0.5, 0.5))
+        _check_colors(
+            self.N, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * self.N
+        )
+
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
             ax = self.df.plot(column="values", color="green")
@@ -266,6 +272,12 @@ class TestLineStringPlotting:
         ax = self.df.plot(color="green")
         _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
 
+        # check rgba tuple GH1178
+        ax = self.df.plot(color=(0.5, 0.5, 0.5))
+        _check_colors(
+            self.N, ax.collections[0].get_colors(), [(0.5, 0.5, 0.5)] * self.N
+        )
+
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'column'
             ax = self.df.plot(column="values", color="green")
@@ -351,6 +363,10 @@ class TestPolygonPlotting:
         ax = self.df.plot(color="green")
         _check_colors(2, ax.collections[0].get_facecolors(), ["green"] * 2)
         _check_colors(2, ax.collections[0].get_edgecolors(), ["k"] * 2)
+
+        # check rgba tuple GH1178
+        ax = self.df.plot(color=(0.5, 0.5, 0.5))
+        _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * 2)
 
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # 'color' overrides 'values'

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -418,6 +418,11 @@ class TestPolygonPlotting:
         _check_colors(2, ax.collections[0].get_facecolors(), ["g"] * 2, alpha=0.4)
         _check_colors(2, ax.collections[0].get_edgecolors(), ["r"] * 2, alpha=0.4)
 
+        # check rgba tuple GH1178 for face and edge
+        ax = self.df.plot(facecolor=(0.5, 0.5, 0.5), edgecolor=(0.4, 0.5, 0.6))
+        _check_colors(2, ax.collections[0].get_facecolors(), [(0.5, 0.5, 0.5)] * 2)
+        _check_colors(2, ax.collections[0].get_edgecolors(), [(0.4, 0.5, 0.6)] * 2)
+
     def test_legend_kwargs(self):
 
         ax = self.df.plot(


### PR DESCRIPTION
Fixes #1178 

I have added `is_color_like` check before checking for list-like in `color` argument, so if we pass RGBA tuple it gets assigned directly to all geometries instead of expecting that it is a list.