### PR TITLE
DOC: explain encoding in to_file, read_file

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -511,7 +511,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         The format drivers will attempt to detect the encoding of your data, but
         may fail. In this case, the proper encoding can be specified explicitly
-        by using the encoding keyword parameter: encoding='utf-8'.
+        by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
         """
         from geopandas.io.file import to_file
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -508,6 +508,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         The extra keyword arguments ``**kwargs`` are passed to fiona.open and
         can be used to write to multi-layer data, store data within archives
         (zip files), etc.
+
+        The format drivers will attempt to detect the encoding of your data, but
+        may fail. In this case, the proper encoding can be specified explicitly
+        by using the encoding keyword parameter: encoding='utf-8'.
         """
         from geopandas.io.file import to_file
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -511,7 +511,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         The format drivers will attempt to detect the encoding of your data, but
         may fail. In this case, the proper encoding can be specified explicitly
-        by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
+        by using the encoding keyword parameter, e.g. ``encoding='utf-8'``.
         """
         from geopandas.io.file import to_file
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -60,7 +60,7 @@ def read_file(filename, bbox=None, **kwargs):
     -----
     The format drivers will attempt to detect the encoding of your data, but
     may fail. In this case, the proper encoding can be specified explicitly
-    by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
+    by using the encoding keyword parameter, e.g. ``encoding='utf-8'``.
     """
     if _is_url(filename):
         req = _urlopen(filename)
@@ -123,7 +123,7 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
     -----
     The format drivers will attempt to detect the encoding of your data, but
     may fail. In this case, the proper encoding can be specified explicitly
-    by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
+    by using the encoding keyword parameter, e.g. ``encoding='utf-8'``.
     """
     if schema is None:
         schema = infer_schema(df)

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -60,7 +60,7 @@ def read_file(filename, bbox=None, **kwargs):
     -----
     The format drivers will attempt to detect the encoding of your data, but
     may fail. In this case, the proper encoding can be specified explicitly
-    by using the encoding keyword parameter: encoding='utf-8'.
+    by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
     """
     if _is_url(filename):
         req = _urlopen(filename)
@@ -118,6 +118,12 @@ def to_file(df, filename, driver="ESRI Shapefile", schema=None, **kwargs):
     The *kwargs* are passed to fiona.open and can be used to write
     to multi-layer data, store data within archives (zip files), etc.
     The path may specify a fiona VSI scheme.
+
+    Notes
+    -----
+    The format drivers will attempt to detect the encoding of your data, but
+    may fail. In this case, the proper encoding can be specified explicitly
+    by using the encoding keyword parameter, e.g. `encoding='utf-8'`.
     """
     if schema is None:
         schema = infer_schema(df)

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -55,6 +55,12 @@ def read_file(filename, bbox=None, **kwargs):
     Returns
     -------
     geodataframe : GeoDataFrame
+
+    Notes
+    -----
+    The format drivers will attempt to detect the encoding of your data, but
+    may fail. In this case, the proper encoding can be specified explicitly
+    by using the encoding keyword parameter: encoding='utf-8'.
     """
     if _is_url(filename):
         req = _urlopen(filename)


### PR DESCRIPTION
#1231 and #1240 are caused by wrong encoding detection. I have added a note to docs mentioning that it may happen and how to fix it.

Closes #1231  