### PR TITLE
BUG: CRS not propagated to GeometryArray based on scalar

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -6,6 +6,8 @@ import pandas as pd
 from pandas import DataFrame, Series
 
 from shapely.geometry import mapping, shape
+from shapely.geometry.base import BaseGeometry
+
 
 from pyproj import CRS
 
@@ -684,13 +686,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         df['geometry'] = [geom... for geom in df.geometry]
         """
         if not pd.api.types.is_list_like(key) and key == self._geometry_column_name:
-            if value is None:
-                value = GeometryArray(np.full(self.shape[0], None), crs=self.crs)
-            else:
-                try:
-                    value = _ensure_geometry(value, crs=self.crs)
-                except TypeError:
-                    warnings.warn("Geometry column does not contain geometry.")
+            if pd.api.types.is_scalar(value) or isinstance(value, BaseGeometry):
+                value = [value] * self.shape[0]
+            try:
+                value = _ensure_geometry(value, crs=self.crs)
+            except TypeError:
+                warnings.warn("Geometry column does not contain geometry.")
         super(GeoDataFrame, self).__setitem__(key, value)
 
     #

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -684,10 +684,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         df['geometry'] = [geom... for geom in df.geometry]
         """
         if not pd.api.types.is_list_like(key) and key == self._geometry_column_name:
-            try:
-                value = _ensure_geometry(value, crs=self.crs)
-            except TypeError:
-                warnings.warn("Geometry column does not contain geometry.")
+            if value is None:
+                value = GeometryArray(np.full(self.shape[0], None), crs=self.crs)
+            else:
+                try:
+                    value = _ensure_geometry(value, crs=self.crs)
+                except TypeError:
+                    warnings.warn("Geometry column does not contain geometry.")
         super(GeoDataFrame, self).__setitem__(key, value)
 
     #

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -282,6 +282,13 @@ class TestGeometryArrayCRS:
         df.crs = 27700
         assert df.crs == self.osgb
 
+        df = GeoDataFrame()
+        df.crs = 4326
+        df["geometry"] = None
+        assert df.crs == self.wgs
+        assert df.geometry.crs == self.wgs
+        assert df.geometry.values.crs == self.wgs
+
     def test_read_file(self):
         nybb_filename = datasets.get_path("nybb")
         df = read_file(nybb_filename)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -6,7 +6,7 @@ import random
 import numpy as np
 import pandas as pd
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Point, Polygon, LineString
 import pyproj
 
 from geopandas import GeoSeries, GeoDataFrame, points_from_xy, datasets, read_file
@@ -282,9 +282,14 @@ class TestGeometryArrayCRS:
         df.crs = 27700
         assert df.crs == self.osgb
 
-        df = GeoDataFrame()
-        df.crs = 4326
-        df["geometry"] = None
+    @pytest.mark.parametrize(
+        "scalar", [None, Point(0, 0), LineString([(0, 0), (1, 1)])]
+    )
+    def test_scalar(self, scalar):
+        with pytest.warns(FutureWarning):
+            df = GeoDataFrame()
+            df.crs = 4326
+        df["geometry"] = scalar
         assert df.crs == self.wgs
         assert df.geometry.crs == self.wgs
         assert df.geometry.values.crs == self.wgs


### PR DESCRIPTION
Closes #1374 

In case of setting geometry column using `None`, we should create either empty GeometryArray as in the following case of GeometryArray of `None` with crs inherited from df.

```py
gdf = gpd.GeoDataFrame()
gdf.crs = 4326
gdf['geometry'] = None
```

On master, `gdf.geometry` returns Series, this PR returns GeoSeries with CRS.