### PR TITLE
TST: skip test_value_counts_with_normalize

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -418,9 +418,13 @@ class TestComparisonOps(extension_tests.BaseComparisonOpsTests):
 
 
 class TestMethods(extension_tests.BaseMethodsTests):
-    @no_sorting
+    @not_yet_implemented
     @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna):
+        pass
+
+    @not_yet_implemented
+    def test_value_counts_with_normalize(self, data):
         pass
 
     @no_sorting


### PR DESCRIPTION
Pandas added `test_value_counts_with_normalize` to ExtensionArray tests. Skipping as we do not support value_counts on geometry.