### PR TITLE
Preserve CRS in GeoDataFrame.astype

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -862,7 +862,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         -------
         GeoDataFrame or DataFrame
         """
-        df = super(GeoDataFrame, self).astype(dtype, copy=copy, errors=errors, **kwargs)
+        df = super(GeoDataFrame, self).astype(
+            dtype, copy=copy, errors=errors, crs=self.crs, **kwargs
+        )
 
         try:
             geoms = df[self._geometry_column_name]


### PR DESCRIPTION
Currently CRS is lost when calling `astype`:
```
gdf = gpd.read_file(gpd.datasets.get_path('nybb'))

gdf.crs
<Projected CRS: EPSG:2263>
Name: NAD83 / New York Long Island (ftUS)
Axis Info [cartesian]:
- X[east]: Easting (US survey foot)
- Y[north]: Northing (US survey foot)
Area of Use:
- name: USA - New York - SPCS - Long Island
- bounds: (-74.26, 40.47, -71.8, 41.3)
Coordinate Operation:
- name: SPCS83 New York Long Island zone (US Survey feet)
- method: Lambert Conic Conformal (2SP)
Datum: North American Datum 1983
- Ellipsoid: GRS 1980
- Prime Meridian: Greenwich

gdf.astype({"BoroCode": str}).crs
# None
```

Seems safe enough to just pull from the existing value?