### PR TITLE
Add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,7 +74,7 @@ free to contact the Code of Conduct Committee at
    * Posting sexually explicit or violent material
    * Posting (or threatening to post) other people's personally identifying
      information ("doxing")
-   * Personal insults, especially those using racist or sexist terms
+   * Personal insults, especially those using xenophobic or sexist terms
    * Unwelcome sexual attention
    * Advocating for, or encouraging, any of the above behavior
    * Repeated harassment of others. In general, if someone asks you to stop,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,7 +74,7 @@ free to contact the Code of Conduct Committee at
    * Posting sexually explicit or violent material
    * Posting (or threatening to post) other people's personally identifying
      information ("doxing")
-   * Personal insults, especially those using xenophobic or sexist terms
+   * Personal insults, especially those using racist, sexist, and xenophobic terms
    * Unwelcome sexual attention
    * Advocating for, or encouraging, any of the above behavior
    * Repeated harassment of others. In general, if someone asks you to stop,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,7 +38,7 @@ violations of this code outside these spaces may affect a person's ability to
 participate within them.
 
 By embracing the following principles, guidelines and actions to follow or
-avoid, you will help us make Jupyter a welcoming and productive community. Feel
+avoid, you will help us make GeoPandas a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
 [*conduct@geopandas.org*](mailto:conduct@geopandas.org) with any questions.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -111,6 +111,13 @@ The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous
 report, we will take appropriate action.
 
+Messages sent to the e-mail address or through the form will be sent
+only to the Code of Conduct Committee, which currently consists of:
+
+* Hannah Aizenman
+* Joris Van den Bossche
+* Martin Fleischmann
+
 
 ## Enforcement
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-# GeoPandas Code of Conduct
+# GeoPandas Project Code of Conduct
 
-Behind GeoPandas is an engaged and respectful community made up of people
+Behind GeoPandas Project is an engaged and respectful community made up of people
 from all over the world and of wide range of backgrounds.
 Naturally, this implies diversity of ideas and perspectives on often complex
 problems. Disagreement and healthy discussion of conflicting viewpoints is
