### PR TITLE
TST: fix api test (no import) for matplotlib

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -7,3 +7,4 @@ import pandas as pd
 # -----------------------------------------------------------------------------
 
 PANDAS_GE_024 = str(pd.__version__) >= LooseVersion("0.24.0")
+PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("0.26.0.dev")

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -9,7 +9,7 @@ def test_no_additional_imports():
 import sys
 import geopandas
 blacklist = {'pytest', 'py', 'ipython',
-             'matplotlib' 'descartes','mapclassify',
+             'matplotlib', 'descartes', 'mapclassify',
              # 'rtree',  # rtree actually gets imported if installed
              'sqlalchemy', 'psycopg2', 'geopy'}
 mods = blacklist & set(m.split('.')[0] for m in sys.modules)

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -1,22 +1,40 @@
 import subprocess
 import sys
 
+from geopandas._compat import PANDAS_GE_10
+
 
 def test_no_additional_imports():
     # test that 'import geopandas' does not import any of the optional or
     # development dependencies
+    blacklist = {
+        "pytest",
+        "py",
+        "ipython",
+        # 'matplotlib',  # matplotlib gets imported by pandas, see below
+        "descartes",
+        "mapclassify",
+        # 'rtree',  # rtree actually gets imported if installed
+        "sqlalchemy",
+        "psycopg2",
+        "geopy",
+    }
+    if PANDAS_GE_10:
+        # pandas > 0.25 stopped importing matplotlib by default
+        blacklist.add("matplotlib")
+
     code = """
 import sys
 import geopandas
-blacklist = {'pytest', 'py', 'ipython',
-             'matplotlib', 'descartes', 'mapclassify',
-             # 'rtree',  # rtree actually gets imported if installed
-             'sqlalchemy', 'psycopg2', 'geopy'}
+blacklist = {0:r}
+
 mods = blacklist & set(m.split('.')[0] for m in sys.modules)
 if mods:
-    sys.stderr.write('err: geopandas should not import: {}'.format(', '.join(mods)))
+    sys.stderr.write('err: geopandas should not import: {{}}'.format(', '.join(mods)))
     sys.exit(len(mods))
-"""
+""".format(
+        blacklist
+    )
     call = [sys.executable, "-c", code]
     returncode = subprocess.run(call).returncode
     assert returncode == 0

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -26,7 +26,7 @@ def test_no_additional_imports():
     code = """
 import sys
 import geopandas
-blacklist = {0:r}
+blacklist = {0!r}
 
 mods = blacklist & set(m.split('.')[0] for m in sys.modules)
 if mods:


### PR DESCRIPTION
While looking at the diff of https://github.com/geopandas/geopandas/pull/1201 (thanks @martinfleis !), I noticed that there was actually a type in the original test which made we were not testing matplotlib correctly.