### PR TITLE
ENH: Implement sindex.query_bulk in overlay

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -4,12 +4,6 @@ import numpy as np
 import pandas as pd
 
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas import _compat as compat
-
-if compat.USE_PYGEOS:
-    import pygeos  # noqa
-else:
-    pygeos = None
 
 
 def _ensure_geometry_column(df):

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -72,16 +72,16 @@ def _overlay_difference(df1, df2):
     df1_idx, df2_idx = df2.sindex.query_bulk(
         df1.geometry, predicate="intersects", sort=True
     )
-    sidx = [
-        df2_idx[df1_idx == idx] if idx in np.unique(df1_idx) else []
+    df2_geoms = (
+        df2.geometry.values[df2_idx[df1_idx == idx]]
+        if idx in np.unique(df1_idx)
+        else []
         for idx in range(df1.geometry.size)
-    ]
+    )
     # Create differences
     new_g = []
-    for geom, neighbours in zip(df1.geometry, sidx):
-        new = reduce(
-            lambda x, y: x.difference(y), [geom] + list(df2.geometry.iloc[neighbours])
-        )
+    for geom, neighbours in zip(df1.geometry, df2_geoms):
+        new = reduce(lambda x, y: x.difference(y), [geom] + list(neighbours))
         new_g.append(new)
     differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
     poly_ix = differences.type.isin(["Polygon", "MultiPolygon"])

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -4,6 +4,12 @@ import numpy as np
 import pandas as pd
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas import _compat as compat
+
+if compat.USE_PYGEOS:
+    import pygeos  # noqa
+else:
+    pygeos = None
 
 
 def _ensure_geometry_column(df):
@@ -68,27 +74,44 @@ def _overlay_difference(df1, df2):
     """
     Overlay Difference operation used in overlay function
     """
