### PR TITLE
BUG: Fix warning import

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -1,5 +1,6 @@
 from distutils.version import LooseVersion
 import os
+import warnings
 
 import pandas as pd
 


### PR DESCRIPTION
Quick fix, warnings is not being imported but is used on [line 73/74](https://github.com/geopandas/geopandas/blob/5d1181af6bcca88351d84bb63fc0fbe0e32ce055/geopandas/_compat.py#L73).