### PR TITLE
BUG: explode() raises ValueError for unordered index

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -655,6 +655,17 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
+        df.index = [1, 0]
+        df.index.name = index_name
+        test_df2 = df.explode()
+        expected_index2 = MultiIndex(
+            [[0, 1], [0, 1]],  # levels
+            [[1, 1, 0], [0, 1, 0]],  # labels/codes
+            names=[index_name, None],
+        )
+        expected_df2 = expected_df.set_index(expected_index2)
+        assert_frame_equal(test_df2, expected_df2)
+
     #
     # Test '&', '|', '^', and '-'
     # The left can only be a GeoSeries. The right hand side can be a


### PR DESCRIPTION
Fixes #1223 

As explained in #1223, pd.concat has a problem merging gdfs with non-unique keys if they are not sorted. 

I have replaced concat with merge and stored order to resort gdf it in the end. Using merge is slightly faster than concat in this case (not needed `df_copy.sort_index(inplace=True)`).
