### PR TITLE
ENH: Carry original schema and use it during to_file

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -63,6 +63,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # getitem accesses crs
         self.crs = crs
 
+        schema = kwargs.pop("schema", None)
+        self.schema = schema
+
         # set_geometry ensures the geometry data have the proper dtype,
         # but is not called if `geometry=None` ('geometry' column present
         # in the data), so therefore need to ensure it here manually
@@ -236,7 +239,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return geopandas.io.file.read_file(filename, **kwargs)
 
     @classmethod
-    def from_features(cls, features, crs=None, columns=None):
+    def from_features(cls, features, crs=None, columns=None, schema=None):
         """
         Alternate constructor to create GeoDataFrame from an iterable of
         features or a feature collection.
@@ -290,6 +293,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             rows.append(d)
         df = GeoDataFrame(rows, columns=columns)
         df.crs = crs
+        df.schema = schema
         return df
 
     @classmethod

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -300,6 +300,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             d.update(f["properties"])
             rows.append(d)
         df = GeoDataFrame(rows, columns=columns)
+        if schema:
+            for c, t in df.dtypes.iteritems():
+                if c != df._geometry_column_name:
+                    if "int" in schema["properties"][c] and t == "float":
+                        df[c] = df[c].astype("Int64")
+
         df.crs = crs
         df.schema = schema
         return df

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -48,6 +48,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     geometry : str or array (optional)
         If str, column to use as geometry. If array, will be set as 'geometry'
         column on GeoDataFrame.
+    schema : dict (optional)
+        If specified, the schema dictionary is passed to Fiona to
+        better control how the file is written. If None, GeoPandas
+        will determine the schema based on each column's dtype
     """
 
     _metadata = ["crs", "_geometry_column_name"]
@@ -259,6 +263,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             Optionally specify the column names to include in the output frame.
             This does not overwrite the property names of the input, but can
             ensure a consistent output format.
+        schema : dict, default None
+            If specified, the schema dictionary is passed to Fiona to
+            better control how the file is written. If None, GeoPandas
+            will determine the schema based on each column's dtype
 
         Returns
         -------

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -138,6 +138,8 @@ def infer_schema(df):
         elif in_type.name.startswith("datetime64"):
             # numpy datetime type regardless of frequency
             out_type = "datetime"
+        elif in_type == "Int64":
+            out_type = "int"
         else:
             out_type = type(np.zeros(1, in_type).item()).__name__
         if out_type == "long":


### PR DESCRIPTION
Following the discussion in #1185, I have drafted a PR which saves schema during `read_file` to `gdf.schema` and then during `to_file` checks if the original schema for each column is still applicable. If so, it uses it, if not it infers new one based on the dtype as we do it now.

I am pretty sure that there will be some corner cases which are not covered here, but I wanted to have this PR opened so we can discuss the implementation. But for the cases described in #1185 and earlier in #177, this should work.

```
path = gpd.datasets.get_path('nybb')
gdf = gpd.read_file(path)
gdf.schema  # original schema from fiona

{'properties': OrderedDict([('BoroCode', 'int:4'),
              ('BoroName', 'str:32'),
              ('Shape_Leng', 'float:19.11'),
              ('Shape_Area', 'float:19.11')]),
 'geometry': 'Polygon'}
```

```
gpd.io.file.infer_schema(gdf)
{'geometry': 'MultiPolygon',

 'properties': OrderedDict([('BoroCode', 'int:4'),
              ('BoroName', 'str:32'),
              ('Shape_Leng', 'float:19.11'),
              ('Shape_Area', 'float:19.11')])}
```

On master:
```
gpd.io.file.infer_schema(gdf)

{'geometry': 'MultiPolygon',
 'properties': OrderedDict([('BoroCode', 'int'),
              ('BoroName', 'str'),
              ('Shape_Leng', 'float'),
              ('Shape_Area', 'float')])}
```

Closes #1185 