### PR TITLE
DOC: Adding geopandas.Series overlaps method in documentation

### DIFF
--- a/doc/source/reference.rst
+++ b/doc/source/reference.rst
@@ -53,6 +53,8 @@ The following Shapely methods and attributes are available on
 
 .. automethod:: geopandas.GeoSeries.intersects
 
+.. automethod:: geopandas.GeoSeries.overlaps
+
 .. automethod:: geopandas.GeoSeries.touches
 
 .. automethod:: geopandas.GeoSeries.within

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -374,7 +374,14 @@ class GeoPandasBase(object):
         return _binary_op("intersects", self, other)
 
     def overlaps(self, other):
-        """Return True for all geometries that overlap *other*, else False"""
+        """Returns True for all geometries that overlap *other*, else False.
+
+        Parameters
+        ----------
+        other : GeoSeries or geometric object
+            The GeoSeries (elementwise) or geometric object to test if
+            overlaps.
+        """
         return _binary_op("overlaps", self, other)
 
     def touches(self, other):


### PR DESCRIPTION
Fix for https://github.com/geopandas/geopandas/issues/1358

The reference for `.. automethod:: geopandas.GeoSeries.overlaps` was missing on doc/source/reference.rst file.
Also, I've added the Parameters description to the function declaration docstring in geopandas/base.py  
