### PR TITLE
BUG: Fix sjoin on empty column

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -120,8 +120,9 @@ def sjoin(
 
     r_idx = np.empty((0, 0))
     l_idx = np.empty((0, 0))
-    # get rtree spatial index
-    if tree_idx_right:
+    # get rtree spatial index. If tree_idx does not exist, it is due to a failure
+    # to generate the index (e.g., if the column is empty).
+    if tree_idx_right and tree_idx:
         idxmatch = left_df.geometry.apply(lambda x: x.bounds).apply(
             lambda x: list(tree_idx.intersection(x)) if not x == () else []
         )
@@ -130,7 +131,7 @@ def sjoin(
         if idxmatch.shape[0] > 0:
             r_idx = np.concatenate(idxmatch.values)
             l_idx = np.concatenate([[i] * len(v) for i, v in idxmatch.iteritems()])
-    else:
+    elif not tree_idx_right and tree_idx:
         # tree_idx_df == 'left'
         idxmatch = right_df.geometry.apply(lambda x: x.bounds).apply(
             lambda x: list(tree_idx.intersection(x)) if not x == () else []

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -75,14 +75,15 @@ def sjoin(
         )
 
     # Attempt to re-use spatial indexes, otherwise generate the spatial index
-    # for the longer dataframe
+    # for the longer dataframe. If we are joining to an empty dataframe,
+    # don't bother generating the index.
     if right_df._sindex_generated or (
         not left_df._sindex_generated and right_df.shape[0] > left_df.shape[0]
     ):
-        tree_idx = right_df.sindex
+        tree_idx = right_df.sindex if len(left_df) > 0 else None
         tree_idx_right = True
     else:
-        tree_idx = left_df.sindex
+        tree_idx = left_df.sindex if len(right_df) > 0 else None
         tree_idx_right = False
 
     # the rtree spatial index only allows limited (numeric) index types, but an
@@ -120,8 +121,9 @@ def sjoin(
 
     r_idx = np.empty((0, 0))
     l_idx = np.empty((0, 0))
-    # get rtree spatial index. If tree_idx does not exist, it is due to a failure
-    # to generate the index (e.g., if the column is empty).
+    # get rtree spatial index. If tree_idx does not exist, it is due to either a
+    # failure to generate the index (e.g., if the column is empty), or the
+    # other dataframe is empty so it wasn't necessary to generate it.
     if tree_idx_right and tree_idx:
         idxmatch = left_df.geometry.apply(lambda x: x.bounds).apply(
             lambda x: list(tree_idx.intersection(x)) if not x == () else []

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -186,7 +186,7 @@ class TestSpatialJoin:
         assert_frame_equal(res, exp)
 
     def test_empty_join(self):
-        # Check empty joins
+        # Check joins resulting in empty gdfs.
         polygons = geopandas.GeoDataFrame(
             {
                 "col2": [1, 2],
@@ -203,6 +203,26 @@ class TestSpatialJoin:
         assert empty.index_left.isnull().all()
         empty = sjoin(not_in, polygons, how="inner", op="intersects")
         assert empty.empty
+
+    @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
+    def test_join_with_empty(self, op):
+        # Check joins with empty geometry columns.
+        polygons = geopandas.GeoDataFrame(
+            {
+                "col2": [1, 2],
+                "geometry": [
+                    Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                    Polygon([(1, 0), (2, 0), (2, 1), (1, 1)]),
+                ],
+            }
+        )
+        empty = GeoDataFrame(geometry=[GeometryCollection(), GeometryCollection()])
+        result = sjoin(empty, polygons, how="left", op=op)
+        assert result.index_right.isnull().all()
+        result = sjoin(empty, polygons, how="right", op=op)
+        assert result.index_left.isnull().all()
+        result = sjoin(empty, polygons, how="inner", op=op)
+        assert result.empty
 
     @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
     def test_sjoin_invalid_args(self, dfs):

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -205,8 +205,15 @@ class TestSpatialJoin:
         assert empty.empty
 
     @pytest.mark.parametrize("op", ["intersects", "contains", "within"])
-    def test_join_with_empty(self, op):
-        # Check joins with empty geometry columns.
+    @pytest.mark.parametrize(
+        "empty",
+        [
+            GeoDataFrame(geometry=[GeometryCollection(), GeometryCollection()]),
+            GeoDataFrame(geometry=GeoSeries()),
+        ],
+    )
+    def test_join_with_empty(self, op, empty):
+        # Check joins with empty geometry columns/dataframes.
         polygons = geopandas.GeoDataFrame(
             {
                 "col2": [1, 2],
@@ -216,7 +223,6 @@ class TestSpatialJoin:
                 ],
             }
         )
-        empty = GeoDataFrame(geometry=[GeometryCollection(), GeometryCollection()])
         result = sjoin(empty, polygons, how="left", op=op)
         assert result.index_right.isnull().all()
         result = sjoin(empty, polygons, how="right", op=op)


### PR DESCRIPTION
Fixes #1307, fixes #1315 .

This allows for sjoin to succeed when one of the joined geodataframes cannot generate a spatial index (either due to an empty GDF, or due to all empty rows).