### PR TITLE
CI: allow failures on DEV CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
 
     - env: ENV_FILE="ci/travis/37-dev.yaml" DEV=true
 
+  allow_failures:
+    - env: ENV_FILE="ci/travis/37-dev.yaml" DEV=true
 
 install:
   # Install conda

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -282,7 +282,7 @@ def test_numerical_operations(s, df):
     with pytest.raises(TypeError):
         s.max()
 
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, ValueError)):
         s.idxmax()
 
     # numerical ops raise an error

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -282,7 +282,7 @@ def test_numerical_operations(s, df):
     with pytest.raises(TypeError):
         s.max()
 
-    with pytest.raises((TypeError, ValueError)):
+    with pytest.raises(TypeError):
         s.idxmax()
 
     # numerical ops raise an error


### PR DESCRIPTION
Fixing one of the issues with testing with pandas master after pandas started to raise different error message.

At the same time, I am moving DEV CI environment to allowed failures on Travis, so we don't get red CI for all our PRs due to changes in pandas master which broke unrelated things.