### PR TITLE
ENH: move CRS to GeometryArray level

### DIFF
--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -118,7 +118,7 @@ projection passed to GeoSeries or GeoDataFrame during the creation:
    - Lon[east]: Geodetic longitude (degree)
    ...
    >>> GeoSeries(array, crs=3395).crs  # crs=3395 is ignored as array already has CRS
-   UserWarning: CRS mismatch between CRS of the passed geometries and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or 'GeoSeries.to_crs()' to reproject geometries.
+   FutureWarning: CRS mismatch between CRS of the passed geometries and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or 'GeoSeries.to_crs()' to reproject geometries. CRS mismatch will raise an error in the future versions of GeoPandas.
        GeoSeries(array, crs=3395).crs
 
    <Geographic 2D CRS: EPSG:4326>

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -101,9 +101,9 @@ Re-projecting is the process of changing the representation of locations from on
 Projection for multiple geometry columns
 ----------------------------------------
 
-GeoPandas 0.8 implements the support for different projections assigned to different geometry
-columns of the same GeoDataFrame. Projection is now stored together with geometries directly
-on the GeometryArray level.
+GeoPandas 0.8 implements support for different projections assigned to different geometry
+columns of the same GeoDataFrame. The projection is now stored together with geometries per column (directly
+on the GeometryArray level).
 
 Note that if GeometryArray has assigned projection, it is preferred over the
 projection passed to GeoSeries or GeoDataFrame during the creation:

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -98,6 +98,41 @@ Re-projecting is the process of changing the representation of locations from on
     ax.set_title("Mercator");
 
 
+Projection for multiple geometry columns
+----------------------------------------
+
+GeoPandas 0.8 implements the support for different projections assigned to different geometry
+columns of the same GeoDataFrame. Projection is now stored together with geometries directly
+on the GeometryArray level.
+
+Note that if GeometryArray has assigned projection, it is preferred over the
+projection passed to GeoSeries or GeoDataFrame during the creation:
+
+.. code-block:: python
+
+   >>> array.crs
+   <Geographic 2D CRS: EPSG:4326>
+   Name: WGS 84
+   Axis Info [ellipsoidal]:
+   - Lat[north]: Geodetic latitude (degree)
+   - Lon[east]: Geodetic longitude (degree)
+   ...
+   >>> GeoSeries(array, crs=3395).crs  # crs=3395 is ignored as array already has CRS
+   <Geographic 2D CRS: EPSG:4326>
+   Name: WGS 84
+   Axis Info [ellipsoidal]:
+   - Lat[north]: Geodetic latitude (degree)
+   - Lon[east]: Geodetic longitude (degree)
+   ...
+
+If you want to overwrite projection, you can then assign it to the GeoSeries manually
+or re-project geometries to the target projection using either ``GeoSeries.crs = 3395``
+or ``GeoSeries.to_crs(3395)``.
+
+All GeometryArray-based operations preserve projection; however, if you loop over a column
+containing geometry, this information might be lost.
+
+
 Upgrading to GeoPandas 0.7 with pyproj > 2.2 and PROJ > 6
 ---------------------------------------------------------
 
@@ -384,7 +419,7 @@ If we construct the CRS object from the EPSG code (truncated output):
 
 You can see that the CRS object constructed from the WKT string has a "Easting,
 Northing" (i.e. x, y) axis order, while the CRS object constructed from the EPSG
-code has a (Northing, Easting) axis order. 
+code has a (Northing, Easting) axis order.
 
 Only having this difference in axis order is no problem when using the CRS in
 GeoPandas, since GeoPandas always uses a (x, y) order to store the data

--- a/doc/source/projections.rst
+++ b/doc/source/projections.rst
@@ -118,6 +118,9 @@ projection passed to GeoSeries or GeoDataFrame during the creation:
    - Lon[east]: Geodetic longitude (degree)
    ...
    >>> GeoSeries(array, crs=3395).crs  # crs=3395 is ignored as array already has CRS
+   UserWarning: CRS mismatch between CRS of the passed geometries and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or 'GeoSeries.to_crs()' to reproject geometries.
+       GeoSeries(array, crs=3395).crs
+
    <Geographic 2D CRS: EPSG:4326>
    Name: WGS 84
    Axis Info [ellipsoidal]:

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -231,7 +231,7 @@ class GeometryArray(ExtensionArray):
             # to numpy array, pass-through non-array-like indexers
             idx = pd.api.indexers.check_array_indexer(self, idx)
         if isinstance(idx, (Iterable, slice)):
-            return GeometryArray(self.data[idx])
+            return GeometryArray(self.data[idx], crs=self.crs)
         else:
             raise TypeError("Index type not supported", idx)
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -72,6 +72,33 @@ def _isna(value):
 # -----------------------------------------------------------------------------
 
 
+def _geom_to_shapely(geom):
+    """
+    Convert internal representation (PyGEOS or Shapely) to external Shapely object.
+    """
+    if not compat.USE_PYGEOS:
+        return geom
+    else:
+        return vectorized._pygeos_to_shapely(geom)
+
+
+def _shapely_to_geom(geom):
+    """
+    Convert external Shapely object to internal representation (PyGEOS or Shapely).
+    """
+    if not compat.USE_PYGEOS:
+        return geom
+    else:
+        return vectorized._shapely_to_pygeos(geom)
+
+
+def _is_scalar_geometry(geom):
+    if compat.USE_PYGEOS:
+        return isinstance(geom, pygeos.Geometry)
+    else:
+        return isinstance(geom, BaseGeometry)
+
+
 def from_shapely(data, crs=None):
     """
     Convert a list or array of shapely objects to a GeometryArray.

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -104,7 +104,7 @@ def to_shapely(geoms):
     return geoms.data
 
 
-def from_wkb(data):
+def from_wkb(data, crs=None):
     """
     Convert a list or array of WKB objects to a GeometryArray.
     """
@@ -124,7 +124,7 @@ def from_wkb(data):
 
     aout = np.empty(n, dtype=object)
     aout[:] = out
-    return GeometryArray(aout)
+    return GeometryArray(aout, crs=crs)
 
 
 def to_wkb(geoms):
@@ -137,7 +137,7 @@ def to_wkb(geoms):
     return np.array(out, dtype=object)
 
 
-def from_wkt(data):
+def from_wkt(data, crs=None):
     """
     Convert a list or array of WKT objects to a GeometryArray.
     """
@@ -159,7 +159,7 @@ def from_wkt(data):
 
     aout = np.empty(n, dtype=object)
     aout[:] = out
-    return GeometryArray(aout)
+    return GeometryArray(aout, crs=crs)
 
 
 def to_wkt(geoms):
@@ -195,7 +195,7 @@ def _points_from_xy(x, y, z=None):
     return geom
 
 
-def points_from_xy(x, y, z=None):
+def points_from_xy(x, y, z=None, crs=None):
     """
     Generate GeometryArray of shapely Point geometries from x, y(, z) coordinates.
 
