### PR TITLE
DOC: add missing methods to reference

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -25,6 +25,10 @@ The following Shapely methods and attributes are available on
 
 .. autoattribute:: geopandas.GeoSeries.interiors
 
+.. autoattribute:: geopandas.GeoSeries.x
+
+.. autoattribute:: geopandas.GeoSeries.y
+
 `Unary Predicates`
 
 .. autoattribute:: geopandas.GeoSeries.is_empty
@@ -95,17 +99,28 @@ The following Shapely methods and attributes are available on
 
 Additionally, the following attributes and methods are implemented:
 
+.. automethod:: geopandas.GeoSeries.from_file
+
+.. automethod:: geopandas.GeoSeries.to_file
+
+.. automethod:: geopandas.GeoSeries.to_json
+
 .. autoattribute:: geopandas.GeoSeries.crs
 
 .. automethod:: geopandas.GeoSeries.to_crs
-
-.. automethod:: geopandas.GeoSeries.from_file
 
 .. automethod:: geopandas.GeoSeries.plot
 
 .. autoattribute:: geopandas.GeoSeries.total_bounds
 
 .. autoattribute:: geopandas.GeoSeries.__geo_interface__
+
+.. automethod:: geopandas.GeoSeries.isna
+
+.. automethod:: geopandas.GeoSeries.notna
+
+.. automethod:: geopandas.GeoSeries.fillna
+
 
 Methods of pandas ``Series`` objects are also available, although not
 all are applicable to geometric objects and some may return a
@@ -128,7 +143,11 @@ Currently, the following methods/attributes are implemented for a ``GeoDataFrame
 
 .. automethod:: geopandas.GeoDataFrame.from_file
 
+.. automethod:: geopandas.GeoDataFrame.from_features
+
 .. automethod:: geopandas.GeoDataFrame.from_postgis
+
+.. automethod:: geopandas.GeoDataFrame.to_crs
 
 .. automethod:: geopandas.GeoDataFrame.to_file
 
@@ -140,6 +159,10 @@ Currently, the following methods/attributes are implemented for a ``GeoDataFrame
 
 .. automethod:: geopandas.GeoDataFrame.set_geometry
 
+.. automethod:: geopandas.GeoDataFrame.explode
+
+.. automethod:: geopandas.GeoDataFrame.dissolve
+
 .. autoattribute:: geopandas.GeoDataFrame.__geo_interface__
 
 All pandas ``DataFrame`` methods are also available, although they may
@@ -147,8 +170,22 @@ not operate in a meaningful way on the ``geometry`` column and may not
 return a ``GeoDataFrame`` result even when it would be appropriate to
 do so.
 
-API Pages
----------
+Testing
+-------
+
+GeoPandas includes specific functions to test its objects.
+
+.. autofunction:: geopandas.testing.geom_equals
+
+.. autofunction:: geopandas.testing.geom_almost_equals
+
+.. autofunction:: geopandas.testing.assert_geoseries_equal
+
+.. autofunction:: geopandas.testing.assert_geodataframe_equal
+
+
+Top-level Functions
+-------------------
 
 .. currentmodule:: geopandas
 .. autosummary::
@@ -162,4 +199,6 @@ API Pages
   overlay
   clip
   tools.geocode
+  tools.collect
+  points_from_xy
   datasets.get_path


### PR DESCRIPTION
Added missing methods and functions to reference API. This was initially part of #1254, but I am splitting it as this can be merged immediately.  

Closes #1052, closes #805