### PR TITLE
ENH: use query_bulk in sjoin

### DIFF
--- a/benchmarks/sjoin.py
+++ b/benchmarks/sjoin.py
@@ -1,30 +1,57 @@
 import random
 
 from geopandas import GeoDataFrame, GeoSeries, sjoin
-from shapely.geometry import Point, LineString, Polygon
+from shapely.geometry import Point, Polygon
 import numpy as np
 
 
 class Bench:
 
-    param_names = ['op']
-    params = [('intersects', 'contains', 'within')]
+    param_names = ["op", "left_size", "right_size", "left_type", "right_type"]
+    params = [
+        ("intersects", "contains", "within"),
+        (100, 1000),
+        (100, 1000),
+        ("points", "polygons"),
+        ("points", "polygons"),
+    ]
 
     def setup(self, *args):
         triangles = GeoSeries(
-            [Polygon([(random.random(), random.random()) for _ in range(3)])
-             for _ in range(1000)])
+            [
+                Polygon([(random.random(), random.random()) for _ in range(3)])
+                for _ in range(1000)
+            ]
+        )
 
         points = GeoSeries(
-            [Point(x, y) for x, y in zip(np.random.random(10000),
-                                         np.random.random(10000))])
+            [
+                Point(x, y)
+                for x, y in zip(np.random.random(10000), np.random.random(10000))
+            ]
+        )
 
-        df1 = GeoDataFrame({'val1': np.random.randn(len(triangles)),
-                            'geometry': triangles})
-        df2 = GeoDataFrame({'val1': np.random.randn(len(points)),
-                            'geometry': points})
+        poly_df = GeoDataFrame(
+            {"val1": np.random.randn(len(triangles)), "geometry": triangles}
+        )
+        point_df = GeoDataFrame(
+            {"val1": np.random.randn(len(points)), "geometry": points}
+        )
 
-        self.df1, self.df2 = df1, df2
+        self.polygons, self.points = poly_df, point_df
 
     def time_sjoin(self, op):
-        sjoin(self.df1, self.df2, op=op)
+        sjoin(self.polygons, self.points, op=op)
+
+    def time_points_on_poly(self, op, left_size, right_size, left_type, right_type):
+        if left_type == "polygons":
+            left_df = self.polygons
+        else:
+            left_df = self.polygons
+        if right_type == "polygons":
+            right_df = self.polygons
+        else:
+            right_df = self.points
+        left_df = left_df.sample(left_size, replace=True)
+        right_df = right_df.sample(right_size, replace=True)
+        sjoin(left_df, right_df, op=op)

--- a/benchmarks/sjoin.py
+++ b/benchmarks/sjoin.py
@@ -1,57 +1,30 @@
 import random
 
 from geopandas import GeoDataFrame, GeoSeries, sjoin
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Point, LineString, Polygon
 import numpy as np
 
 
 class Bench:
 
-    param_names = ["op", "left_size", "right_size", "left_type", "right_type"]
-    params = [
-        ("intersects", "contains", "within"),
-        (100, 1000),
-        (100, 1000),
-        ("points", "polygons"),
-        ("points", "polygons"),
-    ]
+    param_names = ['op']
+    params = [('intersects', 'contains', 'within')]
 
     def setup(self, *args):
         triangles = GeoSeries(
-            [
-                Polygon([(random.random(), random.random()) for _ in range(3)])
-                for _ in range(1000)
-            ]
-        )
+            [Polygon([(random.random(), random.random()) for _ in range(3)])
+             for _ in range(1000)])
 
         points = GeoSeries(
-            [
-                Point(x, y)
-                for x, y in zip(np.random.random(10000), np.random.random(10000))
-            ]
-        )
+            [Point(x, y) for x, y in zip(np.random.random(10000),
+                                         np.random.random(10000))])
 