@@ -221,7 +221,7 @@ def points_from_xy(x, y, z=None):
     out = _points_from_xy(x, y, z)
     aout = np.empty(len(x), dtype=object)
     aout[:] = out
-    return GeometryArray(aout)
+    return GeometryArray(aout, crs=crs)
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -445,6 +445,7 @@ class GeometryArray(ExtensionArray):
                 "'data' should be a 1-dimensional array of geometry objects."
             )
         self.data = data
+
         self.crs = crs
 
     @property

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -446,6 +446,7 @@ class GeometryArray(ExtensionArray):
             )
         self.data = data
 
+        self._crs = None
         self.crs = crs
 
     @property
@@ -835,7 +836,7 @@ class GeometryArray(ExtensionArray):
 
     def copy(self, *args, **kwargs):
         # still taking args/kwargs for compat with pandas 0.24
-        return GeometryArray(self.data.copy())
+        return GeometryArray(self.data.copy(), crs=self._crs)
 
     def take(self, indices, allow_fill=False, fill_value=None):
         from pandas.api.extensions import take

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -271,10 +271,11 @@ class GeometryArray(ExtensionArray):
     if compat.USE_PYGEOS:
 
         def __getstate__(self):
-            return pygeos.to_wkb(self.data)
+            return (pygeos.to_wkb(self.data), self._crs)
 
         def __setstate__(self, state):
-            geoms = pygeos.from_wkb(state)
+            geoms = pygeos.from_wkb(state[0])
+            self._crs = state[1]
             self.data = geoms
             self.base = None
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -104,6 +104,16 @@ def from_shapely(data, crs=None):
     Convert a list or array of shapely objects to a GeometryArray.
 
     Validates the elements.
+
+    Parameters
+    ----------
+    data : array-like
+        list or array of shapely objects
+    crs : value, optional
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
+
     """
     return GeometryArray(vectorized.from_shapely(data), crs=crs)
 
@@ -120,6 +130,16 @@ def to_shapely(geoms):
 def from_wkb(data, crs=None):
     """
     Convert a list or array of WKB objects to a GeometryArray.
+
+    Parameters
+    ----------
+    data : array-like
+        list or array of WKB objects
+    crs : value, optional
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
+
     """
     return GeometryArray(vectorized.from_wkb(data), crs=crs)
 
@@ -136,6 +156,16 @@ def to_wkb(geoms):
 def from_wkt(data, crs=None):
     """
     Convert a list or array of WKT objects to a GeometryArray.
+
+    Parameters
+    ----------
+    data : array-like
+        list or array of WKT objects
+    crs : value, optional
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
+
     """
     return GeometryArray(vectorized.from_wkt(data), crs=crs)
 
@@ -156,6 +186,10 @@ def points_from_xy(x, y, z=None, crs=None):
     Parameters
     ----------
     x, y, z : iterable
+    crs : value, optional
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
 
     Examples
     --------
@@ -204,7 +238,7 @@ class GeometryArray(ExtensionArray):
 
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
-        can be anything accepted by
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
         """

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -325,23 +325,23 @@ class GeometryArray(ExtensionArray):
 
     @property
     def boundary(self):
-        return GeometryArray(vectorized.boundary(self.data))
+        return GeometryArray(vectorized.boundary(self.data), crs=self.crs)
 
     @property
     def centroid(self):
-        return GeometryArray(vectorized.centroid(self.data))
+        return GeometryArray(vectorized.centroid(self.data), crs=self.crs)
 
     @property
     def convex_hull(self):
-        return GeometryArray(vectorized.convex_hull(self.data))
+        return GeometryArray(vectorized.convex_hull(self.data), crs=self.crs)
 
     @property
     def envelope(self):
-        return GeometryArray(vectorized.envelope(self.data))
+        return GeometryArray(vectorized.envelope(self.data), crs=self.crs)
 
     @property
     def exterior(self):
-        return GeometryArray(vectorized.exterior(self.data))
+        return GeometryArray(vectorized.exterior(self.data), crs=self.crs)
 
     @property
     def interiors(self):
@@ -349,7 +349,7 @@ class GeometryArray(ExtensionArray):
         return vectorized.interiors(self.data)
 
     def representative_point(self):
-        return GeometryArray(vectorized.representative_point(self.data))
+        return GeometryArray(vectorized.representative_point(self.data), crs=self.crs)
 
     #
     # Binary predicates
@@ -406,16 +406,22 @@ class GeometryArray(ExtensionArray):
     #
 
     def difference(self, other):
-        return GeometryArray(self._binary_method("difference", self, other))
+        return GeometryArray(
+            self._binary_method("difference", self, other), crs=self.crs
+        )
 
     def intersection(self, other):
-        return GeometryArray(self._binary_method("intersection", self, other))
+        return GeometryArray(
+            self._binary_method("intersection", self, other), crs=self.crs
+        )
 
     def symmetric_difference(self, other):
-        return GeometryArray(self._binary_method("symmetric_difference", self, other))
+        return GeometryArray(
+            self._binary_method("symmetric_difference", self, other), crs=self.crs
+        )
 
     def union(self, other):
-        return GeometryArray(self._binary_method("union", self, other))
+        return GeometryArray(self._binary_method("union", self, other), crs=self.crs)
 
     #
     # Other operations
@@ -426,19 +432,22 @@ class GeometryArray(ExtensionArray):
 
     def buffer(self, distance, resolution=16, **kwargs):
         return GeometryArray(
-            vectorized.buffer(self.data, distance, resolution=resolution, **kwargs)
+            vectorized.buffer(self.data, distance, resolution=resolution, **kwargs),
+            crs=self.crs,
         )
 
     def interpolate(self, distance, normalized=False):
         return GeometryArray(
-            vectorized.interpolate(self.data, distance, normalized=normalized)
+            vectorized.interpolate(self.data, distance, normalized=normalized),
+            crs=self.crs,
         )
 
     def simplify(self, tolerance, preserve_topology=True):
         return GeometryArray(
             vectorized.simplify(
                 self.data, tolerance, preserve_topology=preserve_topology
-            )
+            ),
+            crs=self.crs,
         )
 
     def project(self, other, normalized=False):
