### PR TITLE
Warn about deprecation of sindex.intersection objects parameter

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from warnings import warn
 
 from shapely.geometry.base import BaseGeometry
 import pandas as pd
@@ -243,6 +244,28 @@ if compat.HAS_RTREE:
                 input_geometry_index.extend([i] * len(res))
             return np.vstack([input_geometry_index, tree_index])
 
+        def intersection(self, coordinates, objects=False):
+            """Find tree geometries that intersect the input coordinates.
+
+            Parameters
+            ----------
+            coordinates : sequence or array
+                Sequence of the form (min_x, min_y, max_x, max_y)
+                to query a rectangle or (x, y) to query a point.
+            objects : True or False
+                If True, return the label based indexes. If False, integer indexes
+                are returned.
+            """
+            if objects:
+                warn(
+                    "A future version of GeoPandas will deprecate the `objects`"
+                    " parameter. If you use this option and would like it preserved,"
+                    " please open an issue at https://github.com/geopandas/geopandas"
+                    " and help us understand you use case.",
+                    FutureWarning,
+                )
+            return super().intersection(coordinates, objects)
+
         @property
         def size(self):
             return len(self.leaves()[0][1])
@@ -407,6 +430,15 @@ if compat.HAS_PYGEOS:
                 If True, return the label based indexes. If False, integer indexes
                 are returned.
             """
+            if objects:
+                warn(
+                    "A future version of GeoPandas will deprecate the `objects` "
+                    " parameter. If you use this option and would like it preserved, "
+                    " please open an issue at https://github.com/geopandas/geopandas"
+                    " and help us understand you use case.",
+                    FutureWarning,
+                )
+
             # convert bounds to geometry
             # the old API uses tuples of bound, but pygeos uses geometries
             try:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -252,16 +252,15 @@ if compat.HAS_RTREE:
             coordinates : sequence or array
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
-            objects : True or False
+            objects : boolean, default False
                 If True, return the label based indexes. If False, integer indexes
                 are returned.
             """
             if objects:
                 warn(
-                    "A future version of GeoPandas will deprecate the `objects`"
-                    " parameter. If you use this option and would like it preserved,"
-                    " please open an issue at https://github.com/geopandas/geopandas"
-                    " and help us understand you use case.",
+                    "`objects` is deprecated and will be removed in a future version. "
+                    "Instead, use `iloc` to index your GeoSeries/GeoDataFrame using "
+                    "integer indexes returned by `intersection`.",
                     FutureWarning,
                 )
             return super().intersection(coordinates, objects)
