### PR TITLE
TST: fix sjoin test for pandas master

### DIFF
--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import pandas as pd
 
@@ -287,6 +289,10 @@ class TestSpatialJoin:
                 columns={"df1_ix1": "index_left0", "df1_ix2": "index_left1"}
             )
             exp.index.names = df2.index.names
+
+        # GH 1364 fix of behaviour was done in pandas 1.1.0
+        if op == "within" and str(pd.__version__) >= LooseVersion("1.1.0"):
+            exp = exp.sort_index()
 
         assert_frame_equal(res, exp, check_index_type=False)
 


### PR DESCRIPTION
Closes #1364 

Fix tests for `sjoin(... how='right', op='within')` using pandas master, which now returns gdf of the same order as the original one. This behaviour is essentially a fix of current incorrect result.

I have changed only tests to sort expected df. As this is a very minor issue which is now fixed by pandas, I don't think we have to make fix on our side to make sure that the behaviour is the same with older pandas.