### PR TITLE
DOC: specify zorder when combining cartopy and geopandas

### DIFF
--- a/examples/cartopy_convert.py
+++ b/examples/cartopy_convert.py
@@ -100,7 +100,7 @@ ax.add_geometries(new_geometries, crs=crs_new)
 
 # Calculate centroids and plot
 df_aea_centroids = df_aea.geometry.centroid
-# Need to provide a "zorder" to ensur the points are plotted above the polygons
+# Need to provide "zorder" to ensure the points are plotted above the polygons
 df_aea_centroids.plot(ax=ax, markersize=5, color='r', zorder=10)
 
 plt.show()

--- a/examples/cartopy_convert.py
+++ b/examples/cartopy_convert.py
@@ -100,6 +100,7 @@ ax.add_geometries(new_geometries, crs=crs_new)
 
 # Calculate centroids and plot
 df_aea_centroids = df_aea.geometry.centroid
-df_aea_centroids.plot(ax=ax, markersize=5, color='r')
+# Need to provide a "zorder" to ensur the points are plotted above the polygons
+df_aea_centroids.plot(ax=ax, markersize=5, color='r', zorder=10)
 
 plt.show()


### PR DESCRIPTION
I noticed there was something wrong with the last plot on this page: https://geopandas.readthedocs.io/en/latest/gallery/cartopy_convert.html 
I first thought it was not working, but it's actually just that the centroids are "hidden" behind the countries polygons. Which can be fixed with providing a "zorder" (not ideal a user needs to do this though)