### PR TITLE
TST: GroupBy change on pandas master

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -12,6 +12,7 @@ import shapely
 PANDAS_GE_024 = str(pd.__version__) >= LooseVersion("0.24.0")
 PANDAS_GE_025 = str(pd.__version__) >= LooseVersion("0.25.0")
 PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("0.26.0.dev")
+PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0.dev")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -9,7 +9,7 @@ from shapely.geometry import Point, GeometryCollection
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas._compat import PANDAS_GE_024, PANDAS_GE_025
+from geopandas._compat import PANDAS_GE_024, PANDAS_GE_025, PANDAS_GE_11
 from geopandas.array import from_shapely
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
@@ -444,11 +444,18 @@ def test_groupby(df):
 
     # applying on the geometry column
     res = df.groupby("value2")["geometry"].apply(lambda x: x.cascaded_union)
-    exp = pd.Series(
-        [shapely.geometry.MultiPoint([(0, 0), (2, 2)]), Point(1, 1)],
-        index=pd.Index([1, 2], name="value2"),
-        name="geometry",
-    )
+    if PANDAS_GE_11:
+        exp = GeoSeries(
+            [shapely.geometry.MultiPoint([(0, 0), (2, 2)]), Point(1, 1)],
+            index=pd.Index([1, 2], name="value2"),
+            name="geometry",
+        )
+    else:
+        exp = pd.Series(
+            [shapely.geometry.MultiPoint([(0, 0), (2, 2)]), Point(1, 1)],
+            index=pd.Index([1, 2], name="value2"),
+            name="geometry",
+        )
     assert_series_equal(res, exp)
 
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -458,6 +458,12 @@ def test_groupby(df):
         )
     assert_series_equal(res, exp)
 
+    # apply on geometry column not resulting in new geometry
+    res = df.groupby("value2")["geometry"].apply(lambda x: x.unary_union.area)
+    exp = pd.Series([0.0, 0.0], index=pd.Index([1, 2], name="value2"), name="geometry",)
+
+    assert_series_equal(res, exp)
+
 
 def test_groupby_groups(df):
     g = df.groupby("value2")


### PR DESCRIPTION
Pandas has changed behaviour of `groupby` on ExtensionArray, which in our case returns GeoSeries if the function is applied to geometry. From my perspective, this is a bug fix on pandas side.

I just fixed our tests which were failing on this using pandas master.