-        poly_df = GeoDataFrame(
-            {"val1": np.random.randn(len(triangles)), "geometry": triangles}
-        )
-        point_df = GeoDataFrame(
-            {"val1": np.random.randn(len(points)), "geometry": points}
-        )
+        df1 = GeoDataFrame({'val1': np.random.randn(len(triangles)),
+                            'geometry': triangles})
+        df2 = GeoDataFrame({'val1': np.random.randn(len(points)),
+                            'geometry': points})
 
-        self.polygons, self.points = poly_df, point_df
+        self.df1, self.df2 = df1, df2
 
     def time_sjoin(self, op):
-        sjoin(self.polygons, self.points, op=op)
-
-    def time_points_on_poly(self, op, left_size, right_size, left_type, right_type):
-        if left_type == "polygons":
-            left_df = self.polygons
-        else:
-            left_df = self.polygons
-        if right_type == "polygons":
-            right_df = self.polygons
-        else:
-            right_df = self.points
-        left_df = left_df.sample(left_size, replace=True)
-        right_df = right_df.sample(right_size, replace=True)
-        sjoin(left_df, right_df, op=op)
+        sjoin(self.df1, self.df2, op=op)

--- a/doc/source/mergingdata.rst
+++ b/doc/source/mergingdata.rst
@@ -91,7 +91,7 @@ In a Spatial Join, two geometry objects are merged based on their spatial relati
 Sjoin Arguments
 ~~~~~~~~~~~~~~~~
 
-``sjoin()`` has two core arguments: ``how`` and ``op``.
+``sjoin.()`` has two core arguments: ``how`` and ``op``.
 
 **op**
 
@@ -117,28 +117,18 @@ Note more complicated spatial relationships can be studied by combining geometri
 Sjoin Performance
 ~~~~~~~~~~~~~~~~~~
 
-Most of the computation is done within the spatial index queries. Sjoin always uses ``right_df`` as the spatial index.
-
-**Order of left_df and right_df**
-
-For predicates where the order does not matter (ex: ``intersects``) simply flipping the GeoDataFrames and the ``how`` parameter can speed up the join.
+Existing spatial indexes on either `left_df` or `right_df` will be reused when performing an ``sjoin``. If neither df has a spatial index, a spatial index will be generated for the longer df. If both have a spatial index, the `right_df`'s index will be used preferentially. Performance of multiple sjoins in a row involving a common GeoDataFrame may be improved by pre-generating the spatial index of the common GeoDataFrame prior to performing sjoins using ``df1.sindex``.
 
 .. code-block:: python
 
-   # changing
-   sjoin(left_df=df1, right_df=df2, how="left", op='intersects')
-   # to
-   sjoin(left_df=df2, right_df=df1, how="right", op='intersects')
-   # yields the same result but possibly different performance
+    df1 = # a GeoDataFrame with data
+    df2 = # a second GeoDataFrame
+    df3 = # a third GeoDataFrame
 
-**Choice of op**
+    # pre-generate sindex on df1 if it doesn't already exist
+    df1.sindex
 
-Since some operations have inverses (ex: ``within`` is the inverse of ``contains``), you can try flipping these operations along with the GeoDataFrames to speed up your spatial join.
-
-.. code-block:: python
-
-   # changing
-   sjoin(left_df=df1, right_df=df2, how="left", op='within')
-   # to
-   sjoin(left_df=df2, right_df=df1, how="right", op='contains')
-   # yields the same result but possibly different performance
+    sjoin(df1, df2, ...)
+    # sindex for df1 is reused
+    sjoin(df1, df3, ...)
+    # sindex for df1 is reused again

--- a/doc/source/mergingdata.rst
+++ b/doc/source/mergingdata.rst
@@ -112,23 +112,3 @@ The `how` argument specifies the type of join that will occur and which geometry
 * ``inner``: use intersection of index values from both geodataframes; retain only the `left_df` geometry column
 
 Note more complicated spatial relationships can be studied by combining geometric operations with spatial join. To find all polygons within a given distance of a point, for example, one can first use the ``buffer`` method to expand each point into a circle of appropriate radius, then intersect those buffered circles with the polygons in question.
