### PR TITLE
BENCH: Fix asv config for pygeos

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -30,6 +30,7 @@
     // determined by looking for tools on the PATH environment
     // variable.
     "environment_type": "conda",
+    "conda_channels": ["conda-forge", "defaults"],
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min


### PR DESCRIPTION
Pygeos is in Conda Forge, so that needs to be added.
I also added running with and without Pygoes, which as of right now is a very useful benchmark.