### PR TITLE
BUG: Passing array of RGBA tuples to color parameter in .plot() throws error

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -92,7 +92,7 @@ def plot_polygon_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = np.take(values, multiindex)
+        values = np.take(values, multiindex, axis=0)
 
     # PatchCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -101,7 +101,7 @@ def plot_polygon_collection(
         if is_color_like(color):
             kwargs["color"] = color
         elif pd.api.types.is_list_like(color):
-            kwargs["color"] = np.take(color, multiindex)
+            kwargs["color"] = np.take(color, multiindex, axis=0)
         else:
             raise TypeError(
                 "Color attribute has to be a single color or sequence of colors."
@@ -112,7 +112,7 @@ def plot_polygon_collection(
             if att in kwargs:
                 if not is_color_like(kwargs[att]):
                     if pd.api.types.is_list_like(kwargs[att]):
-                        kwargs[att] = np.take(kwargs[att], multiindex)
+                        kwargs[att] = np.take(kwargs[att], multiindex, axis=0)
                     elif kwargs[att] is not None:
                         raise TypeError(
                             "Color attribute has to be a single color or sequence "
@@ -165,7 +165,7 @@ def plot_linestring_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = np.take(values, multiindex)
+        values = np.take(values, multiindex, axis=0)
 
     # LineCollection does not accept some kwargs.
     if "markersize" in kwargs:
@@ -176,7 +176,7 @@ def plot_linestring_collection(
         if is_color_like(color):
             kwargs["color"] = color
         elif pd.api.types.is_list_like(color):
-            kwargs["color"] = np.take(color, multiindex)
+            kwargs["color"] = np.take(color, multiindex, axis=0)
         else:
             raise TypeError(
                 "Color attribute has to be a single color or sequence of colors."
@@ -236,7 +236,7 @@ def plot_point_collection(
 
     geoms, multiindex = _flatten_multi_geoms(geoms, range(len(geoms)))
     if values is not None:
-        values = np.take(values, multiindex)
+        values = np.take(values, multiindex, axis=0)
 
     x = [p.x for p in geoms]
     y = [p.y for p in geoms]
@@ -250,7 +250,7 @@ def plot_point_collection(
     if color is not None:
         if not is_color_like(color):
             if pd.api.types.is_list_like(color):
-                color = np.take(color, multiindex)
+                color = np.take(color, multiindex, axis=0)
             else:
                 raise TypeError(
                     "Color attribute has to be a single color or sequence of colors."

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -18,6 +18,5 @@ if mods:
     sys.exit(len(mods))
 """
     call = [sys.executable, "-c", code]
-    # TODO(py3) update with subprocess.run once python 2.7 is dropped
-    returncode = subprocess.call(call, stderr=subprocess.STDOUT)
+    returncode = subprocess.run(call).returncode
     assert returncode == 0

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -708,6 +708,23 @@ class TestPlotCollections:
         _check_colors(self.N, coll.get_edgecolors(), ["r", "g", "b"])
         ax.cla()
 
+        coll = plot_point_collection(
+            ax,
+            self.points,
+            color=[(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        _check_colors(
+            self.N,
+            coll.get_facecolors(),
+            [(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        _check_colors(
+            self.N,
+            coll.get_edgecolors(),
+            [(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        ax.cla()
+
         # not a color
         with pytest.raises(TypeError):
             plot_point_collection(ax, self.points, color="not color")
@@ -753,6 +770,18 @@ class TestPlotCollections:
         # list of colors
         coll = plot_linestring_collection(ax, self.lines, color=["r", "g", "b"])
         _check_colors(self.N, coll.get_colors(), ["r", "g", "b"])
+        ax.cla()
+
+        coll = plot_linestring_collection(
+            ax,
+            self.lines,
+            color=[(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        _check_colors(
+            self.N,
+            coll.get_colors(),
+            [(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
         ax.cla()
 
         # pass through of kwargs
@@ -821,6 +850,23 @@ class TestPlotCollections:
         coll = plot_polygon_collection(ax, self.polygons, color=["g", "b", "r"])
         _check_colors(self.N, coll.get_facecolor(), ["g", "b", "r"])
         _check_colors(self.N, coll.get_edgecolor(), ["g", "b", "r"])
+        ax.cla()
+
+        coll = plot_polygon_collection(
+            ax,
+            self.polygons,
+            color=[(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        _check_colors(
+            self.N,
+            coll.get_facecolor(),
+            [(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
+        _check_colors(
+            self.N,
+            coll.get_edgecolor(),
+            [(0.5, 0.5, 0.5, 0.5), (0.1, 0.2, 0.3, 0.5), (0.4, 0.5, 0.6, 0.5)],
+        )
         ax.cla()
 
         # only setting facecolor keeps default for edgecolor


### PR DESCRIPTION
Passing array of tuples (aka list of lists), `np.take` in plotting flattens the array causing the error, reported in https://github.com/pysal/splot/issues/83. I thought that it is the same bug as #1178 but this one was slightly different. Both caused by changes in #1119 though. 

It should be fixed now, including tests.

_(there is so many options how to pass colors...)_