### PR TITLE
ENH: informative error in iterfeatures if no geometry set

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -100,7 +100,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if self._geometry_column_name not in self:
             raise AttributeError(
                 "No geometry data set yet (expected in"
-                " column '%s'." % self._geometry_column_name
+                " column '%s'.)" % self._geometry_column_name
             )
         return self[self._geometry_column_name]
 
@@ -425,6 +425,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         if na not in ["null", "drop", "keep"]:
             raise ValueError("Unknown na method {0}".format(na))
+
+        if self._geometry_column_name not in self:
+            raise AttributeError(
+                "No geometry data set (expected in"
+                " column '%s')." % self._geometry_column_name
+            )
 
         ids = np.array(self.index, copy=False)
         geometries = np.array(self[self._geometry_column_name], copy=False)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -600,6 +600,11 @@ class TestDataFrame:
         result = list(df_only_numerical_cols.iterfeatures(na="keep"))[0]
         assert type(result["properties"]["Shape_Leng"]) is float
 
+        # geometry not set
+        df = GeoDataFrame({"values": [0, 1], "geom": [Point(0, 1), Point(1, 0)]})
+        with pytest.raises(AttributeError):
+            list(df.iterfeatures())
+
     def test_geodataframe_geojson_no_bbox(self):
         geo = self.df._to_geo(na="null", show_bbox=False)
         assert "bbox" not in geo.keys()


### PR DESCRIPTION
If geodataframe has no geometry column set, `iterfeatures()` will fail with no indication why that happened. I am just adding a tiny check to raise an informative error if there is no set geometry.

+ one minor type found along the way.