### PR TITLE
ENH: Add query and query_bulk to sindex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   - echo "Testing without PyGEOS"
   - USE_PYGEOS=0 pytest geopandas -v -r s --cov geopandas --cov-report term-missing
   - if [ "$PYGEOS" ]; then echo "Testing with PyGEOS"; fi
-  - if [ "$PYGEOS" ]; then USE_PYGEOS=1 pytest geopandas -v -r s --cov geopandas --cov-report term-missing; fi
+  - if [ "$PYGEOS" ]; then USE_PYGEOS=1 pytest geopandas -v -r s --cov-append --cov geopandas --cov-report term-missing; fi
   - if [ "$STYLE" ]; then black --check geopandas; fi
   - if [ "$STYLE" ]; then flake8 geopandas; fi
 

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -2,72 +2,68 @@ from geopandas import read_file, datasets
 from geopandas.sindex import VALID_QUERY_PREDICATES
 
 
+def generate_test_df():
+    world = read_file(datasets.get_path("naturalearth_lowres"))
+    capitals = read_file(datasets.get_path("naturalearth_cities"))
+    countries = world.to_crs("epsg:3395")[["geometry"]]
+    capitals = capitals.to_crs("epsg:3395")[["geometry"]]
+    mixed = capitals.append(countries)  # get a mix of geometries
+    points = capitals
+    polygons = countries
+    # filter out invalid geometries
+    data = {
+        "mixed": mixed[mixed.is_valid],
+        "points": points[points.is_valid],
+        "polygons": polygons[polygons.is_valid],
+    }
+    return data
+
+
 class Bench:
+
+    param_names = ["tree_geom_type"]
+    params = [["mixed", "points", "polygons"]]
+
     def setup(self, *args):
-        world = read_file(datasets.get_path("naturalearth_lowres"))
-        capitals = read_file(datasets.get_path("naturalearth_cities"))
-        countries = world.to_crs("epsg:3395")[["geometry"]]
-        capitals = capitals.to_crs("epsg:3395")[["geometry"]]
-
-        # save dfs
-        self.df, self.df2, self.data = (
-            capitals,
-            countries,
-            countries.geometry.values.data,
-        )
+        self.data = generate_test_df()
         # cache bounds so that bound creation is not counted in benchmarks
-        self.bounds = [c.bounds for c in capitals.geometry] + [
-            c.bounds for c in countries.geometry
-        ]
+        self.bounds = [g.bounds for g in self.data["mixed"].geometry]
 
-    def time_sindex_index_creation(self, *args):
+    def time_index_creation(self, tree_geom_type):
         """Time creation of spatial index.
 
         Note: pygeos will only create the index once; this benchmark
         is not intended to be used to compare rtree and pygeos.
         """
-        self.df._invalidate_sindex()
-        self.df._generate_sindex()
+        self.data[tree_geom_type]._invalidate_sindex()
+        self.data[tree_geom_type]._generate_sindex()
 
-    def time_sindex_intersects(self, *args):
+    def time_intersects(self, tree_geom_type):
         for bounds in self.bounds:
-            self.df.sindex.intersection(bounds)
+            self.data[tree_geom_type].sindex.intersection(bounds)
 
-    def time_sindex_intersects_objects(self, *args):
+    def time_intersects_objects(self, tree_geom_type):
         for bounds in self.bounds:
-            self.df.sindex.intersection(bounds, objects=True)
+            self.data[tree_geom_type].sindex.intersection(bounds, objects=True)
 
 
 class BenchQuery:
 
-    param_names = ["predicate"]
-    params = [*VALID_QUERY_PREDICATES]
+    param_names = ["predicate", "input_geom_type", "tree_geom_type"]
+    params = [
+        [*VALID_QUERY_PREDICATES],
+        ["mixed", "points", "polygons"],
+        ["mixed", "points", "polygons"],
+    ]
 
     def setup(self, *args):
-        world = read_file(datasets.get_path("naturalearth_lowres"))
-        capitals = read_file(datasets.get_path("naturalearth_cities"))
-        countries = world.to_crs("epsg:3395")
-        countries = countries[["geometry"]]
-        capitals = capitals.to_crs("epsg:3395")
-        capitals = capitals[["geometry"]]
+        self.data = generate_test_df()
 