@@ -466,33 +475,38 @@ class GeometryArray(ExtensionArray):
 
     def affine_transform(self, matrix):
         return GeometryArray(
-            vectorized._affinity_method("affine_transform", self.data, matrix)
+            vectorized._affinity_method("affine_transform", self.data, matrix),
+            crs=self.crs,
         )
 
     def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
         return GeometryArray(
-            vectorized._affinity_method("translate", self.data, xoff, yoff, zoff)
+            vectorized._affinity_method("translate", self.data, xoff, yoff, zoff),
+            crs=self.crs,
         )
 
     def rotate(self, angle, origin="center", use_radians=False):
         return GeometryArray(
             vectorized._affinity_method(
                 "rotate", self.data, angle, origin=origin, use_radians=use_radians
-            )
+            ),
+            crs=self.crs,
         )
 
     def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin="center"):
         return GeometryArray(
             vectorized._affinity_method(
                 "scale", self.data, xfact, yfact, zfact, origin=origin
-            )
+            ),
+            crs=self.crs,
         )
 
     def skew(self, xs=0.0, ys=0.0, origin="center", use_radians=False):
         return GeometryArray(
             vectorized._affinity_method(
                 "skew", self.data, xs, ys, origin=origin, use_radians=use_radians
-            )
+            ),
+            crs=self.crs,
         )
 
     #
@@ -571,7 +585,7 @@ class GeometryArray(ExtensionArray):
         result = take(self.data, indices, allow_fill=allow_fill, fill_value=fill_value)
         if allow_fill and fill_value is None:
             result[pd.isna(result)] = None
-        return GeometryArray(result)
+        return GeometryArray(result, crs=self.crs)
 
     def _fill(self, idx, value):
         """ Fill index locations with value
@@ -826,7 +840,7 @@ class GeometryArray(ExtensionArray):
         ExtensionArray
         """
         data = np.concatenate([ga.data for ga in to_concat])
-        return GeometryArray(data)
+        return GeometryArray(data, crs=to_concat[0].crs)
 
     def _reduce(self, name, skipna=True, **kwargs):
         # including the base class version here (that raises by default)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -302,6 +302,14 @@ class GeometryArray(ExtensionArray):
                 "Value should be either a BaseGeometry or None, got %s" % str(value)
             )
 
+        # TODO: use this once pandas-dev/pandas#33457 is fixed
+        # if hasattr(value, "crs"):
+        #     if value.crs and (value.crs != self.crs):
+        #         raise ValueError(
+        #             "CRS mismatch between CRS of the passed geometries "
+        #             "and CRS of existing geometries."
+        #         )
+
     if compat.USE_PYGEOS:
 
         def __getstate__(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -145,13 +145,12 @@ class GeoPandasBase(object):
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
         """
-        return self._crs
+        return self.geometry.values.crs
 
     @crs.setter
     def crs(self, value):
         """Sets the value of the crs"""
         self.geometry.values.crs = None if not value else value
-        self._crs = self.geometry.values.crs
 
     @property
     def geom_type(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -150,7 +150,7 @@ class GeoPandasBase(object):
     @crs.setter
     def crs(self, value):
         """Sets the value of the crs"""
-        self.geometry.values.crs = None if not value else value
+        self.geometry.values.crs = value
 
     @property
     def geom_type(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, MultiIndex, Series
 
-from pyproj import CRS
 from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
@@ -151,7 +150,8 @@ class GeoPandasBase(object):
     @crs.setter
     def crs(self, value):
         """Sets the value of the crs"""
-        self._crs = None if not value else CRS.from_user_input(value)
+        self.geometry.values.crs = None if not value else value
+        self._crs = self.geometry.values.crs
 
     @property
     def geom_type(self):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -91,6 +92,14 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if geometry is not None:
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
+
+        if geometry is None and crs:
+            warnings.warn(
+                "Assigning CRS to a GeoDataFrame without a geometry column is now "
+                "deprecated and will not be supported in the future.",
+                FutureWarning,
+                stacklevel=2,
+            )
 
     def __setattr__(self, attr, val):
         # have to special case geometry b/c pandas tries to use as column...
@@ -247,6 +256,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def crs(self, value):
         """Sets the value of the crs"""
         if self._geometry_column_name not in self:
+            warnings.warn(
+                "Assigning CRS to a GeoDataFrame without a geometry column is now "
+                "deprecated and will not be supported in the future.",
+                FutureWarning,
+                stacklevel=4,
+            )
             self._crs = None if not value else CRS.from_user_input(value)
         else:
             if hasattr(self.geometry.values, "crs"):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -84,7 +84,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                     hasattr(self["geometry"].values, "crs")
                     and self["geometry"].values.crs
                     and crs
-                    and self["geometry"].values.crs != crs
+                    and self["geometry"].values.crs != CRS.from_user_input(crs)
                 ):
                     warnings.warn(
                         "CRS mismatch between CRS of the passed geometries "
@@ -112,7 +112,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 hasattr(geometry, "crs")
                 and geometry.crs
                 and crs
-                and geometry.crs != crs
+                and geometry.crs != CRS.from_user_input(crs)
             ):
                 warnings.warn(
                     "CRS mismatch between CRS of the passed geometries "

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -683,7 +683,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Overwritten to preserve CRS of GeometryArray in cases like
         df['geometry'] = [geom... for geom in df.geometry]
         """
-        if key == self._geometry_column_name:
+        if not pd.api.types.is_list_like(key) and key == self._geometry_column_name:
             try:
                 value = _ensure_geometry(value, crs=self.crs)
             except TypeError:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -97,8 +97,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 and geometry.crs != crs
             ):
                 warnings.warn(
-                    "CRS mismatch between CRS of underlying GeometryArray passed as "
-                    "geometry and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
+                    "CRS mismatch between CRS of the passed geometries "
+                    "and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
                     "or 'GeoDataFrame.to_crs()' to reproject geometries.",
                     stacklevel=2,
                 )  # TODO: change 'GeoDataFrame.crs = crs' to 'set_crs()' once done

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -45,8 +45,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     Parameters
     ----------
-    crs : str (optional)
-        Coordinate system
+    crs : value (optional)
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
     geometry : str or array (optional)
         If str, column to use as geometry. If array, will be set as 'geometry'
         column on GeoDataFrame.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -84,7 +84,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                     hasattr(self["geometry"].values, "crs")
                     and self["geometry"].values.crs
                     and crs
