### PR TITLE
ENH: Support nullable integer data type in to_file

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -125,15 +125,19 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
 def infer_schema(df):
     from collections import OrderedDict
 
+    # TODO: test pandas string type and boolean type once released
+    types = {"Int64": "int", "string": "str", "boolean": "bool"}
+
     def convert_type(column, in_type):
         if in_type == object:
             return "str"
         if in_type.name.startswith("datetime64"):
             # numpy datetime type regardless of frequency
             return "datetime"
-        if in_type == "Int64":
-            return "int"
-        out_type = type(np.zeros(1, in_type).item()).__name__
+        if str(in_type) in types:
+            out_type = types[str(in_type)]
+        else:
+            out_type = type(np.zeros(1, in_type).item()).__name__
         if out_type == "long":
             out_type = "int"
         if not _FIONA18 and out_type == "bool":

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -123,10 +123,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
 
 
 def infer_schema(df):
-    try:
-        from collections import OrderedDict
-    except ImportError:
-        from ordereddict import OrderedDict
+    from collections import OrderedDict
 
     def convert_type(column, in_type):
         if in_type == object:
@@ -134,6 +131,8 @@ def infer_schema(df):
         if in_type.name.startswith("datetime64"):
             # numpy datetime type regardless of frequency
             return "datetime"
+        if in_type == "Int64":
+            return "int"
         out_type = type(np.zeros(1, in_type).item()).__name__
         if out_type == "long":
             out_type = "int"

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -287,19 +287,7 @@ def geodataframe(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        "GeoJSON",
-        "ESRI Shapefile",
-        pytest.param(
-            "GPKG",
-            marks=pytest.mark.skipif(
-                (sys.version_info < (3, 0)) and sys.platform.startswith("win"),
-                reason="GPKG tests failing on AppVeyor for Python 2.7",
-            ),
-        ),
-    ]
-)
+@pytest.fixture(params=["GeoJSON", "ESRI Shapefile", "GPKG"])
 def ogr_driver(request):
     return request.param
 

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -11,8 +11,10 @@ from shapely.geometry import (
 
 import pandas as pd
 import numpy as np
+import pytest
 from geopandas import GeoDataFrame
 from geopandas.io.file import _FIONA18, infer_schema
+from geopandas._compat import PANDAS_GE_024
 
 # Credit: Polygons below come from Montreal city Open Data portal
 # http://donnees.ville.montreal.qc.ca/dataset/unites-evaluation-fonciere
@@ -318,6 +320,7 @@ def test_infer_schema_null_geometry_all():
     assert infer_schema(df) == {"geometry": "Unknown", "properties": OrderedDict()}
 
 
+@pytest.mark.skipif(not PANDAS_GE_024, reason="pandas >= 0.24 needed")
 def test_infer_schema_int64():
     df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
     df["int64"] = int64col

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -9,6 +9,8 @@ from shapely.geometry import (
     Polygon,
 )
 
+import pandas as pd
+import numpy as np
 from geopandas import GeoDataFrame
 from geopandas.io.file import _FIONA18, infer_schema
 
@@ -70,6 +72,7 @@ polygon_3D = Polygon(
         (-73.5541107525234, 45.5091983609661, 300),
     )
 )
+int64col = pd.array([1, np.nan], dtype=pd.Int64Dtype())
 
 
 def test_infer_schema_only_points():
@@ -313,3 +316,13 @@ def test_infer_schema_null_geometry_all():
     # None geometry type in then replaced by 'Unknown'
     # (default geometry type supported by Fiona)
     assert infer_schema(df) == {"geometry": "Unknown", "properties": OrderedDict()}
+
+
+def test_infer_schema_int64():
+    df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
+    df["int64"] = int64col
+
+    assert infer_schema(df) == {
+        "geometry": "Point",
+        "properties": OrderedDict([("int64", "int")]),
+    }

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -74,7 +74,6 @@ polygon_3D = Polygon(
         (-73.5541107525234, 45.5091983609661, 300),
     )
 )
-int64col = pd.array([1, np.nan], dtype=pd.Int64Dtype())
 
 
 def test_infer_schema_only_points():
@@ -322,6 +321,7 @@ def test_infer_schema_null_geometry_all():
 
 @pytest.mark.skipif(not PANDAS_GE_024, reason="pandas >= 0.24 needed")
 def test_infer_schema_int64():
+    int64col = pd.array([1, np.nan], dtype=pd.Int64Dtype())
     df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
     df["int64"] = int64col
 


### PR DESCRIPTION
Closes #1200 

This adds support of pandas Int64 (nullable integer dtype) to `infer_schema`, allowing GeoDataFrame with Int64 column to be saved to file.

I am closing #1200 which meant to carry the whole schema and reuse it on save, but this proved to be tricky as it is extremely sensitive to any change of gdf.

