### PR TITLE
CI: add a build without optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - env: ENV_FILE="ci/travis/35-minimal.yaml"
 
     # one build with no optional dependencies
-    - env: ENV_FILE="ci/travis/38-no-optional-deps.yaml" PYGEOS=true
+    - env: ENV_FILE="ci/travis/38-no-optional-deps.yaml"
 
     # Python 3.6 test all supported Pandas versions
     - env: ENV_FILE="ci/travis/36-pd023.yaml" PYGEOS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ sudo: false
 
 matrix:
   include:
-    # Only one test for these Python versions
+    # One build with minimum versions of dependencies
     - env: ENV_FILE="ci/travis/35-minimal.yaml"
+
+    # one build with no optional dependencies
+    - env: ENV_FILE="ci/travis/38-no-optional-deps.yaml" PYGEOS=true
 
     # Python 3.6 test all supported Pandas versions
     - env: ENV_FILE="ci/travis/36-pd023.yaml" PYGEOS=true

--- a/ci/travis/38-no-optional-deps.yaml
+++ b/ci/travis/38-no-optional-deps.yaml
@@ -1,0 +1,15 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  # required
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  - pygeos
+  # testing
+  - pytest
+  - pytest-cov
+  - codecov

--- a/ci/travis/38-no-optional-deps.yaml
+++ b/ci/travis/38-no-optional-deps.yaml
@@ -8,7 +8,6 @@ dependencies:
   - shapely
   - fiona
   - pyproj
-  - pygeos
   # testing
   - pytest
   - pytest-cov

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -15,7 +15,9 @@ import pytest
 DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data", "overlay")
 
 
-pytestmark = pytest.mark.skipif(not compat.HAS_RTREE, reason="overlay requires rtree")
+pytestmark = pytest.mark.skipif(
+    not geopandas.sindex.has_sindex(), reason="overlay requires spatial index"
+)
 
 
 @pytest.fixture

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -15,6 +15,9 @@ import pytest
 DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data", "overlay")
 
 
+pytestmark = pytest.mark.skipif(not compat.HAS_RTREE, reason="overlay requires rtree")
+
+
 @pytest.fixture
 def dfs(request):
     s1 = GeoSeries(

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -22,7 +22,7 @@ import numpy as np
 class TestNoSindex:
     def test_no_sindex(self):
         """Checks that a warning is given when no spatial index is present."""
-        with pytest.warns():
+        with pytest.warns(UserWarning):
             sindex.get_sindex_class()
 
 
@@ -146,7 +146,7 @@ class TestPygeosInterface:
     def setup_method(self):
         data = {
             "location": [Point(x, y) for x, y in zip(range(5), range(5))]
-            + [box(10, 10, 20, 20)],  # include a box geometry
+            + [box(10, 10, 20, 20)]  # include a box geometry
         }
         self.df = GeoDataFrame(data, geometry="location")
         self.expected_size = len(data["location"])
@@ -166,9 +166,7 @@ class TestPygeosInterface:
         res = list(self.df.sindex.intersection(test_geom))
         assert_array_equal(res, expected)
 
-    @pytest.mark.parametrize(
-        "test_geom", ((-1, -1, -0.5), -0.5, None, Point(0, 0),),
-    )
+    @pytest.mark.parametrize("test_geom", ((-1, -1, -0.5), -0.5, None, Point(0, 0)))
     def test_intersection_invalid_bounds_tuple(self, test_geom):
         """Tests the `intersection` method with invalid inputs."""
         if compat.USE_PYGEOS:

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -9,9 +9,13 @@ from shapely.geometry import Polygon, Point, LineString, LinearRing, GeometryCol
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, clip
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from geopandas import _compat as compat
 
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
+
+
+pytestmark = pytest.mark.skipif(not compat.HAS_RTREE, reason="clip requires rtree")
 
 
 @pytest.fixture

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -9,13 +9,14 @@ from shapely.geometry import Polygon, Point, LineString, LinearRing, GeometryCol
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, clip
-from geopandas import _compat as compat
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
 
 
-pytestmark = pytest.mark.skipif(not compat.HAS_RTREE, reason="clip requires rtree")
+pytestmark = pytest.mark.skipif(
+    not geopandas.sindex.has_sindex(), reason="clip requires spatial index"
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
To ensure we don't by accident add a hard requirement (and this way can also test error messages for an optional dependency not being present)