### PR TITLE
TST: fix test_series_constructor_scalar_with_index

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -796,7 +796,7 @@ class GeometryArray(ExtensionArray):
         ExtensionArray
         """
         # GH 1413
-        if not pd.api.types.is_list_like(scalars):
+        if isinstance(scalars, BaseGeometry):
             scalars = [scalars]
         return from_shapely(scalars)
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -795,6 +795,9 @@ class GeometryArray(ExtensionArray):
         -------
         ExtensionArray
         """
+        # GH 1413
+        if not pd.api.types.is_list_like(scalars):
+            scalars = [scalars]
         return from_shapely(scalars)
 
     def _values_for_factorize(self):


### PR DESCRIPTION
Adapt `from_shapely` to allow single geometry on input. That is what pandas master `TestConstructors.test_series_constructor_scalar_with_index` tries to do and fails. 