### PR TITLE
ENH: scaling y-axis for plots in geographic CRS

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -275,7 +275,7 @@ plot_point_collection = deprecated(_plot_point_collection)
 
 
 def plot_series(
-    s, cmap=None, color=None, ax=None, figsize=None, set_aspect="auto", **style_kwds
+    s, cmap=None, color=None, ax=None, figsize=None, aspect="auto", **style_kwds
 ):
     """
     Plot a GeoSeries.
@@ -303,7 +303,7 @@ def plot_series(
     figsize : pair of floats (default None)
         Size of the resulting matplotlib.figure.Figure. If the argument
         ax is given explicitly, figsize is ignored.
-    set_aspect : 'auto', 'equal' or float (default 'auto')
+    aspect : 'auto', 'equal' or float (default 'auto')
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
@@ -346,7 +346,7 @@ def plot_series(
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
 
-    if set_aspect == "auto":
+    if aspect == "auto":
         if s.crs and s.crs.is_geographic:
             bounds = s.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
@@ -354,7 +354,7 @@ def plot_series(
         else:
             ax.set_aspect("equal")
     else:
-        ax.set_aspect(set_aspect)
+        ax.set_aspect(aspect)
 
     if s.empty:
         warnings.warn(
@@ -439,7 +439,7 @@ def plot_dataframe(
     legend_kwds=None,
     classification_kwds=None,
     missing_kwds=None,
-    set_aspect="auto",
+    aspect="auto",
     **style_kwds
 ):
     """