-
-
-Sjoin Performance
-~~~~~~~~~~~~~~~~~~
-
-Existing spatial indexes on either `left_df` or `right_df` will be reused when performing an ``sjoin``. If neither df has a spatial index, a spatial index will be generated for the longer df. If both have a spatial index, the `right_df`'s index will be used preferentially. Performance of multiple sjoins in a row involving a common GeoDataFrame may be improved by pre-generating the spatial index of the common GeoDataFrame prior to performing sjoins using ``df1.sindex``.
-
-.. code-block:: python
-
-    df1 = # a GeoDataFrame with data
-    df2 = # a second GeoDataFrame
-    df3 = # a third GeoDataFrame
-
-    # pre-generate sindex on df1 if it doesn't already exist
-    df1.sindex
-
-    sjoin(df1, df2, ...)
-    # sindex for df1 is reused
-    sjoin(df1, df3, ...)
-    # sindex for df1 is reused again

--- a/doc/source/mergingdata.rst
+++ b/doc/source/mergingdata.rst
@@ -117,23 +117,11 @@ Note more complicated spatial relationships can be studied by combining geometri
 Sjoin Performance
 ~~~~~~~~~~~~~~~~~~
 
-Most of the computation is done within the spatial index queries. The spatial index is always queried as follows:
-
-.. code-block:: python
-
-   right_df.sindex.query_bulk(left_df.geometry, op)
-
-This translates to:
-
-.. code-block:: python
-
-   geom_in_left_df.op(geom_in_right_df)
-
-For ``sjoin``, there are two concrete choices which can be made:
+Most of the computation is done within the spatial index queries. Sjoin always uses ``right_df`` as the spatial index.
 
 **Order of left_df and right_df**
 
-For predicates where the order does not matter (ex: ``intersects``) simply flipping the GeoDataFrames and the ``how`` parameter can yield great performance improvements.
+For predicates where the order does not matter (ex: ``intersects``) simply flipping the GeoDataFrames and the ``how`` parameter can speed up the join.
 
 .. code-block:: python
 
@@ -142,10 +130,6 @@ For predicates where the order does not matter (ex: ``intersects``) simply flipp
    # to
    sjoin(left_df=df2, right_df=df1, how="right", op='intersects')
    # yields the same result but possibly different performance
-
-There are many factors that may influence the performance of the query, some of which are:
-* Complexity of geometries. Some operations may handle complex geometries better than others. For example, ``polygon.intersects(point)`` will perform differently than ``point.intersects(polygon)``. Swapping ``left_df`` and ``right_df`` will change which way the comparison is made.
-* Partitioning of the data by the spatial index. Before doing predicate comparisons, the query uses a leaf-based spatial index to find geometries with intersecting bounds in logarithmic time. Since ``right_df`` is always the GeoDataFrame used as the spatial index, making ``right_df`` the longer GeoDataFrame may improve the performance of the query.
 
 **Choice of op**
 