-                    and self["geometry"].values.crs != CRS.from_user_input(crs)
+                    and not self["geometry"].values.crs == crs
                 ):
                     warnings.warn(
                         "CRS mismatch between CRS of the passed geometries "
@@ -112,7 +112,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 hasattr(geometry, "crs")
                 and geometry.crs
                 and crs
-                and geometry.crs != CRS.from_user_input(crs)
+                and not geometry.crs == crs
             ):
                 warnings.warn(
                     "CRS mismatch between CRS of the passed geometries "

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -646,6 +646,14 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             result.__class__ = DataFrame
         return result
 
+    def __setitem__(self, key, value):
+        if key == self._geometry_column_name:
+            try:
+                value = _ensure_geometry(value, crs=self.crs)
+            except TypeError:
+                warnings.warn("Geometry column does not contain geometry.")
+        super(GeoDataFrame, self).__setitem__(key, value)
+
     #
     # Implement pandas methods
     #

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -690,6 +690,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 warnings.warn("Geometry column does not contain geometry.")
         super(GeoDataFrame, self).__setitem__(key, value)
 
+        # CRS of array may get lost during __setitem__
+        if hasattr(value, "crs"):
+            self[key].crs = value.crs
+
     #
     # Implement pandas methods
     #

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -90,6 +90,18 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 geometry = "geometry"
 
         if geometry is not None:
+            if (
+                hasattr(geometry, "crs")
+                and geometry.crs
+                and crs
+                and geometry.crs != crs
+            ):
+                warnings.warn(
+                    "CRS mismatch between CRS of underlying GeometryArray passed as "
+                    "geometry and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
+                    "or 'GeoDataFrame.to_crs()' to reproject geometries.",
+                    stacklevel=2,
+                )  # TODO: change 'GeoDataFrame.crs = crs' to 'set_crs()' once done
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -690,10 +690,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 warnings.warn("Geometry column does not contain geometry.")
         super(GeoDataFrame, self).__setitem__(key, value)
 
-        # CRS of array may get lost during __setitem__
-        if hasattr(value, "crs"):
-            self[key].crs = value.crs
-
     #
     # Implement pandas methods
     #

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -623,13 +623,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def to_crs(self, crs=None, epsg=None, inplace=False):
         """Transform geometries to a new coordinate reference system.
 
-        Transform all geometries in a GeoSeries to a different coordinate
+        Transform all geometries in an active geometry column to a different coordinate
         reference system.  The ``crs`` attribute on the current GeoSeries must
         be set.  Either ``crs`` or ``epsg`` may be specified for output.
 
-        This method will transform all points in all objects.  It has no notion
+        This method will transform all points in all objects. It has no notion
         or projecting entire geometries.  All segments joining points are
-        assumed to be lines in the current projection, not geodesics.  Objects
+        assumed to be lines in the current projection, not geodesics. Objects
         crossing the dateline (or other projection boundary) will have
         undesirable behavior.
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -88,7 +88,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         if geometry is not None:
             self.set_geometry(geometry, inplace=True)
-
         self._invalidate_sindex()
 
     def __setattr__(self, attr, val):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -732,6 +732,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         else:
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other, name, None))
+
+            # find GeometryArrays and propagate CRS to their self counterparts
+            for col, dtype in other.dtypes.iteritems():
+                if isinstance(dtype, GeometryDtype):
+                    if col in self.columns:
+                        self[col].crs = other[col].crs
+
         return self
 
     def plot(self, *args, **kwargs):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -89,9 +89,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                     warnings.warn(
                         "CRS mismatch between CRS of the passed geometries "
                         "and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
-                        "or 'GeoDataFrame.to_crs()' to reproject geometries.",
+                        "or 'GeoDataFrame.to_crs()' to reproject geometries. "
+                        "CRS mismatch will raise an error in the future versions "
+                        "of GeoPandas.",
+                        FutureWarning,
                         stacklevel=2,
                     )  # TODO: change 'GeoDataFrame.crs = crs' to 'set_crs()' once done
+                    # TODO: raise error in 0.9 or 0.10.
                 self["geometry"] = _ensure_geometry(self["geometry"].values, crs)
             except TypeError:
                 pass
@@ -113,9 +117,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 warnings.warn(
                     "CRS mismatch between CRS of the passed geometries "
                     "and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
-                    "or 'GeoDataFrame.to_crs()' to reproject geometries.",
+                    "or 'GeoDataFrame.to_crs()' to reproject geometries. "
+                    "CRS mismatch will raise an error in the future versions "
+                    "of GeoPandas.",
+                    FutureWarning,
                     stacklevel=2,
                 )  # TODO: change 'GeoDataFrame.crs = crs' to 'set_crs()' once done
+                # TODO: raise error in 0.9 or 0.10.
             self.set_geometry(geometry, inplace=True)
         self._invalidate_sindex()
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -80,6 +80,18 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             # only if we have actual geometry values -> call set_geometry
             index = self.index
             try:
+                if (
+                    hasattr(self["geometry"].values, "crs")
+                    and self["geometry"].values.crs
+                    and crs
+                    and self["geometry"].values.crs != crs
+                ):
+                    warnings.warn(
+                        "CRS mismatch between CRS of the passed geometries "
+                        "and 'crs'. Use 'GeoDataFrame.crs = crs' to overwrite CRS "
+                        "or 'GeoDataFrame.to_crs()' to reproject geometries.",
+                        stacklevel=2,
+                    )  # TODO: change 'GeoDataFrame.crs = crs' to 'set_crs()' once done
                 self["geometry"] = _ensure_geometry(self["geometry"].values, crs)
             except TypeError:
                 pass

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -61,6 +61,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         geometry = kwargs.pop("geometry", None)
         super(GeoDataFrame, self).__init__(*args, **kwargs)
 
+        # need to set this before calling self['geometry'], because
+        # getitem accesses crs
         self._crs = None
 
         # set_geometry ensures the geometry data have the proper dtype,
@@ -175,7 +177,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             frame = self.copy()
 
         if not crs:
-            # note priority & simplify condition
+            # note - simplify condition
             if hasattr(col, "crs"):
                 if col.crs:
                     crs = getattr(col, "crs", self._crs)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -143,7 +143,7 @@ class GeoSeries(GeoPandasBase, Series):
         self._crs = None
 
         if hasattr(data, "crs") and data.crs:
-            # check and warn if crs and data.crs different
+            # check and warn if crs and data.crs different?
             self.crs = data.crs
         elif hasattr(data, "values"):
             if hasattr(data.values, "crs") and data.values.crs:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -52,8 +52,11 @@ class GeoSeries(GeoPandasBase, Series):
         The geometries to store in the GeoSeries.
     index : array-like or Index
         The index for the GeoSeries.
-    crs : str, dict (optional)
-        Coordinate Reference System of the geometry objects.
+    crs : value (optional)
+        Coordinate Reference System of the geometry objects. Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
+
     kwargs
         Additional arguments passed to the Series constructor,
          e.g. ``name``.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -289,9 +289,15 @@ class GeoSeries(GeoPandasBase, Series):
     def __finalize__(self, other, method=None, **kwargs):
         """ propagate metadata from other to self """
         # NOTE: backported from pandas master (upcoming v0.13)
-        for name in self._metadata:
-            object.__setattr__(self, name, getattr(other, name, None))
-        self.values.crs = other.values.crs
+        if method == "concat":
+            for name in self._metadata:
+                # using CRS of the first object
+                object.__setattr__(self, name, getattr(other.objs[0], name, None))
+            self.values.crs = other.objs[0].values.crs
+        else:
+            for name in self._metadata:
+                object.__setattr__(self, name, getattr(other, name, None))
+            self.values.crs = other.values.crs
         return self
 
     def isna(self):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -291,15 +291,8 @@ class GeoSeries(GeoPandasBase, Series):
         # NOTE: backported from pandas master (upcoming v0.13)
         for name in self._metadata:
             object.__setattr__(self, name, getattr(other, name, None))
+        self.values.crs = other.values.crs
         return self
-
-    def copy(self, *args, **kwargs):
-        """
-        Needed to retain crs in GeometryArray during copy.
-        """
-        copy = super(GeoSeries, self).copy(*args, **kwargs)
-        copy.crs = self.crs
-        return copy
 
     def isna(self):
         """

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -82,9 +82,8 @@ class GeoSeries(GeoPandasBase, Series):
         # we need to use __new__ because we want to return Series instance
         # instead of GeoSeries instance in case of non-geometry data
 
-        # make a copy to avoid setting CRS to passed data if GeometryArray
+        # # make a copy to avoid setting CRS to passed GeometryArray
         if hasattr(data, "crs") and not data.crs and crs:
-            print("0")
             data = data.copy()
 
         if isinstance(data, SingleBlockManager):
@@ -141,15 +140,7 @@ class GeoSeries(GeoPandasBase, Series):
         self = super(GeoSeries, cls).__new__(cls)
         super(GeoSeries, self).__init__(data, index=index, name=name, **kwargs)
 
-        if hasattr(data, "crs") and data.crs:
-            # check and warn if crs and data.crs different?
-            self.crs = data.crs
-        elif hasattr(data, "values"):
-            if hasattr(data.values, "crs") and data.values.crs:
-                self.crs = getattr(data.values, "crs")
-            else:
-                self.crs = crs
-        else:
+        if not self.crs:
             self.crs = crs
         self._invalidate_sindex()
         return self

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -76,7 +76,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     """
 
-    _metadata = ["name", "_crs"]
+    _metadata = ["name"]
 
     def __new__(cls, data=None, index=None, crs=None, **kwargs):
         # we need to use __new__ because we want to return Series instance
@@ -140,7 +140,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         self = super(GeoSeries, cls).__new__(cls)
         super(GeoSeries, self).__init__(data, index=index, name=name, **kwargs)
-        self._crs = None
 
         if hasattr(data, "crs") and data.crs:
             # check and warn if crs and data.crs different?

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -82,7 +82,7 @@ class GeoSeries(GeoPandasBase, Series):
         # we need to use __new__ because we want to return Series instance
         # instead of GeoSeries instance in case of non-geometry data
 
-        # make a copy to avoid setting CRS to passed data if there is none
+        # make a copy to avoid setting CRS to passed data if GeometryArray
         if hasattr(data, "crs") and not data.crs and crs:
             print("0")
             data = data.copy()
@@ -144,7 +144,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         if hasattr(data, "crs") and data.crs:
             # check and warn if crs and data.crs different
-            # make proper priority
             self.crs = data.crs
         elif hasattr(data, "values"):
             if hasattr(data.values, "crs") and data.values.crs:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -135,9 +135,14 @@ class GeoSeries(GeoPandasBase, Series):
 
         self = super(GeoSeries, cls).__new__(cls)
         super(GeoSeries, self).__init__(data, index=index, name=name, **kwargs)
-        if data.crs:
+        self._crs = None
+
+        if hasattr(data, "crs") and data.crs:
             # check and warn if crs and data.crs different
             self.crs = data.crs
+        elif hasattr(data, "values"):
+            if hasattr(data.values, "crs") and data.values.crs:
+                self.crs = getattr(data.values, "crs")
         else:
             self.crs = crs
         self._invalidate_sindex()

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -126,6 +126,7 @@ class GeoSeries(GeoPandasBase, Series):
             # try to convert to GeometryArray, if fails return plain Series
             try:
                 data = from_shapely(s.values)
+                data.crs = crs
             except TypeError:
                 warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
                 return s
@@ -134,7 +135,11 @@ class GeoSeries(GeoPandasBase, Series):
 
         self = super(GeoSeries, cls).__new__(cls)
         super(GeoSeries, self).__init__(data, index=index, name=name, **kwargs)
-        self.crs = crs
+        if data.crs:
+            # check and warn if crs and data.crs different
+            self.crs = data.crs
+        else:
+            self.crs = crs
         self._invalidate_sindex()
         return self
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -90,7 +90,7 @@ class GeoSeries(GeoPandasBase, Series):
                 # make a copy to avoid setting CRS to passed GeometryArray
                 data = data.copy()
             else:
-                if data.crs != CRS.from_user_input(crs):
+                if not data.crs == crs:
                     warnings.warn(
                         "CRS mismatch between CRS of the passed geometries "
                         "and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS "

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -92,7 +92,7 @@ class GeoSeries(GeoPandasBase, Series):
             else:
                 if data.crs != crs:
                     warnings.warn(
-                        "CRS mismatch between CRS of underlying GeometryArray and "
+                        "CRS mismatch between CRS of the passed geometries and "
                         "'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or "
                         "'GeoSeries.to_crs()' to reproject geometries.",
                         stacklevel=2,

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -117,7 +117,7 @@ class GeoSeries(GeoPandasBase, Series):
                     data = SingleBlockManager([block], data.axes[0], fastpath=True)
                 self = super(GeoSeries, cls).__new__(cls)
                 super(GeoSeries, self).__init__(data, index=index, **kwargs)
-                self.crs = crs
+                self.crs = getattr(self.values, "crs", crs)
                 return self
             warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
             return Series(data, index=index, **kwargs)
@@ -295,15 +295,8 @@ class GeoSeries(GeoPandasBase, Series):
     def __finalize__(self, other, method=None, **kwargs):
         """ propagate metadata from other to self """
         # NOTE: backported from pandas master (upcoming v0.13)
-        if method == "concat":
-            for name in self._metadata:
-                # using CRS of the first object
-                object.__setattr__(self, name, getattr(other.objs[0], name, None))
-            self.values.crs = other.objs[0].values.crs
-        else:
-            for name in self._metadata:
-                object.__setattr__(self, name, getattr(other, name, None))
-            self.values.crs = other.values.crs
+        for name in self._metadata:
+            object.__setattr__(self, name, getattr(other, name, None))
         return self
 
     def isna(self):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -90,7 +90,7 @@ class GeoSeries(GeoPandasBase, Series):
                 # make a copy to avoid setting CRS to passed GeometryArray
                 data = data.copy()
             else:
-                if data.crs != crs:
+                if data.crs != CRS.from_user_input(crs):
                     warnings.warn(
                         "CRS mismatch between CRS of the passed geometries "
                         "and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS "

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -85,9 +85,18 @@ class GeoSeries(GeoPandasBase, Series):
         # we need to use __new__ because we want to return Series instance
         # instead of GeoSeries instance in case of non-geometry data
 
-        # # make a copy to avoid setting CRS to passed GeometryArray
-        if hasattr(data, "crs") and not data.crs and crs:
-            data = data.copy()
+        if hasattr(data, "crs") and crs:
+            if not data.crs:
+                # make a copy to avoid setting CRS to passed GeometryArray
+                data = data.copy()
+            else:
+                if data.crs != crs:
+                    warnings.warn(
+                        "CRS mismatch between CRS of underlying GeometryArray and "
+                        "'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or "
+                        "'GeoSeries.to_crs()' to reproject geometries.",
+                        stacklevel=2,
+                    )  # TODO: change 'GeoSeries.crs = crs' to 'set_crs()' once done
 
         if isinstance(data, SingleBlockManager):
             if isinstance(data.blocks[0].dtype, GeometryDtype):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -92,11 +92,15 @@ class GeoSeries(GeoPandasBase, Series):
             else:
                 if data.crs != crs:
                     warnings.warn(
-                        "CRS mismatch between CRS of the passed geometries and "
-                        "'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS or "
-                        "'GeoSeries.to_crs()' to reproject geometries.",
+                        "CRS mismatch between CRS of the passed geometries "
+                        "and 'crs'. Use 'GeoSeries.crs = crs' to overwrite CRS "
+                        "or 'GeoSeries.to_crs()' to reproject geometries. "
+                        "CRS mismatch will raise an error in the future versions "
+                        "of GeoPandas.",
+                        FutureWarning,
                         stacklevel=2,
                     )  # TODO: change 'GeoSeries.crs = crs' to 'set_crs()' once done
+                    # TODO: raise error in 0.9 or 0.10.
 
         if isinstance(data, SingleBlockManager):
             if isinstance(data.blocks[0].dtype, GeometryDtype):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -125,8 +125,7 @@ class GeoSeries(GeoPandasBase, Series):
                     return s
             # try to convert to GeometryArray, if fails return plain Series
             try:
-                data = from_shapely(s.values)
-                data.crs = crs
+                data = from_shapely(s.values, crs)
             except TypeError:
                 warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)
                 return s
@@ -139,6 +138,7 @@ class GeoSeries(GeoPandasBase, Series):
 
         if hasattr(data, "crs") and data.crs:
             # check and warn if crs and data.crs different
+            # make proper priority
             self.crs = data.crs
         elif hasattr(data, "values"):
             if hasattr(data.values, "crs") and data.values.crs:

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -212,14 +212,16 @@ def assert_geodataframe_equal(
     )
 
     # geometry comparison
-    assert_geoseries_equal(
-        left.geometry,
-        right.geometry,
-        check_dtype=check_dtype,
-        check_less_precise=check_less_precise,
-        check_geom_type=check_geom_type,
-        check_crs=False,
-    )
+    for col, dtype in left.dtypes.iteritems():
+        if isinstance(dtype, GeometryDtype):
+            assert_geoseries_equal(
+                left[col],
+                right[col],
+                check_dtype=check_dtype,
+                check_less_precise=check_less_precise,
+                check_geom_type=check_geom_type,
+                check_crs=check_crs,
+            )
 
     # drop geometries and check remaining columns
     left2 = left.drop([left._geometry_column_name], axis=1)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -1,6 +1,7 @@
 from distutils.version import LooseVersion
 
 import numpy as np
+import pandas as pd
 
 from shapely.geometry import Point
 import pyproj
@@ -335,6 +336,11 @@ class TestGeometryArrayCRS:
     def test_from_wkt(self):
         L_wkt = [p.wkt for p in self.geoms]
         arr = from_wkt(L_wkt, crs=27700)
+        assert arr.crs == self.osgb
+
+    def test_points_from_xy(self):
+        df = pd.DataFrame([{"x": x, "y": x, "z": x} for x in range(10)])
+        arr = points_from_xy(df["x"], df["y"], crs=27700)
         assert arr.crs == self.osgb
 
     # setting CRS in GeoSeries should not set it in passed array without CRS

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -241,15 +241,19 @@ class TestGeometryArrayCRS:
         assert df.geometry.values.crs == pyproj.CRS(2263)
 
     def test_multiple_geoms(self):
-        arr = from_shapely(self.geoms, crs=4326)
-        s = GeoSeries(self.geoms, crs=27700)
-        df = GeoDataFrame(arr, geometry=s, columns=["col1"])
+        arr = from_shapely(self.geoms, crs=27700)
+        s = GeoSeries(self.geoms, crs=4326)
+        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
         assert df.crs == self.osgb
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
         assert df.col1.crs == self.wgs
         assert df.col1.values.crs == self.wgs
 
+    def test_multiple_geoms_set_geom(self):
+        arr = from_shapely(self.geoms, crs=27700)
+        s = GeoSeries(self.geoms, crs=4326)
+        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
         df = df.set_geometry("col1")
         assert df.crs == self.wgs
         assert df.geometry.crs == self.wgs
@@ -257,20 +261,24 @@ class TestGeometryArrayCRS:
         assert df["geometry"].crs == self.osgb
         assert df["geometry"].values.crs == self.osgb
 
+    def test_assing_cols(self):
+        arr = from_shapely(self.geoms, crs=27700)
+        s = GeoSeries(self.geoms, crs=4326)
+        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
         df["geom2"] = s
         df["geom3"] = s.values
-        assert df.crs == self.wgs
-        assert df.geometry.crs == self.wgs
-        assert df.geometry.values.crs == self.wgs
-        assert df.geom2.crs == self.osgb
-        assert df.geom2.values.crs == self.osgb
-        assert df.geom3.crs == self.osgb
-        assert df.geom3.values.crs == self.osgb
+        assert df.crs == self.osgb
+        assert df.geometry.crs == self.osgb
+        assert df.geometry.values.crs == self.osgb
+        assert df.geom2.crs == self.wgs
+        assert df.geom2.values.crs == self.wgs
+        assert df.geom3.crs == self.wgs
+        assert df.geom3.values.crs == self.wgs
 
     def test_copy(self):
-        arr = from_shapely(self.geoms, crs=4326)
-        s = GeoSeries(self.geoms, crs=27700)
-        df = GeoDataFrame(arr, geometry=s, columns=["col1"])
+        arr = from_shapely(self.geoms, crs=27700)
+        s = GeoSeries(self.geoms, crs=4326)
+        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
 
         arr_copy = arr.copy()
         assert arr_copy.crs == arr.crs
@@ -287,9 +295,9 @@ class TestGeometryArrayCRS:
         assert df_copy.col1.values.crs == df.col1.values.crs
 
     def test_rename(self):
-        arr = from_shapely(self.geoms, crs=4326)
-        s = GeoSeries(self.geoms, crs=27700)
-        df = GeoDataFrame(arr, geometry=s, columns=["col1"])
+        arr = from_shapely(self.geoms, crs=27700)
+        s = GeoSeries(self.geoms, crs=4326)
+        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
         df = df.rename(columns={"geometry": "geom"}).set_geometry("geom")
         assert df.crs == self.osgb
         assert df.geometry.crs == self.osgb

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -490,3 +490,11 @@ class TestGeometryArrayCRS:
         with pytest.warns(FutureWarning):
             df = GeoDataFrame([])
             df.crs = 27700
+
+    # make sure that geometry column from list has CRS (__setitem__)
+    def test_list_to_geometry(self):
+        arr = from_shapely(self.geoms, crs=27700)
+        df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
+
+        df["geometry"] = [g for g in df.geometry]
+        assert df.geometry.values.crs == self.osgb

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -496,9 +496,13 @@ class TestGeometryArrayCRS:
             df.crs = 27700
 
     # make sure that geometry column from list has CRS (__setitem__)
-    def test_list_to_geometry(self):
+    def test_setitem_geometry(self):
         arr = from_shapely(self.geoms, crs=27700)
         df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
 
         df["geometry"] = [g for g in df.geometry]
         assert df.geometry.values.crs == self.osgb
+
+        df2 = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
+        df2["geometry"] = from_shapely(self.geoms, crs=4326)
+        assert df2.geometry.values.crs == self.wgs

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -180,6 +180,13 @@ class TestGeometryArrayCRS:
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
 
+        arr = from_shapely(self.geoms)
+        s = GeoSeries(arr, crs=27700)
+        df = GeoDataFrame(geometry=s)
+        assert df.crs == self.osgb
+        assert df.geometry.crs == self.osgb
+        assert df.geometry.values.crs == self.osgb
+
         # different passed CRS than array CRS is ignored
         # TODO: raise warning?
         df = GeoDataFrame(geometry=s, crs=4326)
@@ -227,11 +234,18 @@ class TestGeometryArrayCRS:
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
 
+        arr = from_shapely(self.geoms, crs=27700)
         df = GeoDataFrame()
         df = df.set_geometry(arr)
         assert df.crs == self.osgb
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
+
+        arr = from_shapely(self.geoms)
+        df = GeoDataFrame({"col1": [1, 2], "geometry": arr}, crs=4326)
+        assert df.crs == self.wgs
+        assert df.geometry.crs == self.wgs
+        assert df.geometry.values.crs == self.wgs
 
     def test_read_file(self):
         nybb_filename = datasets.get_path("nybb")

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -179,6 +179,9 @@ class TestGeometryArrayCRS:
         assert s.crs == self.osgb
         assert s.values.crs == self.osgb
 
+        with pytest.warns(UserWarning):
+            GeoSeries(arr, crs=4326)
+
     @pytest.mark.filterwarnings("ignore:Assigning CRS")
     def test_dataframe(self):
         arr = from_shapely(self.geoms, crs=27700)
@@ -196,11 +199,12 @@ class TestGeometryArrayCRS:
         assert df.geometry.values.crs == self.osgb
 
         # different passed CRS than array CRS is ignored
-        # TODO: raise warning?
         df = GeoDataFrame(geometry=s, crs=4326)
         assert df.crs == self.osgb
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
+        with pytest.warns(UserWarning):
+            GeoDataFrame(geometry=s, crs=4326)
 
         # manually change CRS
         df = GeoDataFrame(geometry=s)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -179,7 +179,7 @@ class TestGeometryArrayCRS:
         assert s.crs == self.osgb
         assert s.values.crs == self.osgb
 
-        with pytest.warns(UserWarning):
+        with pytest.warns(FutureWarning):
             GeoSeries(arr, crs=4326)
 
     @pytest.mark.filterwarnings("ignore:Assigning CRS")
@@ -203,11 +203,11 @@ class TestGeometryArrayCRS:
         assert df.crs == self.osgb
         assert df.geometry.crs == self.osgb
         assert df.geometry.values.crs == self.osgb
-        with pytest.warns(UserWarning):
+        with pytest.warns(FutureWarning):
             GeoDataFrame(geometry=s, crs=4326)
-        with pytest.warns(UserWarning):
+        with pytest.warns(FutureWarning):
             GeoDataFrame({"data": [1, 2], "geometry": s}, crs=4326)
-        with pytest.warns(UserWarning):
+        with pytest.warns(FutureWarning):
             GeoDataFrame(df, crs=27700).crs
 
         # manually change CRS

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -522,3 +522,9 @@ class TestGeometryArrayCRS:
         df2 = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
         df2["geometry"] = from_shapely(self.geoms, crs=4326)
         assert df2.geometry.values.crs == self.wgs
+
+    def test_astype(self):
+        arr = from_shapely(self.geoms, crs=27700)
+        df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
+        df2 = df.astype({"col1": str})
+        assert df2.crs == self.osgb

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -179,6 +179,7 @@ class TestGeometryArrayCRS:
         assert s.crs == self.osgb
         assert s.values.crs == self.osgb
 
+    @pytest.mark.filterwarnings("ignore:Assigning CRS")
     def test_dataframe(self):
         arr = from_shapely(self.geoms, crs=27700)
         s = GeoSeries(arr)
@@ -480,3 +481,12 @@ class TestGeometryArrayCRS:
         assert merged.col2.values.crs == self.wgs
         assert merged.geom.values.crs == self.osgb
         assert merged.crs == self.osgb
+
+    # CRS should be assigned to geometry
+    def test_deprecation(self):
+        with pytest.warns(FutureWarning):
+            GeoDataFrame([], crs=27700)
+
+        with pytest.warns(FutureWarning):
+            df = GeoDataFrame([])
+            df.crs = 27700

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -205,6 +205,10 @@ class TestGeometryArrayCRS:
         assert df.geometry.values.crs == self.osgb
         with pytest.warns(UserWarning):
             GeoDataFrame(geometry=s, crs=4326)
+        with pytest.warns(UserWarning):
+            GeoDataFrame({"data": [1, 2], "geometry": s}, crs=4326)
+        with pytest.warns(UserWarning):
+            GeoDataFrame(df, crs=27700).crs
 
         # manually change CRS
         df = GeoDataFrame(geometry=s)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -457,7 +457,7 @@ class TestGeometryArrayCRS:
         s = GeoSeries(self.arr, crs=27700)
         assert s.iloc[1:].values.crs == self.osgb
 
-        df = GeoDataFrame(self.arr, geometry=s, columns=["col1"])
+        df = GeoDataFrame({"col1": self.arr}, geometry=s)
         assert df.iloc[1:].geometry.values.crs == self.osgb
         assert df.iloc[1:].col1.values.crs == self.osgb
 
@@ -465,19 +465,18 @@ class TestGeometryArrayCRS:
         s = GeoSeries(self.arr, crs=27700)
         assert pd.concat([s, s]).values.crs == self.osgb
 
-        df = GeoDataFrame(
-            from_shapely(self.geoms, crs=4326), geometry=s, columns=["col1"]
-        )
+        df = GeoDataFrame({"col1": from_shapely(self.geoms, crs=4326)}, geometry=s)
         assert pd.concat([df, df]).geometry.values.crs == self.osgb
         assert pd.concat([df, df]).col1.values.crs == self.wgs
 
     def test_merge(self):
         arr = from_shapely(self.geoms, crs=27700)
         s = GeoSeries(self.geoms, crs=4326)
-        df = GeoDataFrame(s, geometry=arr, columns=["col1"])
-        df2 = GeoDataFrame(s, geometry=arr, columns=["col2"])
-        merged = df.merge(df2)
+        df = GeoDataFrame({"col1": s}, geometry=arr)
+        df2 = GeoDataFrame({"col2": s}, geometry=arr).rename_geometry("geom")
+        merged = df.merge(df2, left_index=True, right_index=True)
         assert merged.col1.values.crs == self.wgs
         assert merged.geometry.values.crs == self.osgb
         assert merged.col2.values.crs == self.wgs
+        assert merged.geom.values.crs == self.osgb
         assert merged.crs == self.osgb

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -159,8 +159,7 @@ class TestDataFrame:
         assert_geoseries_equal(df["geometry"], new_geom)
 
         # new crs
-        # note - failing as new_geom already has CRS which is different
-        gs = GeoSeries(new_geom, crs="epsg:3857")
+        gs = new_geom.to_crs(crs="epsg:3857")
         df.geometry = gs
         assert df.crs == "epsg:3857"
 
@@ -209,7 +208,7 @@ class TestDataFrame:
 
         df2 = self.df.set_geometry(geom)
         assert self.df is not df2
-        assert_geoseries_equal(df2.geometry, geom)
+        assert_geoseries_equal(df2.geometry, geom, check_crs=False)
         assert_geoseries_equal(self.df.geometry, original_geom)
         assert_geoseries_equal(self.df["geometry"], self.df.geometry)
         # unknown column
@@ -221,7 +220,6 @@ class TestDataFrame:
             self.df.set_geometry(self.df)
 
         # new crs - setting should default to GeoSeries' crs
-        # note - now failing as it defaults to array crs
         gs = GeoSeries(geom, crs="epsg:3857")
         new_df = self.df.set_geometry(gs)
         assert new_df.crs == "epsg:3857"

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -159,6 +159,7 @@ class TestDataFrame:
         assert_geoseries_equal(df["geometry"], new_geom)
 
         # new crs
+        # note - failing as new_geom already has CRS which is different
         gs = GeoSeries(new_geom, crs="epsg:3857")
         df.geometry = gs
         assert df.crs == "epsg:3857"
@@ -220,6 +221,7 @@ class TestDataFrame:
             self.df.set_geometry(self.df)
 
         # new crs - setting should default to GeoSeries' crs
+        # note - now failing as it defaults to array crs
         gs = GeoSeries(geom, crs="epsg:3857")
         new_df = self.df.set_geometry(gs)
         assert new_df.crs == "epsg:3857"

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -83,7 +83,7 @@ def test_no_crs():
 
 
 def test_ignore_crs_mismatch():
-    df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1}, crs="EPSG:4326")
+    df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1.copy()}, crs="EPSG:4326")
     df2 = GeoDataFrame({"col1": [1, 2], "geometry": s1}, crs="EPSG:31370")
 
     with pytest.raises(AssertionError):

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -42,6 +42,19 @@ s4 = Series(a)
 df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1})
 df2 = GeoDataFrame({"col1": [1, 2], "geometry": s2})
 
+s4 = s1.copy()
+s4.crs = 4326
+s5 = s2.copy()
+s5.crs = 27700
+df4 = GeoDataFrame(
+    {"col1": [1, 2], "geometry": s1.copy(), "geom2": s4.copy(), "geom3": s5.copy()},
+    crs=3857,
+)
+df5 = GeoDataFrame(
+    {"col1": [1, 2], "geometry": s1.copy(), "geom3": s5.copy(), "geom2": s4.copy()},
+    crs=3857,
+)
+
 
 def test_geoseries():
     assert_geoseries_equal(s1, s2)
@@ -68,6 +81,11 @@ def test_geodataframe():
     df3.loc[0, "col1"] = 10
     with pytest.raises(AssertionError):
         assert_geodataframe_equal(df1, df3)
+
+    assert_geodataframe_equal(df5, df4, check_like=True)
+    df5.geom2.crs = 3857
+    with pytest.raises(AssertionError):
+        assert_geodataframe_equal(df5, df4, check_like=True)
 
 
 def test_equal_nans():

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -86,7 +86,7 @@ def _overlay_difference(df1, df2):
             lambda x, y: x.difference(y), [geom] + list(df2.geometry.iloc[neighbours])
         )
         new_g.append(new)
-    differences = GeoSeries(new_g, index=df1.index)
+    differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
     poly_ix = differences.type.isin(["Polygon", "MultiPolygon"])
     differences.loc[poly_ix] = differences[poly_ix].buffer(0)
     geom_diff = differences[~differences.is_empty].copy()


### PR DESCRIPTION
Closes #1193, closes #1340, closes #1362, closes #1366

This moves CRS attribute from GeoDataFrame and GeoSeries to GemetryArray level. It allows us to have multiple geometry columns with different CRS and also making easy access to CRS for array-level methods like `area` or `distance` to implement those for geographic projections using `pyproj.Geod`.

POC at the moment, but everything seems to be working. Few conditions deserve a bit of simplification, I tried to make it explicit so far to cover all possibilities.

I'll post more information and consequences of this (plus few points for discussion) later, I just want to see CI now. 

~Requires #1336 (code of that is included here to make it work for now).~ (merged)

todo:
- [x] docstrings
- [x] documentation
- [x] cleanup of conditions in `GeoDataFrame` and `set_geometry`
- [x] agree on CRS priority
- [x] `assert_geodataframe` should check CRS for all columns (use `assert_geoseries_equal` for all geoseries)
- [x] propagate crs to array during `iloc, loc`
- [x] preserve CRS for array-level operations (buffer...)
- [x] complete tests
- [x] deprecation of CRS if no geometry is set
