### PR TITLE
DOC: Fix intersphinx mapping with pyproj docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,11 +65,11 @@ sphinx_gallery_conf = {
     'reference_url': {'matplotlib': 'http://matplotlib.org',
                       'numpy': 'http://docs.scipy.org/doc/numpy',
                       'scipy': 'http://docs.scipy.org/doc/scipy/reference',
-                      'pyproj': 'http://pyproj4.github.io/pyproj/stable/',
                       'geopandas': None},
     'backreferences_dir': 'reference'
 }
-
+# connect docs in other projects
+intersphinx_mapping = {'pyproj': ('http://pyproj4.github.io/pyproj/stable/', None)}
 # suppress matplotlib warning in examples
 warnings.filterwarnings(
     "ignore",

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -22,7 +22,7 @@ The same CRS can often be referred to in many ways. For example, one of the most
 commonly used CRS is the WGS84 latitude-longitude projection. This can be
 referred to using the authority code ``"EPSG:4326"``.
 
-*geopandas* can accept anything accepted by :meth:`pyproj.crs.CRS.from_user_input`:
+*geopandas* can accept anything accepted by :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`:
 
 - CRS WKT string
 - An authority string (i.e. "epsg:4326")

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -22,7 +22,7 @@ The same CRS can often be referred to in many ways. For example, one of the most
 commonly used CRS is the WGS84 latitude-longitude projection. This can be
 referred to using the authority code ``"EPSG:4326"``.
 
-*geopandas* can accept anything accepted by `pyproj.CRS.from_user_input() <https://pyproj4.github.io/pyproj/stable/api/crs.html#pyproj.crs.CRS.from_user_input>`_:
+*geopandas* can accept anything accepted by :meth:`pyproj.crs.CRS.from_user_input`:
 
 - CRS WKT string
 - An authority string (i.e. "epsg:4326")

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -143,7 +143,7 @@ class GeoPandasBase(object):
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
         can be anything accepted by
-        :meth:`:meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
         """
         return self._crs

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -142,7 +142,7 @@ class GeoPandasBase(object):
 
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
-        can be anything accepted by :meth:`pyproj.CRS.from_user_input`,
+        can be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
         """
         return self._crs

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -142,7 +142,8 @@ class GeoPandasBase(object):
 
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
-        can be anything accepted by :meth:`pyproj.crs.CRS.from_user_input`,
+        can be anything accepted by
+        :meth:`:meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
         """
         return self._crs

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -122,15 +122,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-        col : column label or array
-        drop : boolean, default True
+        col: column label or array
+        drop: boolean, default True
             Delete column to be used as the new geometry
-        inplace : boolean, default False
+        inplace: boolean, default False
             Modify the GeoDataFrame in place (do not create a new object)
-        crs : str/result of fion.get_crs (optional)
-            Coordinate system to use. If passed, overrides both DataFrame and
-            col's crs. Otherwise, tries to get crs from passed col values or
-            DataFrame.
+        crs: pyproj.crs.CRS, optional
+            Coordinate system to use. The value can be anything accepted
+            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
+            string (eg "EPSG:4326") or a WKT string. If passed, overrides
+            both DataFrame and col's crs. Otherwise, tries to get crs
+            from passed col values or DataFrame.
 
         Examples
         --------
@@ -139,7 +141,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Returns
         -------
-        geodataframe : GeoDataFrame
+        GeoDataFrame
         """
         # Most of the code here is taken from DataFrame.set_index()
         if inplace:
@@ -547,15 +549,19 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-        crs : pyproj.CRS, optional if `epsg` is specified
+        crs: pyproj.crs.CRS, optional if `epsg` is specified
             The value can be anything accepted
-            by :meth:`pyproj.CRS.from_user_input`, such as an authority
+            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
             string (eg "EPSG:4326") or a WKT string.
-        epsg : int, optional if `crs` is specified
+        epsg: int, optional if `crs` is specified
             EPSG code specifying output projection.
-        inplace : bool, optional, default: False
+        inplace: bool, optional, default: False
             Whether to return a new GeoDataFrame or do the transformation in
             place.
+
+        Returns
+        -------
+        GeoDataFrame
         """
         if inplace:
             df = self

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -122,17 +122,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-        col: column label or array
-        drop: boolean, default True
+        col : column label or array
+        drop : boolean, default True
             Delete column to be used as the new geometry
-        inplace: boolean, default False
+        inplace : boolean, default False
             Modify the GeoDataFrame in place (do not create a new object)
-        crs: pyproj.crs.CRS, optional
+        crs : pyproj.CRS, optional
             Coordinate system to use. The value can be anything accepted
-            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
-            string (eg "EPSG:4326") or a WKT string. If passed, overrides
-            both DataFrame and col's crs. Otherwise, tries to get crs
-            from passed col values or DataFrame.
+            by :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+            such as an authority string (eg "EPSG:4326") or a WKT string.
+            If passed, overrides both DataFrame and col's crs.
+            Otherwise, tries to get crs from passed col values or DataFrame.
 
         Examples
         --------
@@ -549,13 +549,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-        crs: pyproj.crs.CRS, optional if `epsg` is specified
-            The value can be anything accepted
-            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
-            string (eg "EPSG:4326") or a WKT string.
-        epsg: int, optional if `crs` is specified
+        crs : pyproj.CRS, optional if `epsg` is specified
+            The value can be anything accepted by
+            :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+            such as an authority string (eg "EPSG:4326") or a WKT string.
+        epsg : int, optional if `crs` is specified
             EPSG code specifying output projection.
-        inplace: bool, optional, default: False
+        inplace : bool, optional, default: False
             Whether to return a new GeoDataFrame or do the transformation in
             place.
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -410,11 +410,11 @@ class GeoSeries(GeoPandasBase, Series):
 
         Parameters
         ----------
-        crs: pyproj.crs.CRS, optional if `epsg` is specified
+        crs : pyproj.CRS, optional if `epsg` is specified
             The value can be anything accepted
-            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
-            string (eg "EPSG:4326") or a WKT string.
-        epsg: int, optional if `crs` is specified
+            by :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+            such as an authority string (eg "EPSG:4326") or a WKT string.
+        epsg : int, optional if `crs` is specified
             EPSG code specifying output projection.
 
         Returns

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -410,12 +410,16 @@ class GeoSeries(GeoPandasBase, Series):
 
         Parameters
         ----------
-        crs : pyproj.CRS, optional if `epsg` is specified
+        crs: pyproj.crs.CRS, optional if `epsg` is specified
             The value can be anything accepted
-            by :meth:`pyproj.CRS.from_user_input`, such as an authority
+            by :meth:`pyproj.crs.CRS.from_user_input`, such as an authority
             string (eg "EPSG:4326") or a WKT string.
-        epsg : int, optional if `crs` is specified
+        epsg: int, optional if `crs` is specified
             EPSG code specifying output projection.
+
+        Returns
+        -------
+        GeoSeries
         """
         if self.crs is None:
             raise ValueError(


### PR DESCRIPTION
Also, fixed some cases where an extra space between the parameter and the `:` were causing issues in the docs.

Note: I didn't run black on the `conf.py` in the `doc` folder as it would have redone the entire file and cluttered up the commit.