### PR TITLE
ENH: Move CRS mismatch check to GeometryArray level

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -429,7 +429,10 @@ class GeometryArray(ExtensionArray):
                     "Use `GeoSeries.to_crs()` to reproject one of "
                     "the passed geometry arrays.\n"
                     "Left CRS: {0}\n"
-                    "Right CRS: {1}".format(left.crs, right.crs)
+                    "Right CRS: {1}".format(
+                        left.crs.to_string() if left.crs else None,
+                        right.crs.to_string() if right.crs else None,
+                    )
                 )
             right = right.data
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -428,11 +428,8 @@ class GeometryArray(ExtensionArray):
                     "and the CRS of right geoemtries. "
                     "Use `GeoSeries.to_crs()` to reproject one of "
                     "the passed geometry arrays.\n"
-                    "Left CRS: {0}\n"
-                    "Right CRS: {1}".format(
-                        left.crs.to_string() if left.crs else None,
-                        right.crs.to_string() if right.crs else None,
-                    )
+                    "Left CRS:\n {0}\n"
+                    "Right CRS:\n {1}".format(left.crs.__repr__(), right.crs.__repr__())
                 )
             right = right.data
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 import numbers
 import operator
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -65,6 +66,20 @@ def _isna(value):
         return True
     else:
         return False
+
+
+def _check_crs(left, right, allow_none=False):
+    """
+    Check if the projection of both arrays is the same.
+
+    If allow_none is True, empty CRS is treated as the same.
+    """
+    if allow_none:
+        if not left.crs or not right.crs:
+            return True
+    if not left.crs == right.crs:
+        return False
+    return True
 
 
 # -----------------------------------------------------------------------------
@@ -215,6 +230,8 @@ class GeometryArray(ExtensionArray):
 
     def __init__(self, data, crs=None):
         if isinstance(data, self.__class__):
+            if not crs:
+                crs = data.crs
             data = data.data
         elif not isinstance(data, np.ndarray):
             raise TypeError(
@@ -405,6 +422,13 @@ class GeometryArray(ExtensionArray):
                     len(left), len(right)
                 )
                 raise ValueError(msg)
+            if not _check_crs(left, right):
+                warnings.warn(
+                    "CRS mismatch between the CRS of left geometries ({0}) "
+                    "and the CRS of right geoemtries ({1}). "
+                    "Use `GeoSeries.to_crs()` to reproject one of "
+                    "the passed geometry arrays.".format(left.crs, right.crs)
+                )
             right = right.data
 
         return getattr(vectorized, op)(left.data, right, **kwargs)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -429,7 +429,11 @@ class GeometryArray(ExtensionArray):
                     "Use `GeoSeries.to_crs()` to reproject one of "
                     "the passed geometry arrays.\n"
                     "Left CRS:\n {0}\n"
-                    "Right CRS:\n {1}".format(left.crs.__repr__(), right.crs.__repr__())
+                    "Right CRS:\n {1}\n".format(
+                        left.crs.__repr__(), right.crs.__repr__()
+                    ),
+                    UserWarning,
+                    stacklevel=6,
                 )
             right = right.data
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -424,12 +424,12 @@ class GeometryArray(ExtensionArray):
                 raise ValueError(msg)
             if not _check_crs(left, right):
                 warnings.warn(
-                    "CRS mismatch between the CRS of left geometries ({0}) "
-                    "and the CRS of right geoemtries ({1}). "
+                    "CRS mismatch between the CRS of left geometries "
+                    "and the CRS of right geoemtries. "
                     "Use `GeoSeries.to_crs()` to reproject one of "
-                    "the passed geometry arrays.".format(
-                        left.crs.to_string(), right.crs.to_string()
-                    )
+                    "the passed geometry arrays.\n"
+                    "Left CRS: {0}\n"
+                    "Right CRS: {1}".format(left.crs, right.crs)
                 )
             right = right.data
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -427,7 +427,9 @@ class GeometryArray(ExtensionArray):
                     "CRS mismatch between the CRS of left geometries ({0}) "
                     "and the CRS of right geoemtries ({1}). "
                     "Use `GeoSeries.to_crs()` to reproject one of "
-                    "the passed geometry arrays.".format(left.crs, right.crs)
+                    "the passed geometry arrays.".format(
+                        left.crs.to_string(), right.crs.to_string()
+                    )
                 )
             right = right.data
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -43,8 +43,6 @@ def _delegate_binary_method(op, this, other, *args, **kwargs):
     if isinstance(other, GeoPandasBase):
         this, other = this.align(other.geometry)
 
-        if this.crs != other.crs:
-            warn("GeoSeries crs mismatch: {0} and {1}".format(this.crs, other.crs))
         a_this = GeometryArray(this.values)
         other = GeometryArray(other.values)
     elif isinstance(other, BaseGeometry):

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -122,7 +122,7 @@ def assert_geoseries_equal(
 
     if not check_crs:
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "GeoSeries crs mismatch", UserWarning)
+            warnings.filterwarnings("ignore", "CRS mismatch", UserWarning)
             if check_less_precise:
                 assert geom_almost_equals(left, right)
             else:

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -20,6 +20,7 @@ from geopandas.array import (
     points_from_xy,
     to_wkb,
     to_wkt,
+    _check_crs,
 )
 import geopandas._compat as compat
 
@@ -791,3 +792,11 @@ def test_astype_multipolygon():
     result = arr.astype(np.dtype("U10"))
     assert result.dtype == np.dtype("U10")
     assert result[0] == multi_poly.wkt[:10]
+
+
+def test_check_crs():
+    t1 = T.copy()
+    t1.crs = 4326
+    assert _check_crs(t1, T) is False
+    assert _check_crs(t1, t1) is True
+    assert _check_crs(t1, T, allow_none=True) is True

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -10,7 +10,7 @@ from shapely.geometry import Point, Polygon, LineString
 import pyproj
 
 from geopandas import GeoSeries, GeoDataFrame, points_from_xy, datasets, read_file
-from geopandas.array import from_shapely, from_wkb, from_wkt
+from geopandas.array import from_shapely, from_wkb, from_wkt, GeometryArray
 
 from geopandas.testing import assert_geodataframe_equal
 import pytest
@@ -159,6 +159,12 @@ class TestGeometryArrayCRS:
 
         arr = from_shapely(self.geoms, crs=27700)
         assert arr.crs == self.osgb
+
+        arr = GeometryArray(arr)
+        assert arr.crs == self.osgb
+
+        arr = GeometryArray(arr, crs=4326)
+        assert arr.crs == self.wgs
 
     def test_series(self):
         s = GeoSeries(crs=27700)

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -56,6 +56,7 @@ df5 = GeoDataFrame(
 )
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_geoseries():
     assert_geoseries_equal(s1, s2)
     assert_geoseries_equal(s1, s3, check_series_type=False, check_dtype=False)


### PR DESCRIPTION
Closes #1369 

Move check for CRS mismatch for binary methods to GeometryArray level from GeoSeries level as discussed in #1339.