@@ -426,16 +425,15 @@ if compat.HAS_PYGEOS:
             coordinates : sequence or array
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
-            objects : True or False
+            objects : boolean, default False
                 If True, return the label based indexes. If False, integer indexes
                 are returned.
             """
             if objects:
                 warn(
-                    "A future version of GeoPandas will deprecate the `objects` "
-                    " parameter. If you use this option and would like it preserved, "
-                    " please open an issue at https://github.com/geopandas/geopandas"
-                    " and help us understand you use case.",
+                    "`objects` is deprecated and will be removed in a future version. "
+                    "Instead, use `iloc` to index your GeoSeries/GeoDataFrame using "
+                    "integer indexes returned by `intersection`.",
                     FutureWarning,
                 )
 

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -105,7 +105,11 @@ class TestFrameSindex:
     def test_sindex(self):
         self.df.crs = "epsg:4326"
         assert self.df.sindex.size == 5
-        hits = list(self.df.sindex.intersection((2.5, 2.5, 4, 4), objects=True))
+        with pytest.warns(
+            FutureWarning, match="A future version of GeoPandas will deprecate"
+        ):
+            # TODO: remove warning check once deprecated
+            hits = list(self.df.sindex.intersection((2.5, 2.5, 4, 4), objects=True))
         assert len(hits) == 2
         assert hits[0].object == 3
 
@@ -133,21 +137,33 @@ class TestJoinSindex:
     def test_merge_geo(self):
         # First check that we gets hits from the boros frame.
         tree = self.boros.sindex
-        hits = tree.intersection((1012821.80, 229228.26), objects=True)
+        with pytest.warns(
+            FutureWarning, match="A future version of GeoPandas will deprecate"
+        ):
+            # TODO: remove warning check once deprecated
+            hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [self.boros.loc[hit.object]["BoroName"] for hit in hits]
         assert res == ["Bronx", "Queens"]
 
         # Check that we only get the Bronx from this view.
         first = self.boros[self.boros["BoroCode"] < 3]
         tree = first.sindex
-        hits = tree.intersection((1012821.80, 229228.26), objects=True)
+        with pytest.warns(
+            FutureWarning, match="A future version of GeoPandas will deprecate"
+        ):
+            # TODO: remove warning check once deprecated
+            hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [first.loc[hit.object]["BoroName"] for hit in hits]
         assert res == ["Bronx"]
 
         # Check that we only get Queens from this view.
         second = self.boros[self.boros["BoroCode"] >= 3]
         tree = second.sindex
-        hits = tree.intersection((1012821.80, 229228.26), objects=True)
+        with pytest.warns(
+            FutureWarning, match="A future version of GeoPandas will deprecate"
+        ):
+            # TODO: remove warning check once deprecated
+            hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = ([second.loc[hit.object]["BoroName"] for hit in hits],)
         assert res == ["Queens"]
 
@@ -156,7 +172,11 @@ class TestJoinSindex:
         assert len(merged) == 5
         assert merged.sindex.size == 5
         tree = merged.sindex
-        hits = tree.intersection((1012821.80, 229228.26), objects=True)
+        with pytest.warns(
+            FutureWarning, match="A future version of GeoPandas will deprecate"
+        ):
+            # TODO: remove warning check once deprecated
+            hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [merged.loc[hit.object]["BoroName"] for hit in hits]
         assert res == ["Bronx", "Queens"]
 

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -105,9 +105,7 @@ class TestFrameSindex:
     def test_sindex(self):
         self.df.crs = "epsg:4326"
         assert self.df.sindex.size == 5
-        with pytest.warns(
-            FutureWarning, match="A future version of GeoPandas will deprecate"
-        ):
+        with pytest.warns(FutureWarning, match="`objects` is deprecated"):
             # TODO: remove warning check once deprecated
             hits = list(self.df.sindex.intersection((2.5, 2.5, 4, 4), objects=True))
         assert len(hits) == 2
@@ -137,9 +135,7 @@ class TestJoinSindex:
     def test_merge_geo(self):
         # First check that we gets hits from the boros frame.
         tree = self.boros.sindex
-        with pytest.warns(
-            FutureWarning, match="A future version of GeoPandas will deprecate"
-        ):
+        with pytest.warns(FutureWarning, match="`objects` is deprecated"):
             # TODO: remove warning check once deprecated
             hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [self.boros.loc[hit.object]["BoroName"] for hit in hits]
@@ -148,9 +144,7 @@ class TestJoinSindex:
         # Check that we only get the Bronx from this view.
         first = self.boros[self.boros["BoroCode"] < 3]
         tree = first.sindex
-        with pytest.warns(
-            FutureWarning, match="A future version of GeoPandas will deprecate"
-        ):
+        with pytest.warns(FutureWarning, match="`objects` is deprecated"):
             # TODO: remove warning check once deprecated
             hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [first.loc[hit.object]["BoroName"] for hit in hits]
@@ -159,9 +153,7 @@ class TestJoinSindex:
         # Check that we only get Queens from this view.
         second = self.boros[self.boros["BoroCode"] >= 3]
         tree = second.sindex
-        with pytest.warns(
-            FutureWarning, match="A future version of GeoPandas will deprecate"
-        ):
+        with pytest.warns(FutureWarning, match="`objects` is deprecated"):
             # TODO: remove warning check once deprecated
             hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = ([second.loc[hit.object]["BoroName"] for hit in hits],)
@@ -172,9 +164,7 @@ class TestJoinSindex:
         assert len(merged) == 5
         assert merged.sindex.size == 5
         tree = merged.sindex
-        with pytest.warns(
-            FutureWarning, match="A future version of GeoPandas will deprecate"
-        ):
+        with pytest.warns(FutureWarning, match="`objects` is deprecated"):
             # TODO: remove warning check once deprecated
             hits = tree.intersection((1012821.80, 229228.26), objects=True)
         res = [merged.loc[hit.object]["BoroName"] for hit in hits]


### PR DESCRIPTION
As discussed in #1439, I think it would be best to deprecate the `objects` parameter. This makes a warning for using it. Hopefully this will be a good first step in that direction.