### PR TITLE
ENH: support GeometryCollection and LinearRing in plotting

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -618,6 +618,7 @@ def plot_dataframe(
     subset = values[point_idx & np.invert(nan_idx)]
     if not points.empty:
         if isinstance(markersize, np.ndarray):
+            markersize = np.take(markersize, multiindex, axis=0)
             markersize = markersize[point_idx & np.invert(nan_idx)]
         plot_point_collection(
             ax,

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -343,7 +343,9 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
     geom_types = s.geometry.type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
     line_idx = np.asarray(
-        (geom_types == "LineString") | (geom_types == "MultiLineString")
+        (geom_types == "LineString")
+        | (geom_types == "MultiLineString")
+        | (geom_types == "LinearRing")
     )
     point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
 
@@ -568,7 +570,9 @@ def plot_dataframe(
     geom_types = df.geometry.type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
     line_idx = np.asarray(
-        (geom_types == "LineString") | (geom_types == "MultiLineString")
+        (geom_types == "LineString")
+        | (geom_types == "MultiLineString")
+        | (geom_types == "LinearRing")
     )
     point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -348,6 +348,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
         | (geom_types == "LinearRing")
     )
     point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
+    gcoll_idx = np.asarray((geom_types == "GeometryCollection"))
 
     # plot all Polygons and all MultiPolygon components in the same collection
     polys = s.geometry[poly_idx]
@@ -378,6 +379,12 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
         values_ = values[point_idx] if cmap else None
         plot_point_collection(ax, points, values_, color=color, cmap=cmap, **style_kwds)
 
+    gcolls = s.geometry[gcoll_idx]
+    if not gcolls.empty:
+        exploded = s[gcoll_idx].explode()
+        plot_series(
+            exploded, cmap=cmap, color=color, ax=ax, figsize=figsize, **style_kwds
+        )
     plt.draw()
     return ax
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -20,25 +20,24 @@ def _flatten_multi_geoms(geoms, prefix="Multi"):
 
     components : list of geometry
 
-    component_index : list of whatever type `colors` contains
+    component_index : index array
+        indices are repeated for all components in the same Multi geometry
     """
     components, component_index = [], []
 
     if not geoms.geom_type.str.startswith(prefix).any():
-        return geoms, range(len(geoms))
+        return geoms, np.arange(len(geoms))
 
-    # precondition, so zip can't short-circuit
-    for geom, ix in zip(geoms, range(len(geoms))):
+    for ix, geom in enumerate(geoms):
         if geom.type.startswith(prefix):
             for poly in geom:
                 components.append(poly)
-                # repeat same color for all components
                 component_index.append(ix)
         else:
             components.append(geom)
             component_index.append(ix)
 
-    return components, component_index
+    return components, np.array(component_index)
 
 
 def plot_polygon_collection(

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-import geopandas as gpd
+import geopandas
 
 
 def _flatten_multi_geoms(geoms, prefix="Multi"):
@@ -339,7 +339,7 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
     # decompose GeometryCollections
     geoms, multiindex = _flatten_multi_geoms(s.geometry, prefix="Geom")
     values = np.take(values, multiindex, axis=0) if cmap else None
-    expl_series = gpd.GeoSeries(geoms)
+    expl_series = geopandas.GeoSeries(geoms)
 
     geom_types = expl_series.type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
@@ -585,7 +585,7 @@ def plot_dataframe(
     geoms, multiindex = _flatten_multi_geoms(df.geometry, prefix="Geom")
     values = np.take(values, multiindex, axis=0)
     nan_idx = np.take(nan_idx, multiindex, axis=0)
-    expl_series = gpd.GeoSeries(geoms)
+    expl_series = geopandas.GeoSeries(geoms)
 
     geom_types = expl_series.type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -571,7 +571,7 @@ class TestGeometryCollectionPlotting:
         coll1 = GeometryCollection(
             [
                 Polygon([(1, 0), (2, 0), (2, 1)]),
-                LineString([(0.5, 0.5), (1, 1), (1, 0.5), (1.5, 1)]),
+                MultiLineString([((0.5, 0.5), (1, 1)), ((1, 0.5), (1.5, 1))]),
             ]
         )
         coll2 = GeometryCollection(
@@ -584,17 +584,17 @@ class TestGeometryCollectionPlotting:
     def test_colors(self):
         # default uniform color
         ax = self.series.plot()
-        _check_colors(1, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR])
-        _check_colors(1, ax.collections[1].get_edgecolors(), [MPL_DFT_COLOR])
-        _check_colors(2, ax.collections[2].get_facecolors(), [MPL_DFT_COLOR])
+        _check_colors(1, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR])  # poly
+        _check_colors(2, ax.collections[1].get_edgecolors(), [MPL_DFT_COLOR])  # line
+        _check_colors(2, ax.collections[2].get_facecolors(), [MPL_DFT_COLOR])  # point
 
     def test_values(self):
         ax = self.df.plot("values")
         cmap = plt.get_cmap()
         exp_colors = cmap(np.arange(2) / 1)
-        _check_colors(1, ax.collections[0].get_facecolors(), exp_colors)
-        _check_colors(1, ax.collections[1].get_facecolors(), [exp_colors[0]])
-        _check_colors(2, ax.collections[2].get_facecolors(), [exp_colors[1]])
+        _check_colors(1, ax.collections[0].get_facecolors(), exp_colors)  # poly
+        _check_colors(2, ax.collections[1].get_edgecolors(), [exp_colors[0]])  # line
+        _check_colors(2, ax.collections[2].get_facecolors(), [exp_colors[1]])  # point
 
 
 class TestNonuniformGeometryPlotting:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -8,9 +8,11 @@ from shapely.geometry import (
     MultiPolygon,
     Polygon,
     LineString,
+    LinearRing,
     Point,
     MultiPoint,
     MultiLineString,
+    GeometryCollection,
 )
 
 
@@ -270,12 +272,24 @@ class TestLineStringPlotting:
             {"geometry": [multiline1, multiline2], "values": [0, 1]}
         )
 
+        self.linearrings = GeoSeries(
+            [LinearRing([(0, i), (4, i + 0.5), (9, i)]) for i in range(self.N)],
+            index=list("ABCDEFGHIJ"),
+        )
+        self.df3 = GeoDataFrame({"geometry": self.linearrings, "values": values})
+
     def test_single_color(self):
 
         ax = self.lines.plot(color="green")
         _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
 
         ax = self.df.plot(color="green")
+        _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
+
+        ax = self.linearrings.plot(color="green")
+        _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
+
+        ax = self.df3.plot(color="green")
         _check_colors(self.N, ax.collections[0].get_colors(), ["green"] * self.N)
 
         # check rgba tuple GH1178
@@ -526,6 +540,37 @@ class TestPolygonZPlotting:
     def test_plot(self):
         # basic test that points with z coords don't break plotting
         self.df.plot()
+
+
+class TestGeometryCollectionPlotting:
+    def setup_method(self):
+        coll1 = GeometryCollection(
+            [
+                Polygon([(1, 0), (2, 0), (2, 1)]),
+                LineString([(0.5, 0.5), (1, 1), (1, 0.5), (1.5, 1)]),
+            ]
+        )
+        coll2 = GeometryCollection(
+            [Point(0.75, 0.25), Polygon([(2, 2), (3, 2), (2, 3)])]
+        )
+
+        self.series = GeoSeries([coll1, coll2])
+        self.df = GeoDataFrame({"geometry": self.series, "values": [1, 2]})
+
+    def test_colors(self):
+        # default uniform color
+        ax = self.series.plot()
+        _check_colors(1, ax.collections[0].get_facecolors(), [MPL_DFT_COLOR])
+        _check_colors(1, ax.collections[1].get_edgecolors(), [MPL_DFT_COLOR])
+        _check_colors(2, ax.collections[2].get_facecolors(), [MPL_DFT_COLOR])
+
+    def test_values(self):
+        ax = self.df.plot("values")
+        cmap = plt.get_cmap()
+        exp_colors = cmap(np.arange(2) / 1)
+        _check_colors(1, ax.collections[0].get_facecolors(), exp_colors)
+        _check_colors(1, ax.collections[1].get_facecolors(), [exp_colors[0]])
+        _check_colors(2, ax.collections[2].get_facecolors(), [exp_colors[1]])
 
 
 class TestNonuniformGeometryPlotting:

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -11,6 +11,7 @@ import pytest
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="fails on AppVeyor")
 @pytest.mark.skipif(not base.HAS_SINDEX, reason="Rtree absent, skipping")
 class TestSeriesSindex:
+    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_index(self):
         assert GeoSeries().sindex is None
 
@@ -22,11 +23,13 @@ class TestSeriesSindex:
         hits = s.sindex.intersection((-2, -2, -1, -1))
         assert len(list(hits)) == 0
 
+    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_point(self):
         s = GeoSeries([Point()])
         assert s.sindex is None
         assert s._sindex_generated is True
 
+    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_geo_series(self):
         assert GeoSeries().sindex is None
 

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -11,7 +11,6 @@ import pytest
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="fails on AppVeyor")
 @pytest.mark.skipif(not base.HAS_SINDEX, reason="Rtree absent, skipping")
 class TestSeriesSindex:
-    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_index(self):
         assert GeoSeries().sindex is None
 
@@ -23,13 +22,11 @@ class TestSeriesSindex:
         hits = s.sindex.intersection((-2, -2, -1, -1))
         assert len(list(hits)) == 0
 
-    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_point(self):
         s = GeoSeries([Point()])
         assert s.sindex is None
         assert s._sindex_generated is True
 
-    @pytest.mark.skip(reason="rtree 0.9 - temp")
     def test_empty_geo_series(self):
         assert GeoSeries().sindex is None
 


### PR DESCRIPTION
Added support for GeometryCollections and LinearRings in `.plot()` for both GeoSeries and GeoDataFrame. As you can see, it first decomposes GeometryCollections  in `plot_dataframe` and then explodes MultiGeometries in `plot_XX_collection` as it did till now. I was thinking about decomposing everything at once, but since we can get MultiGeometry inside GeometryCollection,  we would have to do the check twice anyway. This way is seems to be more understandable for future maintenance.

As I am using `_flatten_multi_geoms` to decompose both Multi and GeometryCollections now, I have slightly changed it, so we can select what to decompose. And as we already returned multiindex instead of actual values, I have removed color attribute.

LinearRings are easy, they can be plotted exactly the same way as LineStrings.

Closes #953