-        # save dfs
-        self.df, self.df2, self.data = (
-            countries,
-            capitals,
-            capitals.geometry.values.data,
+    def time_query_bulk(self, predicate, input_geom_type, tree_geom_type):
+        self.data[tree_geom_type].sindex.query_bulk(
+            self.data[input_geom_type].geometry, predicate=predicate
         )
-        # cache bounds so that bound creation is not counted in benchmarks
-        self.bounds = [c.bounds for c in capitals.geometry] + [
-            c.bounds for c in countries.geometry
-        ]
 
-    def time_query_bulk_data(self, predicate):
-        self.df.sindex.query_bulk(self.data, predicate=predicate)
-
-    def time_query_bulk(self, predicate):
-        self.df.sindex.query_bulk(self.df2.geometry, predicate=predicate)
-
-    def time_query(self, predicate):
-        for geo in self.data:
-            self.df.sindex.query(geo, predicate=predicate)
+    def time_query(self, predicate, input_geom_type, tree_geom_type):
+        for geo in self.data[input_geom_type].geometry.sample(10, random_state=0):
+            self.data[tree_geom_type].sindex.query(geo, predicate=predicate)

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -1,6 +1,7 @@
 import random
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas.sindex import VALID_QUERY_PREDICATES
 from shapely.geometry import Point, Polygon
 import numpy as np
 
@@ -49,3 +50,44 @@ class Bench:
     def time_sindex_intersects_objects(self, *args):
         for bounds in self.bounds:
             self.df.sindex.intersection(bounds, objects=True)
+
+
+class BenchQuery:
+
+    param_names = ["predicate"]
+    params = [*VALID_QUERY_PREDICATES]
+
+    def setup(self, *args):
+        triangles = GeoSeries(
+            [
+                Polygon([(random.random(), random.random()) for _ in range(3)])
+                for _ in range(100)
+            ]
+        )
+
+        points = GeoSeries(
+            [
+                Point(x, y)
+                for x, y in zip(
+                    np.random.random_sample(1000), np.random.random_sample(1000)
+                )
+            ]
+        )
+
+        df1 = GeoDataFrame(
+            {"val1": np.random.randn(len(triangles)), "geometry": triangles}
+        )
+        df2 = GeoDataFrame({"val1": np.random.randn(len(points)), "geometry": points})
+
+        self.df, self.df2, self.data = df1, df2, df2.geometry.values.data
+        self.bounds = [point.bounds for point in points]
+
+    def time_bulk_query_data(self, predicate):
+        self.df.sindex.query_bulk(self.data, predicate=predicate)
+
+    def time_bulk_query(self, predicate):
+        self.df.sindex.query_bulk(self.df2.geometry, predicate=predicate)
+
+    def time_query(self, predicate):
+        for geo in self.data:
+            self.df.sindex.query(geo, predicate=predicate)

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -223,7 +223,8 @@ if compat.HAS_RTREE:
 
 if compat.HAS_PYGEOS:
 
-    import geopandas
+    from . import geoseries  # noqa
+    from .array import GeometryArray  # noqa
     from pygeos import STRtree, box, points, Geometry  # noqa
 
     class PyGEOSSTRTreeIndex(STRtree):
@@ -277,9 +278,9 @@ if compat.HAS_PYGEOS:
                     + "`predicate` must be one of %s" % self.valid_query_predicates
                 )
 
-            if isinstance(geometry, geopandas.GeoSeries):
+            if isinstance(geometry, geoseries.GeoSeries):
                 geometry = geometry.values.data
-            elif isinstance(geometry, geopandas.array.GeometryArray):
+            elif isinstance(geometry, GeometryArray):
                 geometry = geometry.data
             elif not isinstance(geometry, np.ndarray):
                 try:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -273,9 +273,10 @@ if compat.HAS_PYGEOS:
         def __init__(self, geometry):
             # for compatibility with old RTree implementation, store ids/indexes
             original_indexes = geometry.index