@@ -158,145 +142,3 @@ Since some operations have inverses (ex: ``within`` is the inverse of ``contains
    # to
    sjoin(left_df=df2, right_df=df1, how="right", op='contains')
    # yields the same result but possibly different performance
-
-For a more in-depth discussion, see the section below regarding spatial index performance in general.
-
-Spatial Index Performance
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The performance of several ``GeoPandas`` functions (namely ``sjoin``, ``overlay`` and ``clip``) is largely determined by the spatial index query.
-As discussed above, many factors may influence the performance of the query.
-To offer some guidance, we have benchmarked queries across different spatial index implementations (``pygeos`` and ``rtree``) as well as different geometry types and predicates.
-Keep in mind that these benchmarks are highly variable and may behave differently than your data. It is highly recommended that you do your own testing for best performance.
-
-
-+--------------------------------------------------------+--------------+---------------+
-| test(predicate, input\_geom\_type, tree\_geom\_type)   | rtree        | pygeos        |
-+========================================================+==============+===============+
-| query\_bulk('contains', 'mixed', 'mixed')              | 130±9ms      | 68.1±0.7ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'mixed', 'points')             | 43.1±0.7ms   | 557±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'mixed', 'polygons')           | 112±2ms      | 69.4±3ms      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'points', 'mixed')             | 41.5±6ms     | 21.3±0.5ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'points', 'points')            | 23.4±0.5ms   | 408±4μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'points', 'polygons')          | 27.0±2ms     | 20.9±0.5ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'polygons', 'mixed')           | 110±2ms      | 48.2±0.8ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'polygons', 'points')          | 30.2±2ms     | 150±7μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('contains', 'polygons', 'polygons')        | 96.6±2ms     | 49.5±1ms      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'mixed', 'mixed')               | 122±4ms      | 159±3ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'mixed', 'points')              | 42.2±4ms     | 19.7±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'mixed', 'polygons')            | 106±2ms      | 140±9ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'points', 'mixed')              | 39.1±0.8ms   | 21.2±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'points', 'points')             | 22.7±1ms     | 388±7μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'points', 'polygons')           | 30.3±2ms     | 20.6±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'polygons', 'mixed')            | 103±3ms      | 137±2ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'polygons', 'points')           | 25.2±0.5ms   | 19.2±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('crosses', 'polygons', 'polygons')         | 94.4±2ms     | 119±4ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'mixed', 'mixed')            | 49.3±1ms     | 59.1±3ms      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'mixed', 'points')           | 35.8±1ms     | 1.72±0.02ms   |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'mixed', 'polygons')         | 39.9±1ms     | 55.8±0.7ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'points', 'mixed')           | 32.0±1ms     | 664±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'points', 'points')          | 18.1±0.8ms   | 407±3μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'points', 'polygons')        | 24.9±0.8ms   | 200±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'polygons', 'mixed')         | 39.2±4ms     | 56.8±1ms      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'polygons', 'points')        | 22.3±0.2ms   | 1.32±0.04ms   |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('intersects', 'polygons', 'polygons')      | 27.9±0.8ms   | 55.4±0.5ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'mixed', 'mixed')              | 246±10ms     | 160±3ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'mixed', 'points')             | 59.9±1ms     | 20.8±1ms      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'mixed', 'polygons')           | 209±5ms      | 141±2ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'points', 'mixed')             | 66.2±5ms     | 21.1±0.2ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'points', 'points')            | 21.6±0.4ms   | 394±8μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'points', 'polygons')          | 52.6±2ms     | 20.5±0.6ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'polygons', 'mixed')           | 202±7ms      | 137±0.9ms     |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'polygons', 'points')          | 50.6±3ms     | 19.2±0.4ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('overlaps', 'polygons', 'polygons')        | 165±3ms      | 122±3ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'mixed', 'mixed')               | 249±8ms      | 157±2ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'mixed', 'points')              | 62.3±3ms     | 19.4±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'mixed', 'polygons')            | 212±4ms      | 139±2ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'points', 'mixed')              | 61.9±2ms     | 21.0±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'points', 'points')             | 22.1±0.3ms   | 397±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'points', 'polygons')           | 51.3±1ms     | 20.6±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'polygons', 'mixed')            | 199±4ms      | 137±2ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'polygons', 'points')           | 54.6±4ms     | 19.4±0.7ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('touches', 'polygons', 'polygons')         | 169±6ms      | 120±1ms       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'mixed', 'mixed')                | 78.1±1ms     | 12.6±0.2ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'mixed', 'points')               | 42.6±1ms     | 1.44±0.02ms   |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'mixed', 'polygons')             | 66.8±2ms     | 12.3±0.09ms   |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'points', 'mixed')               | 37.5±0.8ms   | 948±80μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'points', 'points')              | 22.3±0.7ms   | 114±1μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'points', 'polygons')            | 28.3±0.6ms   | 791±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'polygons', 'mixed')             | 61.6±3ms     | 11.7±0.3ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'polygons', 'points')            | 28.2±0.5ms   | 1.33±0.03ms   |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk('within', 'polygons', 'polygons')          | 48.6±0.5ms   | 11.4±0.7ms    |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'mixed', 'mixed')                    | 249±10ms     | 634±30μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'mixed', 'points')                   | 61.7±2ms     | 193±8μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'mixed', 'polygons')                 | 207±4ms      | 393±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'points', 'mixed')                   | 64.2±3ms     | 286±10μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'points', 'points')                  | 21.5±0.3ms   | 81.1±4μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'points', 'polygons')                | 50.9±0.6ms   | 177±10μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'polygons', 'mixed')                 | 197±4ms      | 392±2μs       |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'polygons', 'points')                | 48.6±4ms     | 133±10μs      |
-+--------------------------------------------------------+--------------+---------------+
-| query\_bulk(None, 'polygons', 'polygons')              | 165±2ms      | 238±20μs      |
-+--------------------------------------------------------+--------------+---------------+
-

