### PR TITLE
API: privacy of geopandas.io

### DIFF
--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -4,8 +4,8 @@ from geopandas.geoseries import GeoSeries  # noqa
 from geopandas.geodataframe import GeoDataFrame  # noqa
 from geopandas.array import points_from_xy  # noqa
 
-from geopandas.io.file import read_file  # noqa
-from geopandas.io.sql import read_postgis  # noqa
+from geopandas.io.file import _read_file as read_file  # noqa
+from geopandas.io.sql import _read_postgis as read_postgis  # noqa
 from geopandas.tools import sjoin  # noqa
 from geopandas.tools import overlay  # noqa
 from geopandas.tools._show_versions import show_versions  # noqa

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -929,7 +929,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 /mydatabase";)
         >>> gdf.to_postgis("my_table", engine)
         """
-        geopandas.io.sql.write_postgis(
+        geopandas.io.sql._write_postgis(
             self, name, con, schema, if_exists, index, index_label, chunksize, dtype
         )
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -618,9 +618,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         --------
         GeoSeries.to_file
         """
-        from geopandas.io.file import to_file
+        from geopandas.io.file import _to_file
 
-        to_file(self, filename, driver, schema, index, **kwargs)
+        _to_file(self, filename, driver, schema, index, **kwargs)
 
     def to_crs(self, crs=None, epsg=None, inplace=False):
         """Transform geometries to a new coordinate reference system.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -330,7 +330,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         --------
         >>> df = geopandas.GeoDataFrame.from_file('nybb.shp')
         """
-        return geopandas.io.file.read_file(filename, **kwargs)
+        return geopandas.io.file._read_file(filename, **kwargs)
 
     @classmethod
     def from_features(cls, features, crs=None, columns=None):
@@ -437,7 +437,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         >>> df = geopandas.GeoDataFrame.from_postgis(sql, con)
         """
 
-        df = geopandas.io.sql.read_postgis(
+        df = geopandas.io.sql._read_postgis(
             sql,
             con,
             geom_col=geom_col,

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -36,7 +36,7 @@ def _is_url(url):
         return False
 
 
-def read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
+def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
     """
     Returns a GeoDataFrame from a file or URL.
 
@@ -139,6 +139,19 @@ def read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
             return GeoDataFrame.from_features(
                 f_filt, crs=crs, columns=columns + ["geometry"]
             )
+
+
+def read_file(*args, **kwargs):
+    import warnings
+
+    warnings.warn(
+        "geopandas.io.file.read_file() is intended for internal "
+        "use only, and will be deprecated. Use geopandas.read_file() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _read_file(*args, **kwargs)
 
 
 def to_file(*args, **kwargs):

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -141,7 +141,21 @@ def read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
             )
 
 
-def to_file(
+def to_file(*args, **kwargs):
+    import warnings
+
+    warnings.warn(
+        "geopandas.io.file.to_file() is intended for internal "
+        "use only, and will be deprecated. Use GeoDataFrame.to_file() "
+        "or GeoSeries.to_file() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _to_file(*args, **kwargs)
+
+
+def _to_file(
     df,
     filename,
     driver="ESRI Shapefile",

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -1,4 +1,3 @@
-import sys
 import warnings
 
 import pandas as pd
@@ -10,7 +9,7 @@ from geopandas import GeoDataFrame
 from .. import _compat as compat
 
 
-def read_postgis(
+def _read_postgis(
     sql,
     con,
     geom_col="geom",
@@ -83,12 +82,7 @@ def read_postgis(
             """Load from binary encoded as text."""
             return shapely.wkb.loads(str(x), hex=True)
 
-        if sys.version_info.major < 3:
-            if isinstance(geoms.iat[0], buffer):
-                load_geom = load_geom_buffer
-            else:
-                load_geom = load_geom_text
-        elif isinstance(geoms.iat[0], bytes):
+        if isinstance(geoms.iat[0], bytes):
             load_geom = load_geom_bytes
         else:
             load_geom = load_geom_text
@@ -101,6 +95,19 @@ def read_postgis(
                 crs = "epsg:{}".format(srid)
 
     return GeoDataFrame(df, crs=crs, geometry=geom_col)
+
+
+def read_postgis(*args, **kwargs):
+    import warnings
+
+    warnings.warn(
+        "geopandas.io.sql.read_postgis() is intended for internal "
+        "use only, and will be deprecated. Use geopandas.read_postgis() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _read_postgis(*args, **kwargs)
 
 
 def _get_geometry_type(gdf):

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -220,7 +220,7 @@ def _psql_insert_copy(tbl, conn, keys, data_iter):
         cur.copy_expert(sql=sql, file=s_buf)
 
 
-def write_postgis(
+def _write_postgis(
     gdf,
     name,
     con,

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -557,6 +557,11 @@ def test_read_file_empty_shapefile(tmpdir):
     assert all(empty.columns == ["A", "Z", "geometry"])
 
 
+def test_read_file_privacy(tmpdir, df_nybb):
+    with pytest.warns(DeprecationWarning):
+        geopandas.io.file.read_file(geopandas.datasets.get_path("nybb"))
+
+
 class FileNumber(object):
     def __init__(self, tmpdir, base, ext):
         self.tmpdir = str(tmpdir)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -211,6 +211,12 @@ def test_to_file_empty(tmpdir):
         input_empty_df.to_file(tempfilename)
 
 
+def test_to_file_privacy(tmpdir, df_nybb):
+    tempfilename = os.path.join(str(tmpdir), "test.shp")
+    with pytest.warns(DeprecationWarning):
+        geopandas.io.file.to_file(df_nybb, tempfilename)
+
+
 def test_to_file_schema(tmpdir, df_nybb):
     """
     Ensure that the file is written according to the schema

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -9,7 +9,7 @@ import os
 import geopandas
 from geopandas import GeoDataFrame, read_file, read_postgis
 
-from geopandas.io.sql import write_postgis
+from geopandas.io.sql import _write_postgis as write_postgis
 from geopandas.tests.util import create_postgis, create_spatialite, validate_boro_df
 import pytest
 

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -292,6 +292,14 @@ class TestIO:
         df = read_postgis(sql, con, geom_col=geom_col)
         validate_boro_df(df)
 
+    def test_read_postgis_privacy(self, connection_postgis, df_nybb):
+        con = connection_postgis
+        create_postgis(con, df_nybb)
+
+        sql = "SELECT * FROM nybb;"
+        with pytest.warns(DeprecationWarning):
+            geopandas.io.sql.read_postgis(sql, con)
+
     def test_write_postgis_default(self, engine_postgis, df_nybb):
         """Tests that GeoDataFrame can be written to PostGIS with defaults."""
         engine = engine_postgis


### PR DESCRIPTION
Making our internal io functions, which are then linked to GeoDataFrame as methods, internal. 

See https://github.com/geopandas/geopandas/pull/1406#issuecomment-623987622

> @jorisvandenbossche Now, you somewhat have the same issue with `read_file`, `read_postgis` etc as well, as we don't want people to use that from `geopandas.io.sql`..., but rather from the top-level. But at least there it is the exact same function.

Since these are the same things, we can keep it as it is now. If we change them, then we can switch to private with deprecation later.