### PR TITLE
DOC: corrections / updates

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -92,9 +92,9 @@ as well::
     When using pip to install GeoPandas, you need to make sure that all dependencies are
     installed correctly.
 
-    - `shapely`_ and `fiona`_ provide binary wheels with the
-      dependencies included for Mac and Linux, but not for Windows.
-    - `pyproj`_ provides binary wheels with depencies included
+    - `fiona`_ provides binary wheels with the dependencies included for Mac and Linux,
+      but not for Windows.
+    - `pyproj`_ and `shapely`_ provide binary wheels with dependencies included
       for Mac, Linux, and Windows.
     - `rtree`_ does not provide wheels.
     - Windows wheels for `shapely`, `fiona`, `pyproj` and `rtree`

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -24,7 +24,7 @@ def sjoin(
         * 'right': use keys from right_df; retain only right_df geometry column
         * 'inner': use intersection of keys from both dfs; retain only
           left_df geometry column
-    op : string, default 'intersection'
+    op : string, default 'intersects'
         Binary predicate, one of {'intersects', 'contains', 'within'}.
         See http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates.
     lsuffix : string, default 'left'


### PR DESCRIPTION
* Binary wheels for shapely have been available since version 1.7.0
* Correction to `sjoin` default for `op`