### PR TITLE
CI: remove skip for Parquet tests on AppVeyor

### DIFF
--- a/geopandas/io/tests/test_parquet.py
+++ b/geopandas/io/tests/test_parquet.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import os
-import sys
 
 import pytest
 from pandas import DataFrame, read_parquet as pd_read_parquet
@@ -26,16 +25,8 @@ from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 # Skip all tests in this module if pyarrow is not available
 pyarrow_skip = pytest.importorskip("pyarrow")
 
-
-pytestmark = [
-    # TEMPORARY: Skip all tests on Windows
-    # https://github.com/conda-forge/pyarrow-feedstock/issues/104
-    pytest.mark.skipif(
-        sys.platform.startswith("win"), reason="pyarrow segfaults on windows"
-    ),
-    # TEMPORARY: hide warning from to_parquet
-    pytest.mark.filterwarnings("ignore:.*initial implementation of Parquet.*"),
-]
+# TEMPORARY: hide warning from to_parquet
+pytestmark = pytest.mark.filterwarnings("ignore:.*initial implementation of Parquet.*")
 
 
 def test_create_metadata():


### PR DESCRIPTION
To test whether this is now solved (cfr https://github.com/conda-forge/pyarrow-feedstock/issues/104)