### PR TITLE
CLN: Update test_no_additional_imports for py3

### DIFF
--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -18,6 +18,5 @@ if mods:
     sys.exit(len(mods))
 """
     call = [sys.executable, "-c", code]
-    # TODO(py3) update with subprocess.run once python 2.7 is dropped
-    returncode = subprocess.call(call, stderr=subprocess.STDOUT)
+    returncode = subprocess.run(call).returncode
     assert returncode == 0


### PR DESCRIPTION
I just randomly came across todo I missed previously. `test_no_additional_imports` now updated for python 3 only.