-            non_empty = geometry[~geometry.values.is_empty]
-            self.objects = self.ids = original_indexes[~geometry.values.is_empty]
-            super().__init__(non_empty.values.data)
+            non_empty = ~geometry.values.is_empty
+            self._geometries = geometry[non_empty]
+            self.objects = self.ids = original_indexes[non_empty]
+            super().__init__(self._geometries.values.data)
 
         def query(self, geometry, predicate=None, sort=False):
             """Wrapper for pygeos.query.

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -95,7 +95,7 @@ if compat.HAS_RTREE:
             self._geometries = geometry.geometry.values
             # create a prepared geometry cache
             self._prepared_geometries = np.array(
-                [None] * self._geometries.size, dtype=np.intp
+                [None] * self._geometries.size, dtype=object
             )
 
         def query(self, geometry, predicate=None, sort=False):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -354,9 +354,8 @@ if compat.HAS_PYGEOS:
                 # handle shapely geometries
                 if compat.PYGEOS_SHAPELY_COMPAT:
                     geometry = from_shapely(geometry)
-
                 # fallback going through WKB
-                if geometry.is_empty and geometry.geom_type == "Point":
+                elif geometry.is_empty and geometry.geom_type == "Point":
                     # empty point does not roundtrip through WKB
                     geometry = from_wkb("POINT EMPTY")
                 else:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -117,14 +117,18 @@ if compat.HAS_RTREE:
             # handle invalid predicates
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
-                    "`predicate` must be one of %s" % self.valid_query_predicates
+                    "Got `predicate` = `%s`; " % predicate
+                    + "`predicate` must be one of %s" % self.valid_query_predicates
                 )
             # handle empty / invalid geometries
             if geometry is None:
                 # this is the behavior in pygeos.strtree.query, we mimic it here
                 return np.array([], dtype=np.intp)
             if not isinstance(geometry, BaseGeometry):
-                raise TypeError("`geometry` must be a shapely geometry")
+                raise TypeError(
+                    "Got `geometry` of type `%s`, " % type(geometry)
+                    + "`geometry` must be a shapely geometry."
+                )
             if geometry.is_empty:
                 return np.array([], dtype=np.intp)
 
@@ -269,7 +273,8 @@ if compat.HAS_PYGEOS:
 
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
-                    "`predicate` must be one of %s" % self.valid_query_predicates
+                    "Got `predicate` = `%s`; " % predicate
+                    + "`predicate` must be one of %s" % self.valid_query_predicates
                 )
 
             if isinstance(geometry, geopandas.GeoSeries):
@@ -277,9 +282,15 @@ if compat.HAS_PYGEOS:
             elif isinstance(geometry, geopandas.array.GeometryArray):
                 geometry = geometry.data
             elif not isinstance(geometry, np.ndarray):
-                raise TypeError(
-                    "`geometry` must be a GeoSeries, GeometryArray or numpy.ndarray"
-                )
+                try:
+                    # accept other iterables, ex list, tuple or generator
+                    iter(geometry)
+                except TypeError:
+                    raise TypeError(
+                        "Got `geometry` of type `%s`, " % type(geometry)
+                        + "`geometry` must be a GeoSeries, GeometryArray, "
+                        "numpy.ndarray or other iterable."
+                    )
 
             res = super().query_bulk(geometry, predicate)
 
@@ -314,7 +325,8 @@ if compat.HAS_PYGEOS:
 
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
-                    "`predicate` must be one of %s" % self.valid_query_predicates
+                    "Got `predicate` = `%s`; " % predicate
+                    + "`predicate` must be one of %s" % self.valid_query_predicates
                 )
 
             matches = super().query(geometry=geometry, predicate=predicate)
@@ -346,7 +358,8 @@ if compat.HAS_PYGEOS:
                 # to ensure a useful failure message
                 raise TypeError(
                     "Invalid coordinates, must be iterable in format "
-                    "(minx, miny, maxx, maxy) (for bounds) or (x, y) (for points)."
+                    "(minx, miny, maxx, maxy) (for bounds) or (x, y) (for points). "
+                    "Got `coordinates` = %s." % coordinates
                 )
 
             # need to convert tuple of bounds to a geometry object
@@ -357,7 +370,8 @@ if compat.HAS_PYGEOS:
             else:
                 raise TypeError(
                     "Invalid coordinates, must be iterable in format "
-                    "(minx, miny, maxx, maxy) (for bounds) or (x, y) (for points)."
+                    "(minx, miny, maxx, maxy) (for bounds) or (x, y) (for points). "
+                    "Got `coordinates` = %s." % coordinates
                 )
 
             if objects:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -166,7 +166,7 @@ if compat.HAS_RTREE:
             if predicate == "within":
                 # To use prepared geometries for within,
                 # we compare tree_geom.contains(input_geom)
-                # Since we are preping the tree geometries,
+                # Since we are preparing the tree geometries,
                 # we cache them for multiple comparisons.
                 res = []
                 for index_in_tree in tree_idx:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -120,19 +120,20 @@ if compat.HAS_RTREE:
                     "`predicate` must be one of %s" % self.valid_query_predicates
                 )
             # handle empty / invalid geometries
-            if not geometry:
-                return np.array([], dtype="int64")
+            if geometry is None:
+                # this is the behavior in pygeos.strtree.query, we mimic it here
+                return np.array([], dtype=np.intp)
             if not isinstance(geometry, BaseGeometry):
                 raise TypeError("`geometry` must be a shapely geometry")
             if geometry.is_empty:
-                return np.array([], dtype="int64")
+                return np.array([], dtype=np.intp)
 
             # get bounds
             bounds = geometry.bounds  # rtree operates on bounds
             tree_query = list(self.intersection(bounds, objects=False))
 
             if not tree_query:
-                return np.array([], dtype="int64")
+                return np.array([], dtype=np.intp)
 
             # check predicate
             if predicate in ("intersects", "within"):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -134,8 +134,10 @@ if compat.HAS_RTREE:
                 return np.array([], dtype=np.intp)
             if not isinstance(geometry, BaseGeometry):
                 raise TypeError(
-                    "Got `geometry` of type `{}`, `geometry` must be "
-                    + "a shapely geometry.".format(type(geometry))
+                    "Got `geometry` of type `{}`, `geometry` must be ".format(
+                        type(geometry)
+                    )
+                    + "a shapely geometry."
                 )
             if geometry.is_empty:
                 return np.array([], dtype=np.intp)
@@ -342,9 +344,9 @@ if compat.HAS_PYGEOS:
 
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
-                    "Got `predicate` = `{}`; "
+                    "Got `predicate` = `{}`; ".format(predicate)
                     + "`predicate` must be one of {}".format(
-                        predicate, self.valid_query_predicates
+                        self.valid_query_predicates
                     )
                 )
 
@@ -356,7 +358,7 @@ if compat.HAS_PYGEOS:
                 # fallback going through WKB
                 if geometry.is_empty and geometry.geom_type == "Point":
                     # empty point does not roundtrip through WKB
-                    geometry = from_wkt("POINT EMPTY")
+                    geometry = from_wkb("POINT EMPTY")
                 else:
                     geometry = from_wkb(geometry.wkb)
 

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -4,7 +4,6 @@ from shapely.geometry import Point, Polygon, box, GeometryCollection
 from numpy.testing import assert_array_equal
 
 import geopandas
-from geopandas.array import _shapely_to_geom as shapely_to_geom
 from geopandas import _compat as compat
 from geopandas import GeoDataFrame, GeoSeries, read_file, sindex
 
@@ -165,7 +164,7 @@ class TestPygeosInterface:
     )
     def test_query(self, predicate, test_geom, expected):
         """Tests the `query` method with valid inputs and valid predicates."""
-        test_geom = shapely_to_geom(box(*test_geom))
+        test_geom = box(*test_geom)
         res = self.df.sindex.query(test_geom, predicate=predicate)
         assert_array_equal(res, expected)
 
@@ -204,7 +203,7 @@ class TestPygeosInterface:
     def test_query_invalid_predicate(self, predicate, test_geom, expected):
         """Tests the `query` method with invalid predicates.
         """
-        test_geom = shapely_to_geom(box(*test_geom))
+        test_geom = box(*test_geom)
         with pytest.raises(ValueError):
             self.df.sindex.query(test_geom, predicate=predicate)
 
@@ -224,7 +223,6 @@ class TestPygeosInterface:
     def test_query_empty_geometry(self, test_geom, expected_error, expected_value):
         """Tests the `query` method with empty geometry.
         """
-        test_geom = shapely_to_geom(test_geom)
         if expected_error is not None:
             with pytest.raises(expected_error):
                 self.df.sindex.query(test_geom)

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -185,16 +185,30 @@ class TestPygeosInterface:
     @pytest.mark.parametrize(
         "predicate, test_geom, expected",
         (
-            (None, box(-1, -1, -0.5, -0.5), []),
-            (None, box(-0.5, -0.5, 0.5, 0.5), [0]),
-            (None, box(0, 0, 1, 1), [0, 1]),
-            # bbox intersects but not geometry
-            (None, LineString([(0, 1), (1, 0)]), [0, 1]),
-            ("intersects", box(-1, -1, -0.5, -0.5), []),
-            ("intersects", box(-0.5, -0.5, 0.5, 0.5), [0]),
-            ("intersects", box(0, 0, 1, 1), [0, 1]),
-            # bbox intersects but not geometry
-            ("intersects", LineString([(0, 1), (1, 0)]), []),
+            (None, box(-1, -1, -0.5, -0.5), []),  # bbox does not intersect
+            (None, box(-0.5, -0.5, 0.5, 0.5), [0]),  # bbox intersects
+            (None, box(0, 0, 1, 1), [0, 1]),  # bbox intersects multiple
+            (
+                None,
+                LineString([(0, 1), (1, 0)]),
+                [0, 1],
+            ),  # bbox intersects but not geometry
+            ("intersects", box(-1, -1, -0.5, -0.5), []),  # bbox does not intersect
+            (
+                "intersects",
+                box(-0.5, -0.5, 0.5, 0.5),
+                [0],
+            ),  # bbox and geometry intersect
+            (
+                "intersects",
+                box(0, 0, 1, 1),
+                [0, 1],
+            ),  # bbox and geometry intersect multiple
+            (
+                "intersects",
+                LineString([(0, 1), (1, 0)]),
+                [],
+            ),  # bbox intersects but not geometry
             ("within", box(0.25, 0.28, 0.75, 0.75), []),  # does not intersect
             ("within", box(0, 0, 10, 10), []),  # intersects but is not within
             ("within", box(11, 11, 12, 12), [5]),  # intersects and is within
@@ -207,7 +221,13 @@ class TestPygeosInterface:
                 "contains",
                 LineString([(0, 1), (1, 0)]),
                 [],
-            ),  # intersects but not contained
+            ),  # intersects but not contains
+            ("touches", box(-1, -1, 0, 0), [0]),  # bbox intersects and touches
+            (
+                "touches",
+                box(-0.5, -0.5, 1.5, 1.5),
+                [],
+            ),  # bbox intersects but geom does not touch
         ),
     )
     def test_query(self, predicate, test_geom, expected):
@@ -394,6 +414,7 @@ class TestPygeosInterface:
         (
             (None, (-1, -1, -0.5, -0.5), [[], []]),
             ("intersects", (-1, -1, -0.5, -0.5), [[], []]),
+            ("contains", (-1, -1, 1, 1), [[0], [0]]),
         ),
     )
     def test_query_bulk_input_type(self, predicate, test_geom, expected):

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -234,21 +234,31 @@ class TestPygeosInterface:
             assert_array_equal(res, expected_value)
 
     @pytest.mark.parametrize(
-        "test_geom, expected_error, expected_value",
-        [(GeometryCollection(), None, [[], []])],
+        "test_geoms, expected_error, expected_value",
+        [
+            # single empty geometry
+            ([GeometryCollection()], None, [[], []]),
+            # None should be skipped
+            ([GeometryCollection(), None], None, [[], []]),
+            ([None], None, [[], []]),
+            ([None, box(-0.5, -0.5, 0.5, 0.5), None], None, [[1], [0]]),
+        ],
     )
-    def test_query_bulk_empty_geometry(self, test_geom, expected_error, expected_value):
+    def test_query_bulk_empty_geometry(
+        self, test_geoms, expected_error, expected_value
+    ):
         """Tests the `query_bulk` method with an empty geometry.
         """
         # pass through GeoSeries to have GeoPandas
         # determine if it should use shapely or pygeos geometry objects
-        test_geom = geopandas.GeoSeries([test_geom], index=["0"])
+        # note: for this test, test_geoms (note plural) is a list already
+        test_geoms = geopandas.GeoSeries(test_geoms, index=range(len(test_geoms)))
         if expected_error is not None:
             with pytest.raises(expected_error):
-                self.df.sindex.query_bulk(test_geom)
+                self.df.sindex.query_bulk(test_geoms)
         else:
             # no error expected
-            res = self.df.sindex.query_bulk(test_geom)
+            res = self.df.sindex.query_bulk(test_geoms)
             assert_array_equal(res, expected_value)
 
     @pytest.mark.parametrize(

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -214,7 +214,7 @@ class TestPygeosInterface:
             self.df.sindex.query(test_geom.geometry.values.data[0], predicate=predicate)
 
     @pytest.mark.parametrize(
-        "test_geom, expected_error", (("notavalidgeom", TypeError),),
+        "test_geom, expected_error", [("notavalidgeom", TypeError)],
     )
     def test_query_invalid_geometry(self, test_geom, expected_error):
         """Tests the `query` method with invalid geometry.