--- a/doc/source/mergingdata.rst
+++ b/doc/source/mergingdata.rst
@@ -91,7 +91,7 @@ In a Spatial Join, two geometry objects are merged based on their spatial relati
 Sjoin Arguments
 ~~~~~~~~~~~~~~~~
 
-``sjoin.()`` has two core arguments: ``how`` and ``op``.
+``sjoin()`` has two core arguments: ``how`` and ``op``.
 
 **op**
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+
 from geopandas import GeoDataFrame
 from geopandas._compat import HAS_RTREE
 
@@ -20,7 +21,7 @@ def sjoin(
         * 'right': use keys from right_df; retain only right_df geometry column
         * 'inner': use intersection of keys from both dfs; retain only
           left_df geometry column
-    op : string, default 'intersection'
+    op : string, default 'intersects'
         Binary predicate, one of {'intersects', 'contains', 'within'}.
         See http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates.
     lsuffix : string, default 'left'
@@ -88,7 +89,8 @@ def sjoin(
         left_df.index = left_df.index.rename(index_left)
     except TypeError:
         index_left = [
-            "index_%s" % lsuffix + str(l) for l, ix in enumerate(left_df.index.names)
+            "index_%s" % lsuffix + str(pos)
+            for pos, ix in enumerate(left_df.index.names)
         ]
         left_index_name = left_df.index.names
         left_df.index = left_df.index.rename(index_left)
@@ -100,7 +102,8 @@ def sjoin(
         right_df.index = right_df.index.rename(index_right)
     except TypeError:
         index_right = [
-            "index_%s" % rsuffix + str(l) for l, ix in enumerate(right_df.index.names)
+            "index_%s" % rsuffix + str(pos)
+            for pos, ix in enumerate(right_df.index.names)
         ]
         right_index_name = right_df.index.names
         right_df.index = right_df.index.rename(index_right)

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -66,7 +66,7 @@ def sjoin(
             "'{0}' and '{1}' cannot be names in the frames being"
             " joined".format(index_left, index_right)
         )
-    
+
     # Check if rtree is installed...
     if not HAS_RTREE:
         raise ImportError(

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,9 +1,8 @@
-from warnings import warn
-
 import pandas as pd
 
 from geopandas import GeoDataFrame
 from geopandas._compat import HAS_RTREE
+from geopandas.array import _check_crs, _crs_mismatch_warn
 
 
 def sjoin(

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,6 +1,6 @@
-import numpy as np
-import pandas as pd
+from warnings import warn
 
+import pandas as pd
 
 from geopandas import GeoDataFrame
 from geopandas._compat import HAS_RTREE
@@ -105,18 +105,14 @@ def sjoin(
     right_df = right_df.reset_index()
 
     # query index
-    r_idx = np.empty((0, 0))
-    l_idx = np.empty((0, 0))
     if right_df.sindex:
         l_idx, r_idx = right_df.sindex.query_bulk(
             left_df.geometry, predicate=op, sort=False
         )
-
-    # build result dataframe if any matches were found
-    if r_idx.size > 0 and l_idx.size > 0:
         result = pd.DataFrame({"_key_left": l_idx, "_key_right": r_idx})
     else:
         # when output from the join has no overlapping geometries
+        # or right_df is empty / has no valid geometries
         result = pd.DataFrame(columns=["_key_left", "_key_right"], dtype=float)
 
     # perform join on the dataframes

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -111,8 +111,7 @@ def sjoin(
         )
         result = pd.DataFrame({"_key_left": l_idx, "_key_right": r_idx})
     else:
-        # when output from the join has no overlapping geometries
-        # or right_df is empty / has no valid geometries
+        # when right_df is empty / has no valid geometries
         result = pd.DataFrame(columns=["_key_left", "_key_right"], dtype=float)
 
     # perform join on the dataframes

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 from geopandas import GeoDataFrame
-from geopandas._compat import HAS_RTREE
 from geopandas.array import _check_crs, _crs_mismatch_warn
 
 
@@ -64,13 +63,6 @@ def sjoin(
         raise ValueError(
             "'{0}' and '{1}' cannot be names in the frames being"
             " joined".format(index_left, index_right)
-        )
-
-    # Check if rtree is installed...
-    if not HAS_RTREE:
-        raise ImportError(
-            "Rtree must be installed to use sjoin\n\n"
-            "See installation instructions at https://geopandas.org/install.html"
         )
 
     # query index

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -467,6 +467,15 @@ class TestSpatialJoinNYBB:
         df2 = sjoin(self.pointdf, self.polydf.append(empty), how="left")
         assert df2.shape == (21, 8)
 
+    @pytest.mark.parametrize("op", ["intersects", "within", "contains"])
+    def test_sjoin_no_valid_geoms(self, op):
+        """Tests a completely empty GeoDataFrame."""
+        empty = GeoDataFrame(geometry=[])
+        assert sjoin(self.pointdf, empty, how="inner", op=op).empty
+        assert sjoin(self.pointdf, empty, how="right", op=op).empty
+        assert sjoin(empty, self.pointdf, how="inner", op=op).empty
+        assert sjoin(empty, self.pointdf, how="left", op=op).empty
+
 
 class TestSpatialJoinNaturalEarth:
     def setup_method(self):


### PR DESCRIPTION
This is the next step for #1404.

Benchmarks:
| before <master> | after <sjoin-query-bulk> | ratio | test                     | pygeos installed |
|-----------------|--------------------------|-------|--------------------------|------------------|
| 9.51±0.1s       | 178±1ms                  | ~0.02 | time_sjoin('contains')   | Y                |
| 8.40±0.4s       | 7.25±0.02s               | ~0.86 | time_sjoin('contains')   | N                |
| 9.09±0.06s      | 592±9ms                  | 0.07  | time_sjoin('intersects') | Y                |
| 7.80±0.01s      | 11.0±0.1s                | ~1.41 | time_sjoin('intersects') | N                |
| 1.14±0.02s      | 585±4ms                  | 0.51  | time_sjoin('within')     | Y                |
| 7.94±0.2s       | 11.5±0.06s               | ~1.45 | time_sjoin('within')     | N                |

We could keep a lot of the existing logic in place to avoid the slowdown without pygeos, but the way it is now reduces the complexity of the module considerably and I think will be easier to manage going forward.

If we did decide to keep the existing logic, I would like to split up `sjoin` into several functions, similar to #1271.