### PR TITLE
ENH: return GeoSeries when accessing GeometryDtype columns

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, Series
 
 from shapely.geometry import mapping, shape
 
-from geopandas.array import GeometryArray, from_shapely
+from geopandas.array import GeometryArray, from_shapely, GeometryDtype
 from geopandas.base import GeoPandasBase, is_geometry_type
 from geopandas.geoseries import GeoSeries
 import geopandas.io
@@ -587,7 +587,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         result = super(GeoDataFrame, self).__getitem__(key)
         geo_col = self._geometry_column_name
-        if isinstance(key, str) and key == geo_col:
+        if isinstance(result, Series) and isinstance(result.dtype, GeometryDtype):
             result.__class__ = GeoSeries
             result.crs = self.crs
             result._invalidate_sindex()

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -61,7 +61,7 @@ def geom_almost_equals(this, that):
 def assert_geoseries_equal(
     left,
     right,
-    check_dtype=False,
+    check_dtype=True,
     check_index_type=False,
     check_series_type=True,
     check_less_precise=False,
@@ -96,7 +96,6 @@ def assert_geoseries_equal(
         msg = "dtype should be a GeometryDtype, got {0}"
         assert isinstance(left.dtype, GeometryDtype), msg.format(left.dtype)
         assert isinstance(right.dtype, GeometryDtype), msg.format(left.dtype)
-        assert left.dtype == right.dtype, "dtype: %s != %s" % (left.dtype, right.dtype)
 
     if check_index_type:
         assert isinstance(left.index, type(right.index))

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -92,15 +92,14 @@ def assert_geoseries_equal(
     """
     assert len(left) == len(right), "%d != %d" % (len(left), len(right))
 
-    msg = "dtype should be a GeometryDtype, got {0}"
-    assert isinstance(left.dtype, GeometryDtype), msg.format(left.dtype)
-    assert isinstance(right.dtype, GeometryDtype), msg.format(left.dtype)
+    if check_dtype:
+        msg = "dtype should be a GeometryDtype, got {0}"
+        assert isinstance(left.dtype, GeometryDtype), msg.format(left.dtype)
+        assert isinstance(right.dtype, GeometryDtype), msg.format(left.dtype)
+        assert left.dtype == right.dtype, "dtype: %s != %s" % (left.dtype, right.dtype)
 
     if check_index_type:
         assert isinstance(left.index, type(right.index))
-
-    if check_dtype:
-        assert left.dtype == right.dtype, "dtype: %s != %s" % (left.dtype, right.dtype)
 
     if check_series_type:
         assert isinstance(left, GeoSeries)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -12,7 +12,7 @@ from shapely.geometry import Point
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, read_file
-from geopandas.array import GeometryArray, GeometryDtype
+from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, connect, create_postgis, validate_boro_df
@@ -76,6 +76,12 @@ class TestDataFrame:
         # good if this changed in the future
         assert not isinstance(df["geometry"], GeoSeries)
         assert isinstance(df["location"], GeoSeries)
+
+        df["buff"] = df.buffer(1)
+        assert isinstance(df["buff"], GeoSeries)
+
+        df["array"] = from_shapely([Point(x, y) for x, y in zip(range(5), range(5))])
+        assert isinstance(df["array"], GeoSeries)
 
         data["geometry"] = [Point(x + 1, y - 1) for x, y in zip(range(5), range(5))]
         df = GeoDataFrame(data, crs=self.crs)

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from shapely.geometry import Point, Polygon
+from pandas import Series
 
 from geopandas import GeoDataFrame, GeoSeries
 
@@ -20,12 +21,21 @@ s2 = GeoSeries(
     ]
 )
 
+s = Series(
+    [
+        Polygon([(0, 2), (0, 0), (2, 0), (2, 2)]),
+        Polygon([(2, 2), (4, 2), (4, 4), (2, 4)]),
+    ]
+)
+
 df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1})
 df2 = GeoDataFrame({"col1": [1, 2], "geometry": s2})
 
 
 def test_geoseries():
     assert_geoseries_equal(s1, s2)
+    assert_geoseries_equal(s1, s, check_series_type=False)
+    assert_geoseries_equal(s, s2, check_series_type=False)
 
     with pytest.raises(AssertionError):
         assert_geoseries_equal(s1, s2, check_less_precise=True)

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -4,6 +4,7 @@ from shapely.geometry import Point, Polygon
 from pandas import Series
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas.array import from_shapely
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
@@ -21,12 +22,22 @@ s2 = GeoSeries(
     ]
 )
 
-s = Series(
+
+s3 = Series(
     [
         Polygon([(0, 2), (0, 0), (2, 0), (2, 2)]),
         Polygon([(2, 2), (4, 2), (4, 4), (2, 4)]),
     ]
 )
+
+a = from_shapely(
+    [
+        Polygon([(0, 2), (0, 0), (2, 0), (2, 2)]),
+        Polygon([(2, 2), (4, 2), (4, 4), (2, 4)]),
+    ]
+)
+
+s4 = Series(a)
 
 df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1})
 df2 = GeoDataFrame({"col1": [1, 2], "geometry": s2})
@@ -34,8 +45,9 @@ df2 = GeoDataFrame({"col1": [1, 2], "geometry": s2})
 
 def test_geoseries():
     assert_geoseries_equal(s1, s2)
-    assert_geoseries_equal(s1, s, check_series_type=False)
-    assert_geoseries_equal(s, s2, check_series_type=False)
+    assert_geoseries_equal(s1, s3, check_series_type=False, check_dtype=False)
+    assert_geoseries_equal(s3, s2, check_series_type=False, check_dtype=False)
+    assert_geoseries_equal(s1, s4, check_series_type=False)
 
     with pytest.raises(AssertionError):
         assert_geoseries_equal(s1, s2, check_less_precise=True)


### PR DESCRIPTION
Closes #1192 

When accessing geometry dtype column, geopandas currently returns GeoSeries only for active geometry. This PR checks for GeometryDtype and returns GeoSeries for all columns containing GeometryArray.

```
df = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres')) 
df['centroids'] = df.geometry.centroid   
df.dtypes   

pop_est          int64
continent       object
name            object
iso_a3          object
gdp_md_est     float64
geometry      geometry
centroids     geometry
dtype: object

type(df['geometry']) 
geopandas.geoseries.GeoSeries

type(df['centroids']) 
geopandas.geoseries.GeoSeries
```