### PR TITLE
DEPR: add DeprecationWarning to set operators ('&', '|', '^', and '-')

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -880,18 +880,38 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
+        warnings.warn(
+            "'^'' operator will be deprecated. Use 'symmetric_difference' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.geometry.symmetric_difference(other)
 
     def __or__(self, other):
         """Implement | operator as for builtin set type"""
+        warnings.warn(
+            "'|'' operator will be deprecated. Use 'union' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.geometry.union(other)
 
     def __and__(self, other):
         """Implement & operator as for builtin set type"""
+        warnings.warn(
+            "'&'' operator will be deprecated. Use 'intersection' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.geometry.intersection(other)
 
     def __sub__(self, other):
         """Implement - operator as for builtin set type"""
+        warnings.warn(
+            "'-'' operator will be deprecated. Use 'difference' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.geometry.difference(other)
 
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -881,7 +881,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
         warnings.warn(
-            "'^'' operator will be deprecated. Use 'symmetric_difference' instead.",
+            "'^' operator will be deprecated. Use the 'symmetric_difference' "
+            "method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -890,7 +891,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __or__(self, other):
         """Implement | operator as for builtin set type"""
         warnings.warn(
-            "'|'' operator will be deprecated. Use 'union' instead.",
+            "'|' operator will be deprecated. Use the 'union' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -899,7 +900,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __and__(self, other):
         """Implement & operator as for builtin set type"""
         warnings.warn(
-            "'&'' operator will be deprecated. Use 'intersection' instead.",
+            "'&' operator will be deprecated. Use the 'intersection' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -908,7 +909,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __sub__(self, other):
         """Implement - operator as for builtin set type"""
         warnings.warn(
-            "'-'' operator will be deprecated. Use 'difference' instead.",
+            "'-' operator will be deprecated. Use the 'difference' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -484,7 +484,8 @@ class GeoSeries(GeoPandasBase, Series):
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
         warnings.warn(
-            "'^'' operator will be deprecated. Use 'symmetric_difference' instead.",
+            "'^' operator will be deprecated. Use the 'symmetric_difference' "
+            "method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -493,7 +494,7 @@ class GeoSeries(GeoPandasBase, Series):
     def __or__(self, other):
         """Implement | operator as for builtin set type"""
         warnings.warn(
-            "'|'' operator will be deprecated. Use 'union' instead.",
+            "'|' operator will be deprecated. Use the 'union' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -502,7 +503,7 @@ class GeoSeries(GeoPandasBase, Series):
     def __and__(self, other):
         """Implement & operator as for builtin set type"""
         warnings.warn(
-            "'&'' operator will be deprecated. Use 'intersection' instead.",
+            "'&' operator will be deprecated. Use the 'intersection' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -511,7 +512,7 @@ class GeoSeries(GeoPandasBase, Series):
     def __sub__(self, other):
         """Implement - operator as for builtin set type"""
         warnings.warn(
-            "'-'' operator will be deprecated. Use 'difference' instead.",
+            "'-' operator will be deprecated. Use the 'difference' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -483,16 +483,36 @@ class GeoSeries(GeoPandasBase, Series):
 
     def __xor__(self, other):
         """Implement ^ operator as for builtin set type"""
+        warnings.warn(
+            "'^'' operator will be deprecated. Use 'symmetric_difference' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.symmetric_difference(other)
 
     def __or__(self, other):
         """Implement | operator as for builtin set type"""
+        warnings.warn(
+            "'|'' operator will be deprecated. Use 'union' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.union(other)
 
     def __and__(self, other):
         """Implement & operator as for builtin set type"""
+        warnings.warn(
+            "'&'' operator will be deprecated. Use 'intersection' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.intersection(other)
 
     def __sub__(self, other):
         """Implement - operator as for builtin set type"""
+        warnings.warn(
+            "'-'' operator will be deprecated. Use 'difference' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.difference(other)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -661,27 +661,39 @@ class TestGeomMethods:
     # Test '&', '|', '^', and '-'
     #
     def test_intersection_operator(self):
-        self._test_binary_operator("__and__", self.t1, self.g1, self.g2)
-        self._test_binary_operator("__and__", self.t1, self.gdf1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__and__", self.t1, self.g1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__and__", self.t1, self.gdf1, self.g2)
 
     def test_union_operator(self):
-        self._test_binary_operator("__or__", self.sq, self.g1, self.g2)
-        self._test_binary_operator("__or__", self.sq, self.gdf1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__or__", self.sq, self.g1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__or__", self.sq, self.gdf1, self.g2)
 
     def test_union_operator_polygon(self):
-        self._test_binary_operator("__or__", self.sq, self.g1, self.t2)
-        self._test_binary_operator("__or__", self.sq, self.gdf1, self.t2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__or__", self.sq, self.g1, self.t2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__or__", self.sq, self.gdf1, self.t2)
 
     def test_symmetric_difference_operator(self):
-        self._test_binary_operator("__xor__", self.sq, self.g3, self.g4)
-        self._test_binary_operator("__xor__", self.sq, self.gdf3, self.g4)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__xor__", self.sq, self.g3, self.g4)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__xor__", self.sq, self.gdf3, self.g4)
 
     def test_difference_series2(self):
         expected = GeoSeries([GeometryCollection(), self.t2])
-        self._test_binary_operator("__sub__", expected, self.g1, self.g2)
-        self._test_binary_operator("__sub__", expected, self.gdf1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__sub__", expected, self.g1, self.g2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__sub__", expected, self.gdf1, self.g2)
 
     def test_difference_poly2(self):
         expected = GeoSeries([self.t1, self.t1])
-        self._test_binary_operator("__sub__", expected, self.g1, self.t2)
-        self._test_binary_operator("__sub__", expected, self.gdf1, self.t2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__sub__", expected, self.g1, self.t2)
+        with pytest.warns(DeprecationWarning):
+            self._test_binary_operator("__sub__", expected, self.gdf1, self.t2)


### PR DESCRIPTION
Deprecating set operators ('&', '|', '^', and '-'). To be removed in v0.9.

ref #1255