### PR TITLE
TST: make dtype error message compatible with pandas

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -28,7 +28,9 @@ class GeometryDtype(ExtensionDtype):
         if string == cls.name:
             return cls()
         else:
-            raise TypeError("Cannot construct a '{}' from '{}'".format(cls, string))
+            raise TypeError(
+                "Cannot construct a '{}' from '{}'".format(cls.__name__, string)
+            )
 
     @classmethod
     def construct_array_type(cls):


### PR DESCRIPTION
This should fix the failure on the pandas master build (due to https://github.com/pandas-dev/pandas/pull/30247)