### PR TITLE
BUG: Fix PyGEOSSTRTreeIndex indexing with scattered empty geometries.

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -240,10 +240,7 @@ if compat.HAS_RTREE:
 
         @property
         def size(self):
-            # use size of geometries
-            # empty geometries are not counted by rtree
-            # but we want to count them for the size attribute
-            return self.geometries.size
+            return len(self.leaves()[0][1])
 
         @property
         def is_empty(self):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -276,9 +276,11 @@ if compat.HAS_PYGEOS:
         def __init__(self, geometry):
             # for compatibility with old RTree implementation, store ids/indexes
             original_indexes = geometry.index
+            geometry = geometry.values.data.copy()
+            geometry[pygeos.is_empty(geometry)] = None
             # set empty geometries to None to mantain indexing
             self.objects = self.ids = original_indexes
-            super().__init__(geometry.values.data)
+            super().__init__(geometry)
 
         def query(self, geometry, predicate=None, sort=False):
             """Wrapper for pygeos.query.

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -91,10 +91,10 @@ if compat.HAS_RTREE:
                 super().__init__()
 
             # store reference to geometries for predicate queries
-            self.geometries = geometry.geometry.values
+            self._geometries = geometry.geometry.values
             # create a prepared geometry cache
             self._prepared_geometries = np.array(
-                [None] * self.geometries.size, dtype=object
+                [None] * self._geometries.size, dtype=object
             )
 
         def query(self, geometry, predicate=None, sort=False):
@@ -173,7 +173,7 @@ if compat.HAS_RTREE:
                     if self._prepared_geometries[index_in_tree] is None:
                         # if not already prepared, prepare and cache
                         self._prepared_geometries[index_in_tree] = prep(
-                            self.geometries[index_in_tree]
+                            self._geometries[index_in_tree]
                         )
                     if self._prepared_geometries[index_in_tree].contains(geometry):
                         res.append(index_in_tree)
@@ -187,7 +187,7 @@ if compat.HAS_RTREE:
                 tree_idx = [
                     index_in_tree
                     for index_in_tree in tree_idx
-                    if getattr(geometry, predicate)(self.geometries[index_in_tree])
+                    if getattr(geometry, predicate)(self._geometries[index_in_tree])
                 ]
 
             # sort if requested

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -91,10 +91,10 @@ if compat.HAS_RTREE:
                 super().__init__()
 
             # store reference to geometries for predicate queries
-            self._geometries = geometry.geometry.values
+            self.geometries = geometry.geometry.values
             # create a prepared geometry cache
             self._prepared_geometries = np.array(
-                [None] * self._geometries.size, dtype=object
+                [None] * self.geometries.size, dtype=object
             )
 
         def query(self, geometry, predicate=None, sort=False):
@@ -173,7 +173,7 @@ if compat.HAS_RTREE:
                     if self._prepared_geometries[index_in_tree] is None:
                         # if not already prepared, prepare and cache
                         self._prepared_geometries[index_in_tree] = prep(
-                            self._geometries[index_in_tree]
+                            self.geometries[index_in_tree]
                         )
                     if self._prepared_geometries[index_in_tree].contains(geometry):
                         res.append(index_in_tree)
@@ -187,7 +187,7 @@ if compat.HAS_RTREE:
                 tree_idx = [
                     index_in_tree
                     for index_in_tree in tree_idx
-                    if getattr(geometry, predicate)(self._geometries[index_in_tree])
+                    if getattr(geometry, predicate)(self.geometries[index_in_tree])
                 ]
 
             # sort if requested

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -274,6 +274,8 @@ if compat.HAS_PYGEOS:
             # for compatibility with old RTree implementation, store ids/indexes
             original_indexes = geometry.index
             geometry = geometry.values.data.copy()
+            # set empty geometries to None to avoid an intermittent segfault
+            # see https://github.com/pygeos/pygeos/issues/146
             geometry[pygeos.is_empty(geometry)] = None
             # set empty geometries to None to mantain indexing
             self.objects = self.ids = original_indexes

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -151,6 +151,14 @@ class TestPygeosInterface:
         self.df = GeoDataFrame(data, geometry="location")
         self.expected_size = len(data["location"])
 
+    #
+    def test_scattered_empty(self):
+        """Tests building sindex with interlived empty geometries.
+        """
+        geoms = [Point(0, 0), None, Point(), Point(1, 1), Point()]
+        df = geopandas.GeoDataFrame(geometry=geoms)
+        assert df.sindex.query(Point(1, 1))[0] == 3
+
     # --------------------------- `intersection` tests -------------------------- #
     @pytest.mark.parametrize(
         "test_geom, expected",

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -151,14 +151,6 @@ class TestPygeosInterface:
         self.df = GeoDataFrame(data, geometry="location")
         self.expected_size = len(data["location"])
 
-    #
-    def test_scattered_empty(self):
-        """Tests building sindex with interlived empty geometries.
-        """
-        geoms = [Point(0, 0), None, Point(), Point(1, 1), Point()]
-        df = geopandas.GeoDataFrame(geometry=geoms)
-        assert df.sindex.query(Point(1, 1))[0] == 3
-
     # --------------------------- `intersection` tests -------------------------- #
     @pytest.mark.parametrize(
         "test_geom, expected",
@@ -494,6 +486,13 @@ class TestPygeosInterface:
             raise e
 
     # --------------------------- misc tests ---------------------------- #
+
+    def test_empty_tree_geometries(self):
+        """Tests building sindex with interleaved empty geometries.
+        """
+        geoms = [Point(0, 0), None, Point(), Point(1, 1), Point()]
+        df = geopandas.GeoDataFrame(geometry=geoms)
+        assert df.sindex.query(Point(1, 1))[0] == 3
 
     def test_size(self):
         """Tests the `size` property."""

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -44,7 +44,8 @@ class TestSeriesSindex:
     def test_empty_point(self):
         s = GeoSeries([Point()])
 
-        assert s.sindex.size == 1
+        assert s.sindex is None
+        assert s._sindex_generated is True
 
     def test_polygons(self):
         t1 = Polygon([(0, 0), (1, 0), (1, 1)])

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -44,8 +44,7 @@ class TestSeriesSindex:
     def test_empty_point(self):
         s = GeoSeries([Point()])
 
-        assert s.sindex is None
-        assert s._sindex_generated is True
+        assert s.sindex.size == 1
 
     def test_polygons(self):
         t1 = Polygon([(0, 0), (1, 0), (1, 1)])


### PR DESCRIPTION
Currently, we are removing empty geometries before creating the tree. This causes the indexing to be off it there is an empty geometry anywhere but the last index (the current tests only check a single empty geometry, i.e. the last index). I fixed this and added a test.

~Where things get a tad more complicated is dealing with empty geometries in calculating the "size" of the spatial index. Empty geometries are not inserted into the tree, but pygeos still counts them towards the size of `pygeos.strtree.STRtree`. I think this behavior makes more sense than passing in an array of size 100 with 1 empty geometry and getting back a spatial index size of 99 (which is what rtree is currently doing). Thus I modified the `size` property in the rtree wrapper to return the size of the geometry array, not the number of leaf nodes in the tree. I also renamed `self._geometries` -> `self.geometries` in `RTreeIndex` to further unify the interface.~

~I think the only reason I was removing the empty geometries in `PyGEOSSTRTreeIndex` was to match the `size` reported by `RTreeIndex`.~

Edit: further testing shows that this was wrong. `len(pygeos.strtree.STRtree)` does _not_ count empty/None geometries.