### PR TITLE
Add rtree>=0.8 as a dependency to setup.py

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -8,6 +8,7 @@ from shapely import prepared
 from geopandas import GeoDataFrame
 from geopandas import _compat as compat
 
+from importlib.util import find_spec
 
 def sjoin(
     left_df, right_df, how="inner", op="intersects", lsuffix="left", rsuffix="right"
@@ -73,6 +74,15 @@ def sjoin(
         raise ValueError(
             "'{0}' and '{1}' cannot be names in the frames being"
             " joined".format(index_left, index_right)
+        )
+
+    # Check if rtree is installed...
+    package='rtree'
+    if find_spec(package) is None:
+        raise ImportError(
+            f"{package} must be installed to use sjoin\n\n"
+            "See installation instructions at https://geopandas.org/install.html"
+            
         )
 
     # Attempt to re-use spatial indexes, otherwise generate the spatial index

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ such as PostGIS.
 if os.environ.get("READTHEDOCS", False) == "True":
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ["pandas >= 0.23.0", "shapely", "fiona", "pyproj >= 2.2.0", "rtree>=0.8"]
+    INSTALL_REQUIRES = ["pandas >= 0.23.0", "shapely", "fiona", "pyproj >= 2.2.0",]
 
 # get all data dirs in the datasets module
 data_files = []

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ such as PostGIS.
 if os.environ.get("READTHEDOCS", False) == "True":
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ["pandas >= 0.23.0", "shapely", "fiona", "pyproj >= 2.2.0"]
+    INSTALL_REQUIRES = ["pandas >= 0.23.0", "shapely", "fiona", "pyproj >= 2.2.0", "rtree>=0.8"]
 
 # get all data dirs in the datasets module
 data_files = []


### PR DESCRIPTION
Geopandas version: 0.7.0

`rtree` is required for  Geopandas' sjoin and is doesn't seem to be a depenency when installing Geopandas with pip hence this pull request

(I'm still a bit of a noob with regards to pull requests etc so hope this fixes the issue...  Thanks for all your work with Geopandas, it's an incredible library)

---

# Minimal example
Geopandas' sjoin operation currently fails for the following:

```python
from shapely.geometry import Polygon
import geopandas as gpd

coords1 = ((0, 0), (0, 5), (2.5, 2.5))
gdf1 = gpd.GeoDataFrame({'geometry': [Polygon(coords1)]})
coords2 = ((1, 0), (0, 6), (2.5, 2.5))
gdf2 = gpd.GeoDataFrame({'geometry': [Polygon(coords2)]})

gpd.sjoin(gdf1, gdf2)
```

```python-traceback
/home/wsl-rowanm/miniconda3/envs/elec/lib/python3.8/site-packages/geopandas/base.py:104: UserWarning: Cannot generate spatial index: Missing package `rtree`.
  warn("Cannot generate spatial index: Missing package `rtree`.")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/mnt/c/users/rowanm/documents/codema_elec/src/codema_elec/preprocess/test.py in <module>
      7 gdf2 = gpd.GeoDataFrame({'geometry': [Polygon(coords2)]})
      8 
----> 9 gpd.sjoin(gdf1, gdf2)

~/miniconda3/envs/elec/lib/python3.8/site-packages/geopandas/tools/sjoin.py in sjoin(left_df, right_df, how, op, lsuffix, rsuffix)
    133     else:
    134         # tree_idx_df == 'left'
--> 135         idxmatch = right_df.geometry.apply(lambda x: x.bounds).apply(
    136             lambda x: list(tree_idx.intersection(x)) if not x == () else []
    137         )

~/miniconda3/envs/elec/lib/python3.8/site-packages/pandas/core/series.py in apply(self, func, convert_dtype, args, **kwds)
   3846             else:
   3847                 values = self.astype(object).values
-> 3848                 mapped = lib.map_infer(values, f, convert=convert_dtype)
   3849 
   3850         if len(mapped) and isinstance(mapped[0], Series):

pandas/_libs/lib.pyx in pandas._libs.lib.map_infer()

~/miniconda3/envs/elec/lib/python3.8/site-packages/geopandas/tools/sjoin.py in <lambda>(x)
    134         # tree_idx_df == 'left'
    135         idxmatch = right_df.geometry.apply(lambda x: x.bounds).apply(
--> 136             lambda x: list(tree_idx.intersection(x)) if not x == () else []
    137         )
    138         idxmatch = idxmatch[idxmatch.apply(len) > 0]

AttributeError: 'NoneType' object has no attribute 'intersection'
```

Helpfully the solution to the problem is to install rtree as stated at the start of the traceback and at this [Stackoverflow thread](https://stackoverflow.com/questions/59985197/geopandas-sjoin-nonetype-object-has-no-attribute-intersection)