### PR TITLE
BUG: Do not modify original DataFrame during creation of GeoDataFrame

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -58,6 +58,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         crs = kwargs.pop("crs", None)
         geometry = kwargs.pop("geometry", None)
         super(GeoDataFrame, self).__init__(*args, **kwargs)
+        self._data = self._data.copy()
 
         # need to set this before calling self['geometry'], because
         # getitem accesses crs

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -44,6 +44,16 @@ class TestDataFrame:
         assert type(self.df2) is GeoDataFrame
         assert self.df2.crs == self.crs
 
+    def test_preserve_original_dataframe(self):
+        dataframe = pd.DataFrame(
+            {"latitude": [35.5, 35.2, 34.89], "longitude": [-112.02, -111.09, -115.3]}
+        )
+        GeoDataFrame(
+            dataframe,
+            geometry=[Point(x, y) for x, y in zip(dataframe.longitude, dataframe.latitude)],
+        )
+        assert_frame_equal(dataframe, dataframe)
+
     def test_different_geo_colname(self):
         data = {
             "A": range(5),

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -52,7 +52,10 @@ class TestDataFrame:
             dataframe,
             geometry=[Point(x, y) for x, y in zip(dataframe.longitude, dataframe.latitude)],
         )
-        assert_frame_equal(dataframe, dataframe)
+        df_check = pd.DataFrame(
+             {"latitude": [35.5, 35.2, 34.89], "longitude": [-112.02, -111.09, -115.3]}
+         )
+        assert_frame_equal(df_check, dataframe)
 
     def test_different_geo_colname(self):
         data = {

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -48,13 +48,11 @@ class TestDataFrame:
         dataframe = pd.DataFrame(
             {"latitude": [35.5, 35.2, 34.89], "longitude": [-112.02, -111.09, -115.3]}
         )
+        df_check = dataframe.copy()
         GeoDataFrame(
             dataframe,
             geometry=[Point(x, y) for x, y in zip(dataframe.longitude, dataframe.latitude)],
         )
-        df_check = pd.DataFrame(
-             {"latitude": [35.5, 35.2, 34.89], "longitude": [-112.02, -111.09, -115.3]}
-         )
         assert_frame_equal(df_check, dataframe)
 
     def test_different_geo_colname(self):


### PR DESCRIPTION
Fixes #1179 
Make modification to the copy of the data instead of the original, 