### PR TITLE
DOC: fix docstring styling with sphinx > 2

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -2,3 +2,16 @@
 div.section a span {
     color: #2980B9 !important
 }
+
+/*Copied from sphinx' basic.css to ensure the sphinx >2.0 docstrings are
+rendered somewhat properly (xref https://github.com/numpy/numpydoc/issues/215) */
+
+.classifier {
+    font-style: oblique;
+}
+
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}


### PR DESCRIPTION
xref https://github.com/geopandas/geopandas/pull/1297#issuecomment-586748219.

There is some discussion in https://github.com/numpy/numpydoc/issues/215 about this. TL;DR: sphinx 2.0 changed the way they format field lists in the Parameters section in the resulting html, which broke how many themes rendered docstrings. 
The numpydoc issues has several cross links from projects dealing with this. Here, I copied the mimimal css from sphinx' basic.css to fix the most pressing display issue (the fact that there is no space between the parameter and its type, see eg https://geopandas.readthedocs.io/en/v0.6.0/reference.html#geopandas.GeoSeries.contains)

The relevant (unsolved) issue on rtd's side: https://github.com/readthedocs/sphinx_rtd_theme/issues/746