@@ -226,10 +226,10 @@ class TestPygeosInterface:
 
     @pytest.mark.parametrize(
         "test_geom, expected_error, expected_value",
-        ((GeometryCollection(), None, []), (None, None, []),),
+        [(GeometryCollection(), None, []), (None, None, [])],
     )
     def test_query_empty_geometry(self, test_geom, expected_error, expected_value):
-        """Tests the `query` method with empty or None geometry.
+        """Tests the `query` method with empty geometry.
         """
         # pass through GeoSeries to have GeoPandas
         # determine if it should use shapely or pygeos geometry objects
@@ -244,7 +244,7 @@ class TestPygeosInterface:
 
     @pytest.mark.parametrize(
         "test_geom, expected_error, expected_value",
-        ((GeometryCollection(), None, [[], []]),),
+        [(GeometryCollection(), None, [[], []])],
     )
     def test_query_bulk_empty_geometry(self, test_geom, expected_error, expected_value):
         """Tests the `query_bulk` method with an empty geometry.

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -209,25 +209,20 @@ class TestPygeosInterface:
             self.df.sindex.query(test_geom)
 
     @pytest.mark.parametrize(
-        "test_geom, expected_error, expected_value",
+        "test_geom, expected_value",
         [
-            (None, None, []),
-            (GeometryCollection(), None, []),
-            (Point(), None, []),
-            (MultiPolygon(), None, []),
-            (Polygon(), None, []),
+            (None, []),
+            (GeometryCollection(), []),
+            (Point(), []),
+            (MultiPolygon(), []),
+            (Polygon(), []),
         ],
     )
