### PR TITLE
TST: fix test_unary_predicates for GEOS 3.8

### DIFF
--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -18,6 +18,5 @@ if mods:
     sys.exit(len(mods))
 """
     call = [sys.executable, "-c", code]
-    # TODO(py3) update with subprocess.run once python 2.7 is dropped
-    returncode = subprocess.call(call, stderr=subprocess.STDOUT)
+    returncode = subprocess.run(call).returncode
     assert returncode == 0

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -392,7 +392,7 @@ def test_binary_geo_scalar(attr):
 @pytest.mark.parametrize(
     "attr", ["is_closed", "is_valid", "is_empty", "is_simple", "has_z", "is_ring"]
 )
-@pytest.mark.xfail(strict=False)
+@pytest.mark.xfail(strict=False, reason="GEOS 3.8.0 changes in is_simple")
 def test_unary_predicates(attr):
     na_value = False
     if attr == "is_simple":

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -392,6 +392,7 @@ def test_binary_geo_scalar(attr):
 @pytest.mark.parametrize(
     "attr", ["is_closed", "is_valid", "is_empty", "is_simple", "has_z", "is_ring"]
 )
+@pytest.mark.xfail
 def test_unary_predicates(attr):
     na_value = False
     if attr == "is_simple":

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -9,6 +9,7 @@ import shapely.affinity
 import shapely.geometry
 from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 import shapely.wkb
+from shapely._buildcfg import geos_version
 
 import geopandas
 from geopandas.array import (
@@ -392,11 +393,10 @@ def test_binary_geo_scalar(attr):
 @pytest.mark.parametrize(
     "attr", ["is_closed", "is_valid", "is_empty", "is_simple", "has_z", "is_ring"]
 )
-@pytest.mark.xfail(strict=False, reason="GEOS 3.8.0 changes in is_simple")
 def test_unary_predicates(attr):
     na_value = False
-    if attr == "is_simple":
-        # poly.is_simple raises an error for empty polygon
+    if attr == "is_simple" and geos_version < (3, 8):
+        # poly.is_simple raises an error for empty polygon for GEOS < 3.8
         with pytest.raises(Exception):
             T.is_simple
         vals = triangle_no_missing

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -392,7 +392,7 @@ def test_binary_geo_scalar(attr):
 @pytest.mark.parametrize(
     "attr", ["is_closed", "is_valid", "is_empty", "is_simple", "has_z", "is_ring"]
 )
-@pytest.mark.xfail
+@pytest.mark.xfail(strict=False)
 def test_unary_predicates(attr):
     na_value = False
     if attr == "is_simple":


### PR DESCRIPTION
Temporary fix for failing tests. conda defaults now comes with GEOS 3.8.0 which apparently no longer raises an error while doing `poly.is_simple` if poly is empty. In the [changelog](https://github.com/libgeos/geos/blob/master/NEWS), I assume the change is in `Improve general predicate, overlay, and buffer performance`. I am not sure how does this affect behaviour of overlay though.