### PR TITLE
FIX: Ensure writing to PostGIS table works when "appending" and table does not exist yet

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -325,8 +325,7 @@ def _write_postgis(
                 schema_name = "public"
 
             # Only check SRID if table exists
-            if pd.io.sql.has_table(name, connection, schema):
-
+            if connection.run_callable(connection.dialect.has_table, name, schema):
                 target_srid = connection.execute(
                     "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
                         schema=schema_name, table=name, geom_col=geom_name

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -324,20 +324,23 @@ def _write_postgis(
             else:
                 schema_name = "public"
 
-            target_srid = connection.execute(
-                "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
-                    schema=schema_name, table=name, geom_col=geom_name
-                )
-            ).fetchone()[0]
+            # Only check SRID if table exists
+            if pd.io.sql.has_table(name, connection, schema):
 
-            if target_srid != srid:
-                msg = (
-                    "The CRS of the target table (EPSG:{epsg_t}) differs from the "
-                    "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
-                        epsg_t=target_srid, epsg_src=srid
+                target_srid = connection.execute(
+                    "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
+                        schema=schema_name, table=name, geom_col=geom_name
                     )
-                )
-                raise ValueError(msg)
+                ).fetchone()[0]
+
+                if target_srid != srid:
+                    msg = (
+                        "The CRS of the target table (EPSG:{epsg_t}) differs from the "
+                        "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
+                            epsg_t=target_srid, epsg_src=srid
+                        )
+                    )
+                    raise ValueError(msg)
 
     with con.begin() as connection:
 

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -585,3 +585,38 @@ class TestIO:
         sql = "SELECT * FROM {table};".format(table=table)
         df = read_postgis(sql, engine, geom_col="geometry")
         assert df["BoroCode"].tolist() == correct_order
+
+    def test_append_before_table_exists(self, engine_postgis, df_nybb):
+        """
+        Tests that insert works with if_exists='append' when table does not exist yet.
+        """
+        engine = engine_postgis
+
+        table = "nybb"
+        # If table exists, delete it before trying to write with defaults
+        drop_table_if_exists(engine, table)
+
+        write_postgis(df_nybb, con=engine, name=table, if_exists="append")
+
+    def test_append_with_different_crs(self, engine_postgis, df_nybb):
+        """
+        Tests that the warning is raised if table CRS differs from frame.
+        """
+        engine = engine_postgis
+
+        table = "nybb"
+        write_postgis(df_nybb, con=engine, name=table, if_exists="replace")
+
+        # Reproject
+        df_nybb2 = df_nybb.to_crs(epsg=4326)
+
+        # Should raise error when appending
+        try:
+            write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
+        except ValueError as e:
+            if "CRS of the target table" in str(e):
+                pass
+            else:
+                raise e
+        except Exception as e:
+            raise e

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -598,6 +598,11 @@ class TestIO:
 
         write_postgis(df_nybb, con=engine, name=table, if_exists="append")
 
+        # Check that the row order matches
+        sql = "SELECT * FROM {table};".format(table=table)
+        df = read_postgis(sql, engine, geom_col="geometry")
+        validate_boro_df(df)
+
     def test_append_with_different_crs(self, engine_postgis, df_nybb):
         """
         Tests that the warning is raised if table CRS differs from frame.
@@ -611,12 +616,5 @@ class TestIO:
         df_nybb2 = df_nybb.to_crs(epsg=4326)
 
         # Should raise error when appending
-        try:
+        with pytest.raises(ValueError, match="CRS of the target table"):
             write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
-        except ValueError as e:
-            if "CRS of the target table" in str(e):
-                pass
-            else:
-                raise e
-        except Exception as e:
-            raise e


### PR DESCRIPTION
Closes #1414 

Ensures that writing to PostGIS table works when `if_exists="append"` and table does not exist. 

Changes:
- Conduct the sql-query to retrieve the SRID of a table only if table exists. 
- add test for the above, as well as, testing that appending to table with different CRS throws an error.

 