### PR TITLE
BUG: clip GeoSeries by non-overlapping mask raises error

### DIFF
--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -152,7 +152,11 @@ def clip(gdf, mask, keep_geom_type=False):
         ((box_mask[0] <= box_gdf[2]) and (box_gdf[0] <= box_mask[2]))
         and ((box_mask[1] <= box_gdf[3]) and (box_gdf[1] <= box_mask[3]))
     ):
-        return GeoDataFrame(columns=gdf.columns, crs=gdf.crs)
+        return (
+            GeoDataFrame(columns=gdf.columns, crs=gdf.crs)
+            if isinstance(gdf, GeoDataFrame)
+            else GeoSeries(crs=gdf.crs)
+        )
 
     if isinstance(mask, (GeoDataFrame, GeoSeries)):
         poly = mask.geometry.unary_union

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -9,7 +9,7 @@ from shapely.geometry import Polygon, Point, LineString, LinearRing, GeometryCol
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, clip
-from geopandas.testing import assert_geodataframe_equal
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 import pytest
 
@@ -159,7 +159,7 @@ def test_returns_series(point_gdf, single_rectangle_gdf):
 
 
 def test_non_overlapping_geoms():
-    """Test that a bounding box returns error if the extents don't overlap"""
+    """Test that a bounding box returns empty if the extents don't overlap"""
     unit_box = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
     unit_gdf = GeoDataFrame([1], geometry=[unit_box], crs="EPSG:4326")
     non_overlapping_gdf = unit_gdf.copy()
@@ -170,6 +170,8 @@ def test_non_overlapping_geoms():
     assert_geodataframe_equal(
         out, GeoDataFrame(columns=unit_gdf.columns, crs=unit_gdf.crs)
     )
+    out2 = clip(unit_gdf.geometry, non_overlapping_gdf)
+    assert_geoseries_equal(out2, GeoSeries(crs=unit_gdf.crs))
 
 
 def test_clip_points(point_gdf, single_rectangle_gdf):


### PR DESCRIPTION
Closes #1308 

Minor fix for clip to ensure that empty GeoSeries is returned if mask is not overlapping with original GeoSeries. Now it raises error as we expect GeoDataFrame there.