-    # Spatial Index to create intersections
-    df1_idx, df2_idx = df2.sindex.query_bulk(
-        df1.geometry, predicate="intersects", sort=True
+    # spatial index query to find intersections
+    idx1, idx2 = df2.sindex.query_bulk(df1.geometry, predicate="intersects", sort=True)
+    idx1_unique, idx1_unique_idxs = np.unique(idx1, return_index=True)
+    df2_neighbors = (
+        df2.geometry.values.data[idxs] for idxs in np.split(idx2, idx1_unique_idxs[1:])
     )
-    df2_geoms = (
-        df2.geometry.values[df2_idx[df1_idx == idx]]
-        if idx in np.unique(df1_idx)
-        else []
-        for idx in range(df1.geometry.size)
-    )
-    # Create differences
-    new_g = []
-    for geom, neighbours in zip(df1.geometry, df2_geoms):
-        new = reduce(lambda x, y: x.difference(y), [geom] + list(neighbours))
-        new_g.append(new)
-    differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
-    poly_ix = differences.type.isin(["Polygon", "MultiPolygon"])
-    differences.loc[poly_ix] = differences[poly_ix].buffer(0)
-    geom_diff = differences[~differences.is_empty].copy()
-    dfdiff = df1[~differences.is_empty].copy()
-    dfdiff[dfdiff._geometry_column_name] = geom_diff
+    # copy the input dataframe
+    dfdiff = df1.copy()
+    if compat.USE_PYGEOS:
+        # create differences
+        for df1_idx, df2_nei in zip(idx1_unique, df2_neighbors):
+            dfdiff.geometry.values.data[df1_idx] = pygeos.lib.difference.reduce(
+                (df1.geometry.values.data[df1_idx], *df2_nei)
+            )
+        # buffer polygons
+        geom_types = pygeos.geometry.get_type_id(
+            dfdiff.geometry.values.data[idx1_unique]
+        )
+        polys = (geom_types == 3) | (geom_types == 6)  # polygon or multipolygon
+        dfdiff.geometry.values.data[idx1_unique][polys] = pygeos.constructive.buffer(
+            dfdiff.geometry.values.data[idx1_unique][polys], 0,
+        )
+        # remove empty
+        dfdiff = dfdiff[~pygeos.is_empty(dfdiff.geometry.values.data)]
+    else:
+        # create differences
+        for df1_idx, df2_nei in zip(idx1_unique, df2_neighbors):
+            dfdiff.geometry.values[df1_idx] = reduce(
+                lambda x, y: x.difference(y),
+                (df1.geometry.values.data[df1_idx], *df2_nei),
+            )
+        # buffer polygons
+        polys = dfdiff.geometry.iloc[idx1_unique].type.isin(("Polygon", "MultiPolygon"))
+        dfdiff.geometry.values[idx1_unique][polys] = dfdiff.geometry.values[
+            idx1_unique
+        ][polys].buffer(0)
+        # remove empty
+        dfdiff = dfdiff[~dfdiff.geometry.is_empty]
     return dfdiff
 
 

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -71,10 +71,9 @@ def _overlay_difference(df1, df2):
     # spatial index query to find intersections
     idx1, idx2 = df2.sindex.query_bulk(df1.geometry, predicate="intersects", sort=True)
     idx1_unique, idx1_unique_indices = np.unique(idx1, return_index=True)
-    idx1_unique = set(idx1_unique)
-    idx2_split = iter(np.split(idx2, idx1_unique_indices[1:]))
+    idx2_split = np.split(idx2, idx1_unique_indices[1:])
     sidx = [
-        next(idx2_split) if idx in idx1_unique else []
+        idx2_split.pop(0) if idx in idx1_unique else []
         for idx in range(df1.geometry.size)
     ]
     # Create differences

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -25,27 +25,20 @@ def _overlay_intersection(df1, df2):
     Overlay Intersection operation used in overlay function
     """
     # Spatial Index to create intersections
-    spatial_index = df2.sindex
-    bbox = df1.geometry.apply(lambda x: x.bounds)
-    sidx = bbox.apply(lambda x: list(spatial_index.intersection(x)))
+    idx1, idx2 = df2.sindex.query_bulk(df1.geometry, predicate="intersects", sort=True)
     # Create pairs of geometries in both dataframes to be intersected
-    nei = []
-    for i, j in enumerate(sidx):
-        for k in j:
-            nei.append([i, k])
-    if nei != []:
-        pairs = pd.DataFrame(nei, columns=["__idx1", "__idx2"])
-        left = df1.geometry.take(pairs["__idx1"].values)
+    if idx1.size > 0 and idx2.size > 0:
+        left = df1.geometry.take(idx1)
         left.reset_index(drop=True, inplace=True)
-        right = df2.geometry.take(pairs["__idx2"].values)
+        right = df2.geometry.take(idx2)
         right.reset_index(drop=True, inplace=True)
         intersections = left.intersection(right)
         poly_ix = intersections.type.isin(["Polygon", "MultiPolygon"])
         intersections.loc[poly_ix] = intersections[poly_ix].buffer(0)
 
         # only keep actual intersecting geometries
-        pairs_intersect = pairs[~intersections.is_empty]
-        geom_intersect = intersections[~intersections.is_empty]
+        pairs_intersect = pd.DataFrame({"__idx1": idx1, "__idx2": idx2})
+        geom_intersect = intersections
 
         # merge data for intersecting geometries
         df1 = df1.reset_index(drop=True)
@@ -76,9 +69,13 @@ def _overlay_difference(df1, df2):
     Overlay Difference operation used in overlay function
     """
     # Spatial Index to create intersections
-    spatial_index = df2.sindex
-    bbox = df1.geometry.apply(lambda x: x.bounds)
-    sidx = bbox.apply(lambda x: list(spatial_index.intersection(x)))
+    df1_idx, df2_idx = df2.sindex.query_bulk(
+        df1.geometry, predicate="intersects", sort=True
+    )
+    sidx = [
+        df2_idx[df1_idx == idx] if idx in np.unique(df1_idx) else []
+        for idx in range(df1.geometry.size)
+    ]
     # Create differences
     new_g = []
     for geom, neighbours in zip(df1.geometry, sidx):


### PR DESCRIPTION
PR for query_bulk in overlay, crossfref #1404 

Benchmarks:
| before      | after      | ratio | test                                                   | pygeos installed? |
|-------------|------------|-------|--------------------------------------------------------|-------------------|
| 328±80ms    | 266±30ms   | ~0.81 | overlay.Countries.time_overlay('difference')           | Y                 |
| 327±80ms    | 247±80ms   | ~0.76 | overlay.Countries.time_overlay('difference')           | N                 |
| 724±20ms    | 731±70ms   | 1.01  | overlay.Countries.time_overlay('identity')             | Y                 |
| 805±20ms    | 988±200ms  | ~1.23 | overlay.Countries.time_overlay('identity')             | N                 |
| 181±20ms    | 203±30ms   | ~1.12 | overlay.Countries.time_overlay('intersection')         | Y                 |
| 261±5ms     | 280±20ms   | 1.07  | overlay.Countries.time_overlay('intersection')         | N                 |
| 587±40ms    | 614±100ms  | 1.05  | overlay.Countries.time_overlay('symmetric_difference') | Y                 |
| 573±10ms    | 595±60ms   | 1.04  | overlay.Countries.time_overlay('symmetric_difference') | N                 |
| 752±100ms   | 672±50ms   | ~0.89 | overlay.Countries.time_overlay('union')                | Y                 |
| 791±7ms     | 1.04±0.08s | ~1.31 | overlay.Countries.time_overlay('union')                | N                 |
| 10.00±0.4ms | 9.84±0.3ms | 0.98  | overlay.Small.time_overlay('difference')               | Y                 |
| 9.72±0.3ms  | 12.8±5ms   | ~1.31 | overlay.Small.time_overlay('difference')               | N                 |
| 42.1±5ms    | 45.2±4ms   | 1.07  | overlay.Small.time_overlay('identity')                 | Y                 |
| 42.5±5ms    | 44.6±20ms  | 1.05  | overlay.Small.time_overlay('identity')                 | N                 |
| 18.7±3ms    | 17.4±3ms   | 0.93  | overlay.Small.time_overlay('intersection')             | Y                 |
| 18.7±3ms    | 14.3±0.9ms | ~0.76 | overlay.Small.time_overlay('intersection')             | N                 |
| 28.4±3ms    | 27.7±1ms   | 0.98  | overlay.Small.time_overlay('symmetric_difference')     | Y                 |
| 28.2±3ms    | 27.2±8ms   | 0.96  | overlay.Small.time_overlay('symmetric_difference')     | N                 |
| 42.3±5ms    | 41.3±7ms   | 0.98  | overlay.Small.time_overlay('union')                    | Y                 |
| 41.1±6ms    | 34.1±3ms   | ~0.83 | overlay.Small.time_overlay('union')                    | N                 |

Benchmarks were taken at c5d9e90a1cb9eee95a24eb04d593b24108cd6ce2