@@ -31,14 +31,14 @@ for that: we welcome reports by emailing
 form](https://goo.gl/forms/CHANGETHELINK).
 
 This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by GeoPandas. This
+members, in all spaces managed by GeoPandas Project. This
 includes the mailing lists, our GitHub organization, our chat room, in-person
 events, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
 
 By embracing the following principles, guidelines and actions to follow or
-avoid, you will help us make GeoPandas a welcoming and productive community. Feel
+avoid, you will help us make GeoPandas Project a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
 [*conduct@geopandas.org*](mailto:conduct@geopandas.org) with any questions.
 
@@ -85,7 +85,7 @@ free to contact the Code of Conduct Committee at
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and GeoPandas is no exception.  Try to
+   technical, happen all the time and GeoPandas Project is no exception.  Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward.  And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn
@@ -113,13 +113,13 @@ report, we will take appropriate action.
 
 ## Enforcement
 
-Enforcement procedures within GeoPandas follow Project Jupyter's
+Enforcement procedures within GeoPandas Project follow Project Jupyter's
 [*Enforcement Manual*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md). For information on enforcement, please view the [original manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
 
 Original text courtesy of the [*Speak
 Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
 [*Django*](https://www.djangoproject.com/conduct) and [*Jupyter*](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md) Projects,
-modified by GeoPandas. We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
+modified by GeoPandas Project. We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
 
 All content on this page is licensed under a [*Creative Commons
 Attribution*](http://creativecommons.org/licenses/by/3.0/) license.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,8 +27,9 @@ work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc.  For these or other
 reasons, structured follow-up may be necessary and here we provide the means
 for that: we welcome reports by emailing
-[*conduct@geopandas.org*](mailto:conduct@geopandas.org) or by filling out [this
-form](https://goo.gl/forms/CHANGETHELINK).
+[*geopandas-conduct@googlegroups.com*](mailto:geopandas-conduct@googlegroups.com)
+or by filling out
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
 
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by the GeoPandas Project. This
@@ -40,7 +41,7 @@ participate within them.
 By embracing the following principles, guidelines and actions to follow or
 avoid, you will help us make the GeoPandas Project a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
-[*conduct@geopandas.org*](mailto:conduct@geopandas.org) with any questions.
+[*geopandas-conduct@googlegroups.com*](mailto:geopandas-conduct@googlegroups.com)  with any questions.
 
 
 1. **Be friendly and patient**.
@@ -103,8 +104,8 @@ a timely manner. Code of conduct violations reduce the value of the community
 for everyone and we take them seriously.
 
 You can file a report by emailing
-[*conduct@geopandas.org*](mailto:conduct@geopandas.org) or by filing out
-[this form](https://goo.gl/forms/CHANGETHELINK).
+[*geopandas-conduct@googlegroups.com*](mailto:geopandas-conduct@googlegroups.com) or by filing out
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform).
 
 The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 # GeoPandas Project Code of Conduct
 
-Behind GeoPandas Project is an engaged and respectful community made up of people
-from all over the world and of wide range of backgrounds.
+Behind the GeoPandas Project is an engaged and respectful community made up of people
+from all over the world and with a wide range of backgrounds.
 Naturally, this implies diversity of ideas and perspectives on often complex
 problems. Disagreement and healthy discussion of conflicting viewpoints is
 welcome: the best solutions to hard problems rarely come from a single angle.
@@ -31,14 +31,14 @@ for that: we welcome reports by emailing
 form](https://goo.gl/forms/CHANGETHELINK).
 
 This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by GeoPandas Project. This
+members, in all spaces managed by the GeoPandas Project. This
 includes the mailing lists, our GitHub organization, our chat room, in-person
 events, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
 
 By embracing the following principles, guidelines and actions to follow or
-avoid, you will help us make GeoPandas Project a welcoming and productive community. Feel
+avoid, you will help us make the GeoPandas Project a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
 [*conduct@geopandas.org*](mailto:conduct@geopandas.org) with any questions.
 
@@ -85,7 +85,7 @@ free to contact the Code of Conduct Committee at
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and GeoPandas Project is no exception.  Try to
+   technical, happen all the time and the GeoPandas Project is no exception.  Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward.  And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn
@@ -113,13 +113,13 @@ report, we will take appropriate action.
 
 ## Enforcement
 
-Enforcement procedures within GeoPandas Project follow Project Jupyter's
+Enforcement procedures within the GeoPandas Project follow Project Jupyter's
 [*Enforcement Manual*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md). For information on enforcement, please view the [original manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
 
 Original text courtesy of the [*Speak
 Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
 [*Django*](https://www.djangoproject.com/conduct) and [*Jupyter*](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md) Projects,
-modified by GeoPandas Project. We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
+modified by the GeoPandas Project. We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
 
 All content on this page is licensed under a [*Creative Commons
 Attribution*](http://creativecommons.org/licenses/by/3.0/) license.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,11 +1,7 @@
-# Project Jupyter Code of Conduct
+# GeoPandas Code of Conduct
 
-Project Jupyter is an engaged and respectful community made up of people
-from all over the world. Your involvement helps us to further our
-mission and to create an open platform that serves a broad range of
-communities, from research and education, to journalism, industry and
-beyond.
-
+Behind GeoPandas is an engaged and respectful community made up of people
+from all over the world and of wide range of backgrounds.
 Naturally, this implies diversity of ideas and perspectives on often complex
 problems. Disagreement and healthy discussion of conflicting viewpoints is
 welcome: the best solutions to hard problems rarely come from a single angle.
@@ -31,14 +27,12 @@ work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc.  For these or other
 reasons, structured follow-up may be necessary and here we provide the means
 for that: we welcome reports by emailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filling out [this
-form](https://goo.gl/forms/sJzOIie3zde9M71T2). For more details please see our
-Reporting Guidelines (for [online](reporting_online.md) and
-[in-person](reporting_events.md) contexts).
+[*conduct@geopandas.org*](mailto:conduct@geopandas.org) or by filling out [this
+form](https://goo.gl/forms/CHANGETHELINK).
 
 This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by Project Jupyter (including IPython). This
-includes the mailing lists, our GitHub organizations, our chat rooms, in-person
+members, in all spaces managed by GeoPandas. This
+includes the mailing lists, our GitHub organization, our chat room, in-person
 events, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
 participate within them.
@@ -46,7 +40,7 @@ participate within them.
 By embracing the following principles, guidelines and actions to follow or
 avoid, you will help us make Jupyter a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org) with any questions.
+[*conduct@geopandas.org*](mailto:conduct@geopandas.org) with any questions.
 
 
 1. **Be friendly and patient**.
@@ -91,7 +85,7 @@ free to contact the Code of Conduct Committee at
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and Jupyter is no exception.  Try to
+   technical, happen all the time and GeoPandas is no exception.  Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward.  And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn
@@ -109,10 +103,8 @@ a timely manner. Code of conduct violations reduce the value of the community
 for everyone and we take them seriously.
 
 You can file a report by emailing
-[*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filing out
-[this form](https://goo.gl/forms/sJzOIie3zde9M71T2). For more details or
-information on reporting in-person at an event, please see our Reporting
-Guidelines.
+[*conduct@geopandas.org*](mailto:conduct@geopandas.org) or by filing out
+[this form](https://goo.gl/forms/CHANGETHELINK).
 
 The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous
@@ -121,13 +113,13 @@ report, we will take appropriate action.
 
 ## Enforcement
 
-For information on enforcement, please view the [*Enforcement
-Manual*](enforcement.md).
+Enforcement procedures within GeoPandas follow Project Jupyter's
+[*Enforcement Manual*](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md). For information on enforcement, please view the [original manual](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md).
 
 Original text courtesy of the [*Speak
-Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
-and [*Django*](https://www.djangoproject.com/conduct) Projects,
-modified by Project Jupyter.  We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
+Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
+[*Django*](https://www.djangoproject.com/conduct) and [*Jupyter*](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md) Projects,
+modified by GeoPandas. We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
 
 All content on this page is licensed under a [*Creative Commons
 Attribution*](http://creativecommons.org/licenses/by/3.0/) license.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Project Jupyter Code of Conduct
+
+Project Jupyter is an engaged and respectful community made up of people
+from all over the world. Your involvement helps us to further our
+mission and to create an open platform that serves a broad range of
+communities, from research and education, to journalism, industry and
+beyond.
+
+Naturally, this implies diversity of ideas and perspectives on often complex
+problems. Disagreement and healthy discussion of conflicting viewpoints is
+welcome: the best solutions to hard problems rarely come from a single angle.
+But disagreement is not an excuse for aggression: humans tend to take
+disagreement personally and easily drift into behavior that ultimately degrades
+a community. This is particularly acute with online communication across
+language and cultural gaps, where many cues of human behavior are unavailable.
+We are outlining here a set of principles and processes to support a
+healthy community in the face of these challenges.
+
+Fundamentally, we are committed to fostering a productive, harassment-free
+environment for everyone. Rather than considering this code an exhaustive list
+of things that you can’t do, take it in the spirit it is intended - a guide to
+make it easier to enrich all of us and the communities in which we participate.
+
+Importantly: as a member of our community, *you are also a steward of these
+values*.  Not all problems need to be resolved via formal processes, and often
+a quick, friendly but clear word on an online forum or in person can help
+resolve a misunderstanding and de-escalate things.
+
+However, sometimes these informal processes may be inadequate: they fail to
+work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc.  For these or other
+reasons, structured follow-up may be necessary and here we provide the means
+for that: we welcome reports by emailing
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filling out [this
+form](https://goo.gl/forms/sJzOIie3zde9M71T2). For more details please see our
+Reporting Guidelines (for [online](reporting_online.md) and
+[in-person](reporting_events.md) contexts).
+
+This code applies equally to founders, developers, mentors and new community
+members, in all spaces managed by Project Jupyter (including IPython). This
+includes the mailing lists, our GitHub organizations, our chat rooms, in-person
+events, and any other forums created by the project team. In addition,
+violations of this code outside these spaces may affect a person's ability to
+participate within them.
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make Jupyter a welcoming and productive community. Feel
+free to contact the Code of Conduct Committee at
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org) with any questions.
+
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports
+   people of all backgrounds and identities. This includes, but is not limited
+   to, members of any race, ethnicity, culture, national origin, color,
+   immigration status, social and economic class, educational level, sex, sexual
+   orientation, gender identity and expression, age, physical appearance, family
+   status, technological or professional choices, academic
+   discipline, religion, mental ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn
+   will depend on the work of others. Any decision you take will affect users
+   and colleagues, and you should take those consequences into account when
+   making decisions. Remember that we're a world-wide community. You may be
+   communicating with someone with a different primary language or cultural
+   background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior or poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a community where people
+   feel uncomfortable or threatened is not a productive one.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not insult
+   or put down other community members. Harassment and other exclusionary
+   behavior are not acceptable. This includes, but is not limited to:
+   * Violent threats or violent language directed against another person
+   * Discriminatory jokes and language
+   * Posting sexually explicit or violent material
+   * Posting (or threatening to post) other people's personally identifying
+     information ("doxing")
+   * Personal insults, especially those using racist or sexist terms
+   * Unwelcome sexual attention
+   * Advocating for, or encouraging, any of the above behavior
+   * Repeated harassment of others. In general, if someone asks you to stop,
+     then stop
+
+6. **Moderate your expectations**. Please respect that community members choose
+   how they spend their time in the project. A thoughtful question about your
+   expectations is preferable to demands for another person's time.
+
+7. **When we disagree, try to understand why**. Disagreements, both social and
+   technical, happen all the time and Jupyter is no exception.  Try to
+   understand where others are coming from, as seeing a question from their
+   viewpoint may help find a new path forward.  And don’t forget that it is
+   human to err: blaming each other doesn’t get us anywhere, while we can learn
+   from mistakes to find better solutions.
+
+8. **A simple apology can go a long way**. It can often de-escalate a situation,
+   and telling someone that you are sorry is an act of empathy that doesn’t
+   automatically imply an admission of guilt.
+
+
+## Reporting
+
+If you believe someone is violating the code of conduct, please report this in
+a timely manner. Code of conduct violations reduce the value of the community
+for everyone and we take them seriously.
+
+You can file a report by emailing
+[*conduct@jupyter.org*](mailto:conduct@jupyter.org) or by filing out
+[this form](https://goo.gl/forms/sJzOIie3zde9M71T2). For more details or
+information on reporting in-person at an event, please see our Reporting
+Guidelines.
+
+The online form gives you the option to keep your report anonymous or request
+that we follow up with you directly. While we cannot follow up on an anonymous
+report, we will take appropriate action.
+
+
+## Enforcement
+
+For information on enforcement, please view the [*Enforcement
+Manual*](enforcement.md).
+
+Original text courtesy of the [*Speak
+Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
+and [*Django*](https://www.djangoproject.com/conduct) Projects,
+modified by Project Jupyter.  We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
+
+All content on this page is licensed under a [*Creative Commons
+Attribution*](http://creativecommons.org/licenses/by/3.0/) license.

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -28,8 +28,8 @@ work, there is urgency or risk to someone, nobody is intervening publicly and
 you don't feel comfortable speaking in public, etc. For these or other
 reasons, structured follow-up may be necessary and here we provide the means
 for that: we welcome reports by emailing
-`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ or by filling out `this
-form <https://goo.gl/forms/CHANGETHELINK>`__.
+`geopandas-conduct@googlegroups.com <mailto:geopandas-conduct@googlegroups.com>`__ or by filling out `this
+form <https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform>`__.
 
 This code applies equally to founders, developers, mentors and new community
 members, in all spaces managed by the GeoPandas Project. This
@@ -41,7 +41,7 @@ participate within them.
 By embracing the following principles, guidelines and actions to follow or
 avoid, you will help us make Jupyter a welcoming and productive community. Feel
 free to contact the Code of Conduct Committee at
-`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ with any questions.
+`geopandas-conduct@googlegroups.com <mailto:geopandas-conduct@googlegroups.com>`__ with any questions.
 
 1. **Be friendly and patient**.
 
@@ -102,8 +102,8 @@ a timely manner. Code of conduct violations reduce the value of the community
 for everyone and we take them seriously.
 
 You can file a report by emailing
-`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ or by filing out
-`this form <https://goo.gl/forms/CHANGETHELINK>`__.
+`geopandas-conduct@googlegroups.com <mailto:geopandas-conduct@googlegroups.com>`__ or by filing out
+`this form <https://docs.google.com/forms/d/e/1FAIpQLSd8Tbi2zNl1i2N9COX0yavHEqTGFIPQ1_cLcy1A3JgVc1OrAQ/viewform>`__.
 
 The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -1,8 +1,8 @@
 GeoPandas Project Code of Conduct
 =================================
 
-Behind GeoPandas Project is an engaged and respectful community made up of
-people from all over the world and of wide range of backgrounds.
+Behind the GeoPandas Project is an engaged and respectful community made up of
+people from all over the world and with a wide range of backgrounds.
 Naturally, this implies diversity of ideas and perspectives on often
 complex problems. Disagreement and healthy discussion of conflicting
 viewpoints is welcome: the best solutions to hard problems rarely come from a single
@@ -32,7 +32,7 @@ for that: we welcome reports by emailing
 form <https://goo.gl/forms/CHANGETHELINK>`__.
 
 This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by GeoPandas Project. This
+members, in all spaces managed by the GeoPandas Project. This
 includes the mailing lists, our GitHub organization, our chat room, in-person
 events, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
@@ -84,7 +84,7 @@ free to contact the Code of Conduct Committee at
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and GeoPandas Project is no exception. Try to
+   technical, happen all the time and the GeoPandas Project is no exception. Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward. And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn
@@ -112,7 +112,7 @@ report, we will take appropriate action.
 Enforcement
 -----------
 
-Enforcement procedures within GeoPandas Project follow Project Jupyter's `Enforcement
+Enforcement procedures within the GeoPandas Project follow Project Jupyter's `Enforcement
 Manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
 For information on enforcement, please view the `original
 manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
@@ -121,7 +121,7 @@ Original text courtesy of the `Speak
 Up! <http://web.archive.org/web/20141109123859/http://speakup.io/coc.html>`__,
 `Django <https://www.djangoproject.com/conduct>`__ and
 `Jupyter <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__
-Projects, modified by GeoPandas Project. We are grateful to those projects for
+Projects, modified by the GeoPandas Project. We are grateful to those projects for
 contributing these materials under open licensing terms for us to easily reuse.
 
 All content on this page is licensed under a `Creative Commons

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -74,7 +74,7 @@ free to contact the Code of Conduct Committee at
    -  Discriminatory jokes and language
    -  Posting sexually explicit or violent material
    -  Posting (or threatening to post) other people's personally identifying information ("doxing")
-   -  Personal insults, especially those using xenophobic or sexist terms
+   -  Personal insults, especially those using racist, sexist, and xenophobic terms
    -  Unwelcome sexual attention
    -  Advocating for, or encouraging, any of the above behavior
    -  Repeated harassment of others. In general, if someone asks you to stop, then stop

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -109,6 +109,13 @@ The online form gives you the option to keep your report anonymous or request
 that we follow up with you directly. While we cannot follow up on an anonymous
 report, we will take appropriate action.
 
+Messages sent to the e-mail address or through the form will be sent
+only to the Code of Conduct Committee, which currently consists of:
+
+- Hannah Aizenman
+- Joris Van den Bossche
+- Martin Fleischmann
+
 Enforcement
 -----------
 

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -74,7 +74,7 @@ free to contact the Code of Conduct Committee at
    -  Discriminatory jokes and language
    -  Posting sexually explicit or violent material
    -  Posting (or threatening to post) other people's personally identifying information ("doxing")
-   -  Personal insults, especially those using racist or sexist terms
+   -  Personal insults, especially those using xenophobic or sexist terms
    -  Unwelcome sexual attention
    -  Advocating for, or encouraging, any of the above behavior
    -  Repeated harassment of others. In general, if someone asks you to stop, then stop

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -1,7 +1,7 @@
-GeoPandas Code of Conduct
-=========================
+GeoPandas Project Code of Conduct
+=================================
 
-Behind GeoPandas is an engaged and respectful community made up of
+Behind GeoPandas Project is an engaged and respectful community made up of
 people from all over the world and of wide range of backgrounds.
 Naturally, this implies diversity of ideas and perspectives on often
 complex problems. Disagreement and healthy discussion of conflicting
@@ -32,7 +32,7 @@ for that: we welcome reports by emailing
 form <https://goo.gl/forms/CHANGETHELINK>`__.
 
 This code applies equally to founders, developers, mentors and new community
-members, in all spaces managed by GeoPandas. This
+members, in all spaces managed by GeoPandas Project. This
 includes the mailing lists, our GitHub organization, our chat room, in-person
 events, and any other forums created by the project team. In addition,
 violations of this code outside these spaces may affect a person's ability to
@@ -84,7 +84,7 @@ free to contact the Code of Conduct Committee at
    expectations is preferable to demands for another person's time.
 
 7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and GeoPandas is no exception. Try to
+   technical, happen all the time and GeoPandas Project is no exception. Try to
    understand where others are coming from, as seeing a question from their
    viewpoint may help find a new path forward. And don’t forget that it is
    human to err: blaming each other doesn’t get us anywhere, while we can learn
@@ -112,7 +112,7 @@ report, we will take appropriate action.
 Enforcement
 -----------
 
-Enforcement procedures within GeoPandas follow Project Jupyter's `Enforcement
+Enforcement procedures within GeoPandas Project follow Project Jupyter's `Enforcement
 Manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
 For information on enforcement, please view the `original
 manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
@@ -121,7 +121,7 @@ Original text courtesy of the `Speak
 Up! <http://web.archive.org/web/20141109123859/http://speakup.io/coc.html>`__,
 `Django <https://www.djangoproject.com/conduct>`__ and
 `Jupyter <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__
-Projects, modified by GeoPandas. We are grateful to those projects for
+Projects, modified by GeoPandas Project. We are grateful to those projects for
 contributing these materials under open licensing terms for us to easily reuse.
 
 All content on this page is licensed under a `Creative Commons

--- a/doc/source/code_of_conduct.rst
+++ b/doc/source/code_of_conduct.rst
@@ -1,0 +1,128 @@
+GeoPandas Code of Conduct
+=========================
+
+Behind GeoPandas is an engaged and respectful community made up of
+people from all over the world and of wide range of backgrounds.
+Naturally, this implies diversity of ideas and perspectives on often
+complex problems. Disagreement and healthy discussion of conflicting
+viewpoints is welcome: the best solutions to hard problems rarely come from a single
+angle. But disagreement is not an excuse for aggression: humans tend to take
+disagreement personally and easily drift into behavior that ultimately
+degrades a community. This is particularly acute with online communication
+across language and cultural gaps, where many cues of human behavior are
+unavailable. We are outlining here a set of principles and processes to support a
+healthy community in the face of these challenges.
+
+Fundamentally, we are committed to fostering a productive, harassment-free
+environment for everyone. Rather than considering this code an exhaustive list
+of things that you can’t do, take it in the spirit it is intended - a guide to
+make it easier to enrich all of us and the communities in which we participate.
+
+Importantly: as a member of our community, *you are also a steward of these
+values*. Not all problems need to be resolved via formal processes, and often
+a quick, friendly but clear word on an online forum or in person can help
+resolve a misunderstanding and de-escalate things.
+
+However, sometimes these informal processes may be inadequate: they fail to
+work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc. For these or other
+reasons, structured follow-up may be necessary and here we provide the means
+for that: we welcome reports by emailing
+`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ or by filling out `this
+form <https://goo.gl/forms/CHANGETHELINK>`__.
+
+This code applies equally to founders, developers, mentors and new community
+members, in all spaces managed by GeoPandas. This
+includes the mailing lists, our GitHub organization, our chat room, in-person
+events, and any other forums created by the project team. In addition,
+violations of this code outside these spaces may affect a person's ability to
+participate within them.
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make Jupyter a welcoming and productive community. Feel
+free to contact the Code of Conduct Committee at
+`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ with any questions.
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports
+   people of all backgrounds and identities. This includes, but is not limited
+   to, members of any race, ethnicity, culture, national origin, color,
+   immigration status, social and economic class, educational level, sex, sexual
+   orientation, gender identity and expression, age, physical appearance, family
+   status, technological or professional choices, academic
+   discipline, religion, mental ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn
+   will depend on the work of others. Any decision you take will affect users
+   and colleagues, and you should take those consequences into account when
+   making decisions. Remember that we're a world-wide community. You may be
+   communicating with someone with a different primary language or cultural
+   background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior or poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a community where people
+   feel uncomfortable or threatened is not a productive one.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not insult
+   or put down other community members. Harassment and other exclusionary
+   behavior are not acceptable. This includes, but is not limited to:
+
+   -  Violent threats or violent language directed against another person
+   -  Discriminatory jokes and language
+   -  Posting sexually explicit or violent material
+   -  Posting (or threatening to post) other people's personally identifying information ("doxing")
+   -  Personal insults, especially those using racist or sexist terms
+   -  Unwelcome sexual attention
+   -  Advocating for, or encouraging, any of the above behavior
+   -  Repeated harassment of others. In general, if someone asks you to stop, then stop
+
+6. **Moderate your expectations**. Please respect that community members choose
+   how they spend their time in the project. A thoughtful question about your
+   expectations is preferable to demands for another person's time.
+
+7. **When we disagree, try to understand why**. Disagreements, both social and
+   technical, happen all the time and GeoPandas is no exception. Try to
+   understand where others are coming from, as seeing a question from their
+   viewpoint may help find a new path forward. And don’t forget that it is
+   human to err: blaming each other doesn’t get us anywhere, while we can learn
+   from mistakes to find better solutions.
+
+8. **A simple apology can go a long way**. It can often de-escalate a situation,
+   and telling someone that you are sorry is an act of empathy that doesn’t
+    automatically imply an admission of guilt.
+
+Reporting
+---------
+
+If you believe someone is violating the code of conduct, please report this in
+a timely manner. Code of conduct violations reduce the value of the community
+for everyone and we take them seriously.
+
+You can file a report by emailing
+`conduct@geopandas.org <mailto:conduct@geopandas.org>`__ or by filing out
+`this form <https://goo.gl/forms/CHANGETHELINK>`__.
+
+The online form gives you the option to keep your report anonymous or request
+that we follow up with you directly. While we cannot follow up on an anonymous
+report, we will take appropriate action.
+
+Enforcement
+-----------
+
+Enforcement procedures within GeoPandas follow Project Jupyter's `Enforcement
+Manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
+For information on enforcement, please view the `original
+manual <https://github.com/jupyter/governance/blob/master/conduct/enforcement.md>`__.
+
+Original text courtesy of the `Speak
+Up! <http://web.archive.org/web/20141109123859/http://speakup.io/coc.html>`__,
+`Django <https://www.djangoproject.com/conduct>`__ and
+`Jupyter <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`__
+Projects, modified by GeoPandas. We are grateful to those projects for
+contributing these materials under open licensing terms for us to easily reuse.
+
+All content on this page is licensed under a `Creative Commons
+Attribution <http://creativecommons.org/licenses/by/3.0/>`__ license.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,7 @@ such as PostGIS.
   :caption: Developer
 
   Contributing to GeoPandas <contributing>
+  Code of Conduct <code_of_conduct>
 
 
 Get in touch


### PR DESCRIPTION
Added Code of Conduct for GeoPandas Project based on [Project Jupyter's version](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md) as agreed in #978. You can see the changes by comparing with the first commit on this branch containing the original text.

We have to do couple of things:

- [x] decide who will be on the Code of Conduct committee. These people will receive email sent to specific email address set up for the purpose of reporting/questions and from the form.
- [x] set-up email address. At the moment I have used conduct@geopandas.org but we can go with geopandas-conduct@googlegroups.com as Dask has. I am not sure what are the options with our domain.
- [x] set-up reporting form. I can do that once we'll know the committee, based on Jupyter's example.


Closes #978