### PR TITLE
BUG: GeoSeries.reset_index() gives DataFrame not GeoDataFrame

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -220,6 +220,12 @@ class GeoSeries(GeoPandasBase, Series):
     def _constructor(self):
         return _geoseries_constructor_with_fallback
 
+    @property
+    def _constructor_expanddim(self):
+        from geopandas import GeoDataFrame
+
+        return GeoDataFrame
+
     def _wrapped_pandas_method(self, mtd, *args, **kwargs):
         """Wrap a generic pandas method to ensure it returns a GeoSeries"""
         val = getattr(super(GeoSeries, self), mtd)(*args, **kwargs)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -18,7 +18,7 @@ from shapely.geometry import (
 )
 from shapely.geometry.base import BaseGeometry
 
-from geopandas import GeoSeries
+from geopandas import GeoSeries, GeoDataFrame
 from geopandas.array import GeometryArray, GeometryDtype
 
 from geopandas.tests.util import geom_equals
@@ -324,3 +324,12 @@ class TestConstructor:
         assert [a.equals(b) for a, b in zip(s, g)]
         assert s.name == g.name
         assert s.index is g.index
+
+    # GH 1216
+    def test_expanddim(self):
+        s = GeoSeries(
+            [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
+        )
+        s = s.explode()
+        df = s.reset_index()
+        assert type(df) == GeoDataFrame


### PR DESCRIPTION
Fixes #1216 

Having GeoSeries with MultiIndex, GeoSeries.reset_index() returned pandas DataFrame not GeoDataFrame as I would expect in such a case.

I have used `GeoSeries._constructor_expanddim` as @jorisvandenbossche mentioned. As a result, `to_frame` also returns GeoDataFrame if called on GeoSeries which makes sense to me (it was a DataFrame).