### PR TITLE
BUG: patch gdf.explode() concat issue

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -737,9 +737,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
         exploded_index = exploded_geom.columns[0]
 
-        df = pd.concat(
-            [df_copy.drop(df_copy._geometry_column_name, axis=1), exploded_geom], axis=1
-        )
+        df = df_copy.drop(df_copy._geometry_column_name, axis=1).join(exploded_geom)
         # reset to MultiIndex, otherwise df index is only first level of
         # exploded GeoSeries index.
         df.set_index(exploded_index, append=True, inplace=True)


### PR DESCRIPTION
This is a patch for #1223. It should be fixed in pandas (https://github.com/pandas-dev/pandas/pull/31113), but in the meantime this seems to resolve the issue as workaround of sorting/reseting index doesn't always work.

cc @seizethedata