-    def test_query_empty_geometry(self, test_geom, expected_error, expected_value):
+    def test_query_empty_geometry(self, test_geom, expected_value):
         """Tests the `query` method with empty geometry.
         """
-        if expected_error is not None:
-            with pytest.raises(expected_error):
-                self.df.sindex.query(test_geom)
-        else:
-            # no error expected
-            res = self.df.sindex.query(test_geom)
-            assert_array_equal(res, expected_value)
+        res = self.df.sindex.query(test_geom)
+        assert_array_equal(res, expected_value)
 
     @pytest.mark.parametrize(
         "predicate, test_geom, expected", (("test", (-1, -1, -0.5, -0.5), [[], []]),),
@@ -325,49 +320,34 @@ class TestPygeosInterface:
         assert_array_equal(res, expected)
 
     @pytest.mark.parametrize(
-        "test_geoms, expected_error, expected_value",
+        "test_geoms, expected_value",
         [
             # single empty geometry
-            ([GeometryCollection()], None, [[], []]),
+            ([GeometryCollection()], [[], []]),
             # None should be skipped
-            ([GeometryCollection(), None], None, [[], []]),
-            ([None], None, [[], []]),
-            ([None, box(-0.5, -0.5, 0.5, 0.5), None], None, [[1], [0]]),
+            ([GeometryCollection(), None], [[], []]),
+            ([None], [[], []]),
+            ([None, box(-0.5, -0.5, 0.5, 0.5), None], [[1], [0]]),
         ],
     )
-    def test_query_bulk_empty_geometry(
-        self, test_geoms, expected_error, expected_value
-    ):
+    def test_query_bulk_empty_geometry(self, test_geoms, expected_value):
         """Tests the `query_bulk` method with an empty geometry.
         """
         # pass through GeoSeries to have GeoPandas
         # determine if it should use shapely or pygeos geometry objects
         # note: for this test, test_geoms (note plural) is a list already
         test_geoms = geopandas.GeoSeries(test_geoms, index=range(len(test_geoms)))
-        if expected_error is not None:
-            with pytest.raises(expected_error):
-                self.df.sindex.query_bulk(test_geoms)
-        else:
-            # no error expected
-            res = self.df.sindex.query_bulk(test_geoms)
-            assert_array_equal(res, expected_value)
+        res = self.df.sindex.query_bulk(test_geoms)
+        assert_array_equal(res, expected_value)
 
     @pytest.mark.parametrize(
-        "test_array, expected_error, expected_value",
-        ((np.array([], dtype=object), None, [[], []]),),
+        "test_array, expected_value", ((np.array([], dtype=object), [[], []]),),
     )
-    def test_query_bulk_empty_input_array(
-        self, test_array, expected_error, expected_value
-    ):
+    def test_query_bulk_empty_input_array(self, test_array, expected_value):
         """Tests the `query_bulk` method with an empty input array.
         """
-        if expected_error is not None:
-            with pytest.raises(expected_error):
-                self.df.sindex.query_bulk(test_array)
-        else:
-            # no error expected
-            res = self.df.sindex.query_bulk(test_array)
-            assert_array_equal(res, expected_value)
+        res = self.df.sindex.query_bulk(test_array)
+        assert_array_equal(res, expected_value)
 
     @pytest.mark.parametrize(
         "test_array, expected_error, expected_value",
@@ -378,13 +358,8 @@ class TestPygeosInterface:
     ):
         """Tests the `query_bulk` method with invalid input for the `geometry` parameter.
         """
-        if expected_error is not None:
-            with pytest.raises(expected_error):
-                self.df.sindex.query_bulk(test_array)
-        else:
-            # no error expected
-            res = self.df.sindex.query_bulk(test_array)
-            assert_array_equal(res, expected_value)
+        with pytest.raises(expected_error):
+            self.df.sindex.query_bulk(test_array)
 
     @pytest.mark.parametrize(
         "predicate, test_geom, expected", (("test", (-1, -1, -0.5, -0.5), [[], []]),),

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -521,13 +521,6 @@ class TestPygeosInterface:
         """Tests output sizes for the naturalearth datasets."""
         world = read_file(datasets.get_path("naturalearth_lowres"))
         capitals = read_file(datasets.get_path("naturalearth_cities"))
-        # Reproject to Mercator (after dropping Antartica)
-        world = world[
-            (world.name != "Antarctica") & (world.name != "Fr. S. Antarctic Lands")
-        ]
-        countries = world.to_crs("epsg:3395")[["geometry"]]
-        capitals = capitals.to_crs("epsg:3395")[["geometry"]]
 
-        res = countries.sindex.query_bulk(capitals.geometry, predicate)
-        print(res.shape)
+        res = world.sindex.query_bulk(capitals.geometry, predicate)
         assert res.shape == expected_shape

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -282,7 +282,9 @@ class TestPygeosInterface:
             if not compat.USE_PYGEOS and sort is False:
                 pytest.xfail(
                     "rtree results are known to be unordered, see "
-                    "https://github.com/geopandas/geopandas/issues/1337"
+                    "https://github.com/geopandas/geopandas/issues/1337\n"
+                    "Expected:\n {}\n".format(expected)
+                    + "Got:\n {}\n".format(res.tolist())
                 )
             raise e
 
@@ -458,7 +460,9 @@ class TestPygeosInterface:
             if not compat.USE_PYGEOS and sort is False:
                 pytest.xfail(
                     "rtree results are known to be unordered, see "
-                    "https://github.com/geopandas/geopandas/issues/1337"
+                    "https://github.com/geopandas/geopandas/issues/1337\n"
+                    "Expected:\n {}\n".format(expected)
+                    + "Got:\n {}\n".format(res.tolist())
                 )
             raise e
 


### PR DESCRIPTION
The next step in integration of `pygeos.strtree`.

A couple of notes:
1. I included sorting for now, but am happy to remove it if it adds too much complexity.
2. I included support for other predicates (and tests, it works) but will be happy to remove it for now if we want to do that separately.

A general comment:
I think it would be cool to have a spatial index abstract base class that lives inside of `sindex.py` that starts to sketch out what API we expect for spatial indexes. Any thoughts on that are welcome.

CCing @jorisvandenbossche  @martinfleis  @brendan-ward 