@@ -510,7 +510,7 @@ def plot_dataframe(
         to be passed on to geometries with missing values in addition to
         or overwriting other style kwds. If None, geometries with missing
         values are not plotted.
-    set_aspect : 'auto', 'equal' or float (default 'auto')
+    aspect : 'auto', 'equal' or float (default 'auto')
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
@@ -562,7 +562,7 @@ def plot_dataframe(
             raise ValueError("'ax' can not be None if 'cax' is not.")
         fig, ax = plt.subplots(figsize=figsize)
 
-    if set_aspect == "auto":
+    if aspect == "auto":
         if df.crs and df.crs.is_geographic:
             bounds = df.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
@@ -570,7 +570,7 @@ def plot_dataframe(
         else:
             ax.set_aspect("equal")
     else:
-        ax.set_aspect(set_aspect)
+        ax.set_aspect(aspect)
 
     if df.empty:
         warnings.warn(
@@ -591,7 +591,7 @@ def plot_dataframe(
             ax=ax,
             figsize=figsize,
             markersize=markersize,
-            set_aspect=set_aspect,
+            aspect=aspect,
             **style_kwds
         )
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -340,9 +340,7 @@ def plot_series(
         if s.crs and s.crs.is_geographic:
             bounds = s.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
-
             ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
-
         else:
             ax.set_aspect("equal", share=True)
     else:
@@ -556,9 +554,7 @@ def plot_dataframe(
         if df.crs and df.crs.is_geographic:
             bounds = df.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
-
             ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
-
         else:
             ax.set_aspect("equal", share=True)
     else:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -293,6 +293,13 @@ def plot_series(
     figsize : pair of floats (default None)
         Size of the resulting matplotlib.figure.Figure. If the argument
         ax is given explicitly, figsize is ignored.
+    set_aspect : 'auto', 'equal' or float (default 'auto')
+        Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
+        however data are not projected (coordinates are long/lat), the aspect is by
+        default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
+        the GeoSeries (the mean of the y range of bounding box). This implies an
+        Equirectangular projection. It can also be set manually (float) as the ratio
+        of y-unit to x-unit.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
@@ -330,7 +337,7 @@ def plot_series(
         fig, ax = plt.subplots(figsize=figsize)
 
     if set_aspect == "auto":
-        if s.crs.is_geographic:
+        if s.crs and s.crs.is_geographic:
             bounds = s.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
 
@@ -493,8 +500,13 @@ def plot_dataframe(
         to be passed on to geometries with missing values in addition to
         or overwriting other style kwds. If None, geometries with missing
         values are not plotted.
-    set_aspect : 'auto', 'equal' or float [0, 1]
-        Set aspect of axis. 'auto' geog, etc. TO WRITE
+    set_aspect : 'auto', 'equal' or float (default 'auto')
+        Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
+        however data are not projected (coordinates are long/lat), the aspect is by
+        default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
+        the GeoDataFrame (the mean of the y range of bounding box). This implies an
+        Equirectangular projection. It can also be set manually (float) as the ratio
+        of y-unit to x-unit.
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -541,7 +553,7 @@ def plot_dataframe(
         fig, ax = plt.subplots(figsize=figsize)
 
     if set_aspect == "auto":
-        if df.crs.is_geographic:
+        if df.crs and df.crs.is_geographic:
             bounds = df.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -340,11 +340,11 @@ def plot_series(
         if s.crs and s.crs.is_geographic:
             bounds = s.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
-            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
+            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180))
         else:
-            ax.set_aspect("equal", share=True)
+            ax.set_aspect("equal")
     else:
-        ax.set_aspect(set_aspect, share=True)
+        ax.set_aspect(set_aspect)
 
     if s.empty:
         warnings.warn(
@@ -554,11 +554,11 @@ def plot_dataframe(
         if df.crs and df.crs.is_geographic:
             bounds = df.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
-            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
+            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180))
         else:
-            ax.set_aspect("equal", share=True)
+            ax.set_aspect("equal")
     else:
-        ax.set_aspect(set_aspect, share=True)
+        ax.set_aspect(set_aspect)
 
     if df.empty:
         warnings.warn(

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -264,7 +264,9 @@ def plot_point_collection(
     return collection
 
 
-def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
+def plot_series(
+    s, cmap=None, color=None, ax=None, figsize=None, set_aspect="auto", **style_kwds
+):
     """
     Plot a GeoSeries.
 
@@ -326,7 +328,18 @@ def plot_series(s, cmap=None, color=None, ax=None, figsize=None, **style_kwds):
 
     if ax is None:
         fig, ax = plt.subplots(figsize=figsize)
-    ax.set_aspect("equal")
+
+    if set_aspect == "auto":
+        if s.crs.is_geographic:
+            bounds = s.total_bounds
+            y_coord = np.mean([bounds[1], bounds[3]])
+
+            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
+
+        else:
+            ax.set_aspect("equal", share=True)
+    else:
+        ax.set_aspect(set_aspect, share=True)
 
     if s.empty:
         warnings.warn(
@@ -409,6 +422,7 @@ def plot_dataframe(
     legend_kwds=None,
     classification_kwds=None,
     missing_kwds=None,
+    set_aspect="auto",
     **style_kwds
 ):
     """
@@ -479,6 +493,8 @@ def plot_dataframe(
         to be passed on to geometries with missing values in addition to
         or overwriting other style kwds. If None, geometries with missing
         values are not plotted.
+    set_aspect : 'auto', 'equal' or float [0, 1]
+        Set aspect of axis. 'auto' geog, etc. TO WRITE
 
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -523,7 +539,18 @@ def plot_dataframe(
         if cax is not None:
             raise ValueError("'ax' can not be None if 'cax' is not.")
         fig, ax = plt.subplots(figsize=figsize)
-    ax.set_aspect("equal")
+
+    if set_aspect == "auto":
+        if df.crs.is_geographic:
+            bounds = df.total_bounds
+            y_coord = np.mean([bounds[1], bounds[3]])
+
+            ax.set_aspect(1 / np.cos(y_coord * np.pi / 180), share=True)
+
+        else:
+            ax.set_aspect("equal", share=True)
+    else:
+        ax.set_aspect(set_aspect, share=True)
 
     if df.empty:
         warnings.warn(
@@ -544,6 +571,7 @@ def plot_dataframe(
             ax=ax,
             figsize=figsize,
             markersize=markersize,
+            set_aspect=set_aspect,
             **style_kwds
         )
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -307,7 +307,8 @@ def plot_series(
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
-        the GeoSeries (the mean of the y range of bounding box). This implies an
+        the GeoSeries (the mean of the y range of bounding box) so that a long/lat
+        square appears square in the middle of the plot. This implies an
         Equirectangular projection. It can also be set manually (float) as the ratio
         of y-unit to x-unit.
     **style_kwds : dict
@@ -351,6 +352,8 @@ def plot_series(
             bounds = s.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
             ax.set_aspect(1 / np.cos(y_coord * np.pi / 180))
+            # formula ported from R package sp
+            # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
     else:
@@ -514,7 +517,8 @@ def plot_dataframe(
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
-        the GeoDataFrame (the mean of the y range of bounding box). This implies an
+        the GeoDataFrame (the mean of the y range of bounding box) so that a long/lat
+        square appears square in the middle of the plot. This implies an
         Equirectangular projection. It can also be set manually (float) as the ratio
         of y-unit to x-unit.
 
@@ -567,6 +571,8 @@ def plot_dataframe(
             bounds = df.total_bounds
             y_coord = np.mean([bounds[1], bounds[3]])
             ax.set_aspect(1 / np.cos(y_coord * np.pi / 180))
+            # formula ported from R package sp
+            # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
     else:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -629,6 +629,51 @@ class TestNonuniformGeometryPlotting:
         assert ax.collections[2].get_sizes() == [10]
 
 
+class TestGeographicAspect:
+    def setup_class(self):
+        pth = get_path("naturalearth_lowres")
+        df = read_file(pth)
+        self.north = df.loc[df.continent == "North America"]
+        self.north_proj = self.north.to_crs("ESRI:102008")
+        bounds = self.north.total_bounds
+        y_coord = np.mean([bounds[1], bounds[3]])
+        self.exp = 1 / np.cos(y_coord * np.pi / 180)
+
+    def test_auto(self):
+        ax = self.north.geometry.plot()
+        assert ax.get_aspect() == self.exp
+        ax2 = self.north_proj.geometry.plot()
+        assert ax2.get_aspect() == "equal"
+        ax = self.north.plot()
+        assert ax.get_aspect() == self.exp
+        ax2 = self.north_proj.plot()
+        assert ax2.get_aspect() == "equal"
+        ax3 = self.north.plot("pop_est")
+        assert ax3.get_aspect() == self.exp
+        ax4 = self.north_proj.plot("pop_est")
+        assert ax4.get_aspect() == "equal"
+
+    def test_manual(self):
+        ax = self.north.geometry.plot(set_aspect="equal")
+        assert ax.get_aspect() == "equal"
+        ax2 = self.north.geometry.plot(set_aspect=0.5)
+        assert ax2.get_aspect() == 0.5
+        ax3 = self.north_proj.geometry.plot(set_aspect=0.5)
+        assert ax3.get_aspect() == 0.5
+        ax = self.north.plot(set_aspect="equal")
+        assert ax.get_aspect() == "equal"
+        ax2 = self.north.plot(set_aspect=0.5)
+        assert ax2.get_aspect() == 0.5
+        ax3 = self.north_proj.plot(set_aspect=0.5)
+        assert ax3.get_aspect() == 0.5
+        ax = self.north.plot("pop_est", set_aspect="equal")
+        assert ax.get_aspect() == "equal"
+        ax2 = self.north.plot("pop_est", set_aspect=0.5)
+        assert ax2.get_aspect() == 0.5
+        ax3 = self.north_proj.plot("pop_est", set_aspect=0.5)
+        assert ax3.get_aspect() == 0.5
+
+
 class TestMapclassifyPlotting:
     @classmethod
     def setup_class(cls):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -643,31 +643,31 @@ class TestGeographicAspect:
         ax = self.north.geometry.plot()
         assert ax.get_aspect() == self.exp
         ax2 = self.north_proj.geometry.plot()
-        assert ax2.get_aspect() == "equal"
+        assert ax2.get_aspect() in ["equal", 1.0]
         ax = self.north.plot()
         assert ax.get_aspect() == self.exp
         ax2 = self.north_proj.plot()
-        assert ax2.get_aspect() == "equal"
+        assert ax2.get_aspect() in ["equal", 1.0]
         ax3 = self.north.plot("pop_est")
         assert ax3.get_aspect() == self.exp
         ax4 = self.north_proj.plot("pop_est")
-        assert ax4.get_aspect() == "equal"
+        assert ax4.get_aspect() in ["equal", 1.0]
 
     def test_manual(self):
         ax = self.north.geometry.plot(set_aspect="equal")
-        assert ax.get_aspect() == "equal"
+        assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.geometry.plot(set_aspect=0.5)
         assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.geometry.plot(set_aspect=0.5)
         assert ax3.get_aspect() == 0.5
         ax = self.north.plot(set_aspect="equal")
-        assert ax.get_aspect() == "equal"
+        assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.plot(set_aspect=0.5)
         assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.plot(set_aspect=0.5)
         assert ax3.get_aspect() == 0.5
         ax = self.north.plot("pop_est", set_aspect="equal")
-        assert ax.get_aspect() == "equal"
+        assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.plot("pop_est", set_aspect=0.5)
         assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.plot("pop_est", set_aspect=0.5)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -654,23 +654,23 @@ class TestGeographicAspect:
         assert ax4.get_aspect() in ["equal", 1.0]
 
     def test_manual(self):
-        ax = self.north.geometry.plot(set_aspect="equal")
+        ax = self.north.geometry.plot(aspect="equal")
         assert ax.get_aspect() in ["equal", 1.0]
-        ax2 = self.north.geometry.plot(set_aspect=0.5)
+        ax2 = self.north.geometry.plot(aspect=0.5)
         assert ax2.get_aspect() == 0.5
-        ax3 = self.north_proj.geometry.plot(set_aspect=0.5)
+        ax3 = self.north_proj.geometry.plot(aspect=0.5)
         assert ax3.get_aspect() == 0.5
-        ax = self.north.plot(set_aspect="equal")
+        ax = self.north.plot(aspect="equal")
         assert ax.get_aspect() in ["equal", 1.0]
-        ax2 = self.north.plot(set_aspect=0.5)
+        ax2 = self.north.plot(aspect=0.5)
         assert ax2.get_aspect() == 0.5
-        ax3 = self.north_proj.plot(set_aspect=0.5)
+        ax3 = self.north_proj.plot(aspect=0.5)
         assert ax3.get_aspect() == 0.5
-        ax = self.north.plot("pop_est", set_aspect="equal")
+        ax = self.north.plot("pop_est", aspect="equal")
         assert ax.get_aspect() in ["equal", 1.0]
-        ax2 = self.north.plot("pop_est", set_aspect=0.5)
+        ax2 = self.north.plot("pop_est", aspect=0.5)
         assert ax2.get_aspect() == 0.5
-        ax3 = self.north_proj.plot("pop_est", set_aspect=0.5)
+        ax3 = self.north_proj.plot("pop_est", aspect=0.5)
         assert ax3.get_aspect() == 0.5
 
 


### PR DESCRIPTION
Implementation of #1121 and the first utilisation of brand new pyproj.CRS 🎉.

`.plot()` now automatically determines whether GeoSeries (or GeoDataFrame) is in geographic or projected CRS and calculates aspect for geographic using `1/cos(s_y * pi/180)` with s_y the y coordinate of the mean of y-bounds of GeoSeries. This leads to better representation of the actual shapes than current hard-coded 'equal' aspect. It is just a minor visual thing, but note that it changes the default behaviour. Implementation is ported from R package `sf`.

You can control the behaviour using new `set_aspect` (matching matplotlib `ax.set_aspect`) keyword, which can be set to `'auto'` (default new behaviour explained above), 'equal' (current) or float which is then passed to `ax.set_aspect()`. Terminology is the same used within [matplotlib](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_aspect.html).

Can be merged for 0.7.0 as an illustration of the new pyproj.CRS abilities or we can keep it for 0.8.0, there is no rush.

Illustrations:

`world[world.name == 'Canada'].plot()`

Current:
![Unknown-1](https://user-images.githubusercontent.com/36797143/74092372-b3416000-4aba-11ea-9cbb-298ea27aba38.png)

New:
![Unknown](https://user-images.githubusercontent.com/36797143/74092362-9e64cc80-4aba-11ea-88f1-cdaacf0e7e47.png)

You can imitate current behaviour using 
`world[world.name == 'Canada'].plot(set_aspect='equal')`

Closes #1121

cc @rsbivand