### PR TITLE
ENH: Allow appending from to_file

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -162,7 +162,7 @@ def to_file(
     mode : string, default 'w'
         The write mode, 'w' to overwrite the existing file and 'a' to append.
         Not all drivers support appending. The drivers that support appending
-        are listed in
+        are listed in fiona.supported_drivers or
         https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py
 
     The *kwargs* are passed to fiona.open and can be used to write

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -89,7 +89,7 @@ def read_file(filename, bbox=None, **kwargs):
     return gdf
 
 
-def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
+def to_file(df, filename, driver="ESRI Shapefile", schema=None, mode="w", **kwargs):
     """
     Write this GeoDataFrame to an OGR data source
 
@@ -108,6 +108,11 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
         If specified, the schema dictionary is passed to Fiona to
         better control how the file is written. If None, GeoPandas
         will determine the schema based on each column's dtype
+    mode : string, default 'w'
+        The write mode, 'w' to overwrite the existing file and 'a' to append.
+        Not all drivers support appending. The drivers that support appending
+        are listed in
+        https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py
 
     The *kwargs* are passed to fiona.open and can be used to write
     to multi-layer data, store data within archives (zip files), etc.
@@ -117,7 +122,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
         schema = infer_schema(df)
     with fiona_env():
         with fiona.open(
-            filename, "w", driver=driver, crs=df.crs, schema=schema, **kwargs
+            filename, mode=mode, driver=driver, crs=df.crs, schema=schema, **kwargs
         ) as colxn:
             colxn.writerecords(df.iterfeatures())
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -129,7 +129,9 @@ def read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
     return gdf
 
 
-def to_file(df, filename, driver="ESRI Shapefile", schema=None, index=None, mode="w", **kwargs):
+def to_file(
+    df, filename, driver="ESRI Shapefile", schema=None, index=None, mode="w", **kwargs
+):
 
     """
     Write this GeoDataFrame to an OGR data source

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -216,7 +216,7 @@ def test_to_file_schema(tmpdir, df_nybb):
     assert result_schema == schema
 
 
-def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
+def test_append_file(tmpdir, df_nybb, df_null):
     """ Test to_file with append mode and from_file """
     tempfilename = os.path.join(str(tmpdir), "boros.shp")
     df_nybb.to_file(tempfilename, driver="ESRI Shapefile")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -216,6 +216,34 @@ def test_to_file_schema(tmpdir, df_nybb):
     assert result_schema == schema
 
 
+def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
+    """ Test to_file with append mode and from_file """
+    tempfilename = os.path.join(str(tmpdir), "boros.shp")
+    df_nybb.to_file(tempfilename, driver="ESRI Shapefile")
+    df_nybb.to_file(tempfilename, mode="a", driver="ESRI Shapefile")
+    # Read layer back in
+    df = GeoDataFrame.from_file(tempfilename)
+    assert "geometry" in df
+    assert len(df) == (5 * 2)
+    assert np.alltrue(
+        df["BoroName"].values
+        == np.concatenate([df_nybb["BoroName"].values, df_nybb["BoroName"].values])
+    )
+
+    # Write layer with null geometry out to file
+    tempfilename = os.path.join(str(tmpdir), "null_geom.shp")
+    df_null.to_file(tempfilename, driver="ESRI Shapefile")
+    df_null.to_file(tempfilename, mode="a", driver="ESRI Shapefile")
+    # Read layer back in
+    df = GeoDataFrame.from_file(tempfilename)
+    assert "geometry" in df
+    assert len(df) == (2 * 2)
+    assert np.alltrue(
+        df["Name"].values
+        == np.concatenate([df_null["Name"].values, df_null["Name"].values])
+    )
+
+
 # -----------------------------------------------------------------------------
 # read_file tests
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/1004

A simple test for appending to a Shapefile is included. It shouldn't be necessary to test for non-matching schemas when appending, because [Fiona does that](https://fiona.readthedocs.io/en/latest/manual.html#appending-data-to-existing-files):

> The record you write must match the file’s schema. You’ll get a ValueError if it doesn’t.

It doesn't look like there's a more user-friendly list of which formats support appending than in the code: https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py