### PR TITLE
BUG: ignore NaNs in total_bounds if there is geometry 

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -788,12 +788,12 @@ class GeometryArray(ExtensionArray):
         b = self.bounds
         return np.array(
             (
-                b[:, 0].min(),  # minx
-                b[:, 1].min(),  # miny
-                b[:, 2].max(),  # maxx
-                b[:, 3].max(),
+                np.nanmin(b[:, 0]),  # minx
+                np.nanmin(b[:, 1]),  # miny
+                np.nanmax(b[:, 2]),  # maxx
+                np.nanmax(b[:, 3]),  # maxy
             )
-        )  # maxy
+        )
 
     # -------------------------------------------------------------------------
     # general array like compat

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -635,10 +635,10 @@ def test_total_bounds():
     )
     expected = np.array(
         [
-            bounds[:, 0].min(),  # minx
-            bounds[:, 1].min(),  # miny
-            bounds[:, 2].max(),  # maxx
-            bounds[:, 3].max(),  # maxy
+            np.nanmin(bounds[:, 0]),  # minx
+            np.nanmin(bounds[:, 1]),  # miny
+            np.nanmax(bounds[:, 2]),  # maxx
+            np.nanmax(bounds[:, 3]),  # maxy
         ]
     )
     np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
Closes #1310 

`total_bounds` should ignore missing and empty geometries as they do not have any spatial extent and return extent of existing geometries instead of returning array of NaNs. See #1310 for details. As `total_bounds` is a property, there is no way to give a choice to filter out missing geoms, so I'd say the correct way to handle it is ignoring them. Moreover, it was implemented like that in the beginning, than changed during refactoring, I'd say unintentionally as there is no discussion on the topic.
