### PR TITLE
DOC: Add note on field types to io

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -50,6 +50,12 @@ Writing Spatial Data
 
 GeoDataFrames can be exported to many different standard formats using the ``GeoDataFrame.to_file()`` method. For a full list of supported formats, type ``import fiona; fiona.supported_drivers``.
 
+.. note::
+
+    GeoDataFrame can contain more field types than most of the file types. For example tuples or lists
+    can be easily stored in the GeoDataFrame, but saving them to GeoPackage will raise a ValueError.
+    Before saving to a file, they need to be converted to a format supported by a selected driver.
+
 **Writing to Shapefile**::
 
     countries_gdf.to_file("countries.shp")

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -53,7 +53,7 @@ GeoDataFrames can be exported to many different standard formats using the ``Geo
 .. note::
 
     GeoDataFrame can contain more field types than most of the file types. For example tuples or lists
-    can be easily stored in the GeoDataFrame, but saving them to GeoPackage will raise a ValueError.
+    can be easily stored in the GeoDataFrame, but saving them to e.g. GeoPackage or Shapefile will raise a ValueError.
     Before saving to a file, they need to be converted to a format supported by a selected driver.
 
 **Writing to Shapefile**::

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -52,7 +52,7 @@ GeoDataFrames can be exported to many different standard formats using the ``Geo
 
 .. note::
 
-    GeoDataFrame can contain more field types than most of the file types. For example tuples or lists
+    GeoDataFrame can contain more field types than supported by most of the file formats. For example tuples or lists
     can be easily stored in the GeoDataFrame, but saving them to e.g. GeoPackage or Shapefile will raise a ValueError.
     Before saving to a file, they need to be converted to a format supported by a selected driver.
 


### PR DESCRIPTION
As discussed in #1286, the fact that GeoDataFrame can contain various objects, while standard GIS formats can't, can be confusing on using `to_file()`. I have added a note to the documentation explaining the issue. 

Closes #1286