### PR TITLE
REF: Move sindex to GeometryArray

### DIFF
--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -54,6 +54,8 @@ class BenchQuery:
 
     def setup(self, *args):
         self.data = generate_test_df()
+        for data in self.data.values():
+            data.sindex  # ensure index is pre-generated
 
     def time_query_bulk(self, predicate, input_geom_type, tree_geom_type):
         self.data[tree_geom_type].sindex.query_bulk(

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -64,6 +64,10 @@ class BenchIndexCreation:
         Note: requires running a single query to ensure that
         lazy-building indexes are actually built.
         """
+        # Note: the GeoDataFram._sindex_generated attribute will
+        # be removed by GH#1444 but is kept so that
+        # benchmarks can be run comparing pre GH#1444 to
+        # post GH#1444
         self.data[tree_geom_type]._sindex_generated = None
         self.data[tree_geom_type].geometry.values._sindex = None
         tree = self.data[tree_geom_type].sindex

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -42,10 +42,6 @@ class Bench:
         for bounds in self.bounds:
             self.data[tree_geom_type].sindex.intersection(bounds)
 
-    def time_intersects_objects(self, tree_geom_type):
-        for bounds in self.bounds:
-            self.data[tree_geom_type].sindex.intersection(bounds, objects=True)
-
 
 class BenchQuery:
 

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -63,6 +63,7 @@ class BenchIndexCreation:
         lazy-building indexes are actually built.
         """
         for tree_geom_type in geom_types:
+            self.data[tree_geom_type]._sindex_generated = None
             self.data[tree_geom_type].geometry.values._sindex = None
             self.data[tree_geom_type].sindex
             # also do a single query to ensure the index is actually

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -64,9 +64,17 @@ class BenchIndexCreation:
 
     def time_index_creation(self, tree_geom_type):
         """Time creation of spatial index.
+
+        Note: requires running a single query to ensure that
+        lazy-building indexes are actually built.
         """
         self.data[tree_geom_type].geometry.values._sindex = None
         self.data[tree_geom_type].sindex
+        # also do a single query to ensure the index is actually
+        # generated and used
+        self.data[tree_geom_type].sindex.query(
+            self.data[tree_geom_type].geometry.values.data[0]
+        )
 
 
 class BenchQuery:

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -94,6 +94,6 @@ class BenchQuery:
 
     def time_query(self, predicate, input_geom_type, tree_geom_type):
         self.data[tree_geom_type].sindex.query(
-            np.random.choice(self.data[input_geom_type].geometry.values),
+            np.random.choice(self.data[input_geom_type].geometry.values.data),
             predicate=predicate,
         )

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -35,8 +35,8 @@ class Bench:
         Note: pygeos will only create the index once; this benchmark
         is not intended to be used to compare rtree and pygeos.
         """
-        self.data[tree_geom_type]._invalidate_sindex()
-        self.data[tree_geom_type]._generate_sindex()
+        self.data[tree_geom_type].geometry.values._sindex = None
+        self.data[tree_geom_type].sindex
 
     def time_intersects(self, tree_geom_type):
         for bounds in self.bounds:

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -1,5 +1,3 @@
-%%writefile /content/geopandas/benchmarks/sindex_new.py
-
 import numpy as np
 import random
 

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -1,13 +1,6 @@
-import numpy as np
-import random
-
 from geopandas import read_file, datasets
 from geopandas.sindex import VALID_QUERY_PREDICATES
 
-
-# set random seeds for deterministic results
-np.random.seed(0)
-random.seed(0)
 
 predicates = sorted(VALID_QUERY_PREDICATES, key=lambda x: (x is None, x))
 geom_types = ("mixed", "points", "polygons")

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -390,16 +390,14 @@ class GeometryArray(ExtensionArray):
 
     if compat.USE_PYGEOS:
 
-        if compat.USE_PYGEOS:
+        def __getstate__(self):
+            return (pygeos.to_wkb(self.data), self._crs)
 
-            def __getstate__(self):
-                return (pygeos.to_wkb(self.data), self._crs)
-
-            def __setstate__(self, state):
-                geoms = pygeos.from_wkb(state[0])
-                self._crs = state[1]
-                self.data = geoms
-                self.base = None
+        def __setstate__(self, state):
+            geoms = pygeos.from_wkb(state[0])
+            self._crs = state[1]
+            self.data = geoms
+            self.base = None
 
     else:
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -287,7 +287,6 @@ class GeometryArray(ExtensionArray):
     def sindex(self):
         if self._sindex is None:
             self._sindex = get_sindex_class()(self.data) 
-
         return self._sindex
 
     @property

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -285,7 +285,10 @@ class GeometryArray(ExtensionArray):
 
     @property
     def sindex(self):
-        if self._sindex is not None:  # check for existing
+        if self._sindex is None:
+            self._sindex = get_sindex_class()(self.data)
+            
+        return self._sindex
             pass
         else:  # build it
             self._sindex = get_sindex_class()(self.data)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -286,7 +286,7 @@ class GeometryArray(ExtensionArray):
     @property
     def sindex(self):
         if self._sindex is None:
-            self._sindex = get_sindex_class()(self.data) 
+            self._sindex = get_sindex_class()(self.data)
         return self._sindex
 
     @property

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from . import _compat as compat
 from . import _vectorized as vectorized
-from .sindex import get_sindex_class
+from .sindex import get_sindex_class, has_sindex
 
 
 class GeometryDtype(ExtensionDtype):
@@ -283,8 +283,12 @@ class GeometryArray(ExtensionArray):
 
         self._crs = None
         self.crs = crs
-
-        self.sindex_backend = sindex_backend or get_sindex_class()
+        if sindex_backend:
+            self.sindex_backend = sindex_backend
+        elif has_sindex():
+            self.sindex_backend = get_sindex_class()
+        else:
+            self.sindex_backend = None
         self._sindex = None
 
     @property

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -286,12 +286,7 @@ class GeometryArray(ExtensionArray):
     @property
     def sindex(self):
         if self._sindex is None:
-            self._sindex = get_sindex_class()(self.data)
-            
-        return self._sindex
-            pass
-        else:  # build it
-            self._sindex = get_sindex_class()(self.data)
+            self._sindex = get_sindex_class()(self.data) 
 
         return self._sindex
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -390,19 +390,16 @@ class GeometryArray(ExtensionArray):
 
     if compat.USE_PYGEOS:
 
-        def __getstate__(self):
-            return {
-                "wkb_data": pygeos.to_wkb(self.data),
-                "_crs": self._crs,
-                "sindex_backend": self.sindex_backend,
-            }
+        if compat.USE_PYGEOS:
 
-        def __setstate__(self, state):
-            self.data = pygeos.from_wkb(state["wkb_data"])
-            self._crs = state["_crs"]
-            self.sindex_backend = state["sindex_backend"]
-            self._sindex = None  # invalidate
-            self.base = None
+            def __getstate__(self):
+                return (pygeos.to_wkb(self.data), self._crs)
+
+            def __setstate__(self, state):
+                geoms = pygeos.from_wkb(state[0])
+                self._crs = state[1]
+                self.data = geoms
+                self.base = None
 
     else:
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -149,7 +149,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 )
                 # TODO: raise error in 0.9 or 0.10.
             self.set_geometry(geometry, inplace=True)
-        self._invalidate_sindex()
 
         if geometry is None and crs:
             warnings.warn(
@@ -260,7 +259,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             frame.index = index
         frame._geometry_column_name = geo_column_name
         frame.crs = crs
-        frame._invalidate_sindex()
         if not inplace:
             return frame
 
@@ -829,11 +827,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         geo_col = self._geometry_column_name
         if isinstance(result, Series) and isinstance(result.dtype, GeometryDtype):
             result.__class__ = GeoSeries
-            result._invalidate_sindex()
         elif isinstance(result, DataFrame) and geo_col in result:
             result.__class__ = GeoDataFrame
             result._geometry_column_name = geo_col
-            result._invalidate_sindex()
         elif isinstance(result, DataFrame) and geo_col not in result:
             result.__class__ = DataFrame
         return result
@@ -883,7 +879,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             result.__class__ = GeoDataFrame
             result.crs = self.crs
             result._geometry_column_name = geo_col
-            result._invalidate_sindex()
         elif isinstance(result, DataFrame) and geo_col not in result:
             result.__class__ = DataFrame
         return result

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -177,7 +177,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         if not self.crs:
             self.crs = crs
-        self._invalidate_sindex()
         return self
 
     def __init__(self, *args, **kwargs):
@@ -296,7 +295,6 @@ class GeoSeries(GeoPandasBase, Series):
         if type(val) == Series:
             val.__class__ = GeoSeries
             val.crs = self.crs
-            val._invalidate_sindex()
         return val
 
     def __getitem__(self, key):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -70,7 +70,7 @@ if compat.HAS_RTREE:
 
         Parameters
         ----------
-        geometry : np.array of PyGEOS geometries
+        geometry : np.array of Shapely geometries
             Geometries from which to build the spatial index.
         """
 

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -1,9 +1,3 @@
-<<<<<<< HEAD
-from collections import namedtuple
-=======
-from warnings import warn
->>>>>>> move sindex to geometryarrya
-
 from shapely.geometry.base import BaseGeometry
 import pandas as pd
 import numpy as np
@@ -100,11 +94,7 @@ if compat.HAS_RTREE:
                 super().__init__()
 
             # store reference to geometries for predicate queries
-<<<<<<< HEAD
-            self.geometries = geometry.geometry.values
-=======
-            self._geometries = geometry
->>>>>>> move sindex to geometryarrya
+            self.geometries = geometry
             # create a prepared geometry cache
             self._prepared_geometries = np.array(
                 [None] * self.geometries.size, dtype=object

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -303,7 +303,7 @@ if compat.HAS_PYGEOS:
 
             Parameters
             ----------
-            geometry : single PyGEOS geometry
+            geometry : single PyGEOS or shapely geometry
             predicate : {None, 'intersects', 'within', 'contains', \
 'overlaps', 'crosses', 'touches'}, optional
                 If predicate is provided, the input geometry is tested

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -241,26 +241,16 @@ if compat.HAS_RTREE:
                 input_geometry_index.extend([i] * len(res))
             return np.vstack([input_geometry_index, tree_index])
 
-        def intersection(self, coordinates, objects=False):
-            """Find tree geometries that intersect the input coordinates.
+        def intersection(self, coordinates):
+            """Wrapper for rtree.index.Index.intersection.
 
             Parameters
             ----------
             coordinates : sequence or array
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
-            objects : boolean, default False
-                If True, return the label based indexes. If False, integer indexes
-                are returned.
             """
-            if objects:
-                warn(
-                    "`objects` is deprecated and will be removed in a future version. "
-                    "Instead, use `iloc` to index your GeoSeries/GeoDataFrame using "
-                    "integer indexes returned by `intersection`.",
-                    FutureWarning,
-                )
-            return super().intersection(coordinates, objects)
+            return super().intersection(coordinates, objects=False)
 
         @property
         def size(self):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -250,7 +250,9 @@ if compat.HAS_RTREE:
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
             """
-            return super().intersection(coordinates, objects=False)
+            return np.array(
+                list(super().intersection(coordinates, objects=False)), dtype=np.intp,
+            )
 
         @property
         def size(self):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -70,8 +70,8 @@ if compat.HAS_RTREE:
 
         Parameters
         ----------
-        geometry : GeoSeries
-            GeoSeries from which to build the spatial index.
+        geometry : np.array of PyGEOS geometries
+            Geometries from which to build the spatial index.
         """
 
         # set of valid predicates for this spatial index
@@ -276,8 +276,8 @@ if compat.HAS_PYGEOS:
 
         Parameters
         ----------
-        geometry : GeoSeries
-            GeoSeries from which to build the spatial index.
+        geometry : np.array of PyGEOS geometries
+            Geometries from which to build the spatial index.
         """
 
         # set of valid predicates for this spatial index

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -409,14 +409,6 @@ if compat.HAS_PYGEOS:
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
             """
-            if objects:
-                warn(
-                    "`objects` is deprecated and will be removed in a future version. "
-                    "Instead, use `iloc` to index your GeoSeries/GeoDataFrame using "
-                    "integer indexes returned by `intersection`.",
-                    FutureWarning,
-                )
-
             # convert bounds to geometry
             # the old API uses tuples of bound, but pygeos uses geometries
             try:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -250,9 +250,7 @@ if compat.HAS_RTREE:
                 Sequence of the form (min_x, min_y, max_x, max_y)
                 to query a rectangle or (x, y) to query a point.
             """
-            return np.array(
-                list(super().intersection(coordinates, objects=False)), dtype=np.intp,
-            )
+            return super().intersection(coordinates, objects=False)
 
         @property
         def size(self):

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -154,7 +154,7 @@ class TestFrameSindex:
         assert sliced.sindex is not original_index
 
     @pytest.mark.skipif(
-        str(pd.__version__) >= LooseVersion("1.0.0"),
+        str(pd.__version__) <= LooseVersion("1.0.0"),
         reason="Column selection returns a copy on pd<=1.0.0"
     )
     def test_rebuild_on_col_selection(self):

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -158,12 +158,20 @@ class TestFrameSindex:
         original_index = self.df.sindex
         geometry_col = self.df["location"]
         assert geometry_col.sindex is original_index
-        # Selecting a subset of columns preserves the index on pd > 1
+
         if int(pd.__version__.split('.')[0]) >= 1:
+            # Selecting a subset of columns preserves the
+            # index on pd > 1
             subset1 = self.df[["location", "A"]]
             assert subset1.sindex is original_index
             subset2 = self.df[["A", "location"]]
             assert subset2.sindex is original_index
+        else:
+            # On pd < 1, a copy is returned
+            subset1 = self.df[["location", "A"]]
+            assert subset1.sindex is not original_index
+            subset2 = self.df[["A", "location"]]
+            assert subset2.sindex is not original_index
 
 
 # Skip to accommodate Shapely geometries being unhashable

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -15,6 +15,7 @@ from geopandas import _compat as compat
 from geopandas import GeoDataFrame, GeoSeries, read_file, sindex, datasets
 
 import pytest
+import pandas as pd
 import numpy as np
 
 
@@ -157,11 +158,12 @@ class TestFrameSindex:
         original_index = self.df.sindex
         geometry_col = self.df["location"]
         assert geometry_col.sindex is original_index
-        # Selecting a subset of columns preserves the index
-        subset1 = self.df[["location", "A"]]
-        assert subset1.sindex is original_index
-        subset2 = self.df[["A", "location"]]
-        assert subset2.sindex is original_index
+        # Selecting a subset of columns preserves the index on pd > 1
+        if int(pd.__version__.split('.')[0]) >= 1:
+            subset1 = self.df[["location", "A"]]
+            assert subset1.sindex is original_index
+            subset2 = self.df[["A", "location"]]
+            assert subset2.sindex is original_index
 
 
 # Skip to accommodate Shapely geometries being unhashable

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -161,10 +161,9 @@ class TestFrameSindex:
         assert geometry_col.sindex is original_index
         geometry_col = self.df.geometry
         assert geometry_col.sindex is original_index
-    
+
     @pytest.mark.skipif(
-        not compat.PANDAS_GE_10,
-        reason="Column selection returns a copy on pd<=1.0.0",
+        not compat.PANDAS_GE_10, reason="Column selection returns a copy on pd<=1.0.0",
     )
     def test_rebuild_on_multiple_col_selection(self):
         """Selecting a subset of columns preserves the index."""

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -111,7 +111,7 @@ class TestFrameSindex:
     def test_sindex(self):
         self.df.crs = "epsg:4326"
         assert self.df.sindex.size == 5
-        hits = self.df.sindex.intersection((2.5, 2.5, 4, 4))
+        hits = list(self.df.sindex.intersection((2.5, 2.5, 4, 4)))
         assert len(hits) == 2
         assert hits[0] == 3
 

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -578,7 +578,7 @@ class TestPygeosInterface:
     def test_is_empty(self):
         """Tests the `is_empty` property."""
         # create empty tree
-        empty = geopandas.GeoSeries([])
+        empty = geopandas.GeoSeries([], dtype=object)
         assert empty.sindex.is_empty
         empty = geopandas.GeoSeries([None])
         assert empty.sindex.is_empty

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -153,16 +153,22 @@ class TestFrameSindex:
         sliced = self.df.iloc[::-1]
         assert sliced.sindex is not original_index
 
-    @pytest.mark.skipif(
-        str(pd.__version__) <= LooseVersion("1.0.0"),
-        reason="Column selection returns a copy on pd<=1.0.0",
-    )
-    def test_rebuild_on_col_selection(self):
-        """Selecting columns should not rebuild the spatial index."""
+    def test_rebuild_on_single_col_selection(self):
+        """Selecting a single column should not rebuild the spatial index."""
         # Selecting geometry column preserves the index
         original_index = self.df.sindex
         geometry_col = self.df["location"]
         assert geometry_col.sindex is original_index
+        geometry_col = self.df.geometry
+        assert geometry_col.sindex is original_index
+    
+    @pytest.mark.skipif(
+        not compat.PANDAS_GE_10,
+        reason="Column selection returns a copy on pd<=1.0.0",
+    )
+    def test_rebuild_on_multiple_col_selection(self):
+        """Selecting a subset of columns preserves the index."""
+        original_index = self.df.sindex
         # Selecting a subset of columns preserves the index
         subset1 = self.df[["location", "A"]]
         assert subset1.sindex is original_index

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -94,16 +94,14 @@ class TestSeriesSindex:
 
     def test_rebuild_on_slice(self):
         s = GeoSeries([Point(0, 0), Point(0, 0)])
-        # Select a couple
         original_index = s.sindex
+        # Select a couple of rows
         sliced = s.iloc[:1]
         assert sliced.sindex is not original_index
-        # Select all
-        original_index = s.sindex
+        # Select all rows
         sliced = s.iloc[:]
         assert sliced.sindex is original_index
-        # Select all flip
-        original_index = s.sindex
+        # Select all rows and flip
         sliced = s.iloc[::-1]
         assert sliced.sindex is not original_index
 
@@ -139,28 +137,27 @@ class TestFrameSindex:
             [Point(x, y) for x, y in zip(range(5, 10), range(5, 10))], inplace=True
         )
         assert self.df.sindex is not original_index
-    
+
     def test_rebuild_on_row_slice(self):
-        # Select a couple
+        # Select a subset of rows rebuilds
         original_index = self.df.sindex
         sliced = self.df.iloc[:1]
         assert sliced.sindex is not original_index
-        # Select all
+        # Slicing all does not rebuild
         original_index = self.df.sindex
         sliced = self.df.iloc[:]
         assert sliced.sindex is original_index
-        # Select all inverse
+        # Re-ordering rebuilds
         sliced = self.df.iloc[::-1]
         assert sliced.sindex is not original_index
-    
+
     def test_rebuild_on_col_selection(self):
         """Selecting columns should not rebuild the spatial index."""
-        # Selecting geometry column
+        # Selecting geometry column preserves the index
         original_index = self.df.sindex
         geometry_col = self.df["location"]
         assert geometry_col.sindex is original_index
-        assert original_index is self.df.sindex
-        # Selecting a subset of columns
+        # Selecting a subset of columns preserves the index
         subset1 = self.df[["location", "A"]]
         assert subset1.sindex is original_index
         subset2 = self.df[["A", "location"]]

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -45,9 +45,7 @@ class TestNoSindex:
 class TestSeriesSindex:
     def test_empty_geoseries(self):
         """Tests creating a spatial index from an empty GeoSeries."""
-        with pytest.warns(FutureWarning, match="Generated spatial index is empty"):
-            # TODO: add checking len(GeoSeries().sindex) == 0 once deprecated
-            assert not GeoSeries(dtype=object).sindex
+        assert not GeoSeries(dtype=object).sindex
 
     def test_point(self):
         s = GeoSeries([Point(0, 0)])
@@ -534,15 +532,12 @@ class TestPygeosInterface:
     def test_is_empty(self):
         """Tests the `is_empty` property."""
         # create empty tree
-<<<<<<< HEAD
-        cls_ = sindex.get_sindex_class()
-        empty = geopandas.GeoSeries(dtype=object)
-        tree = cls_(empty)
-        assert tree.is_empty
-=======
         empty = geopandas.GeoSeries([])
-        assert empty.sindex is None
->>>>>>> move sindex to geometryarrya
+        assert empty.sindex.is_empty
+        empty = geopandas.GeoSeries([None])
+        assert empty.sindex.is_empty
+        empty = geopandas.GeoSeries([Point()])
+        assert empty.sindex.is_empty
         # create a non-empty tree
         non_empty = geopandas.GeoSeries([Point(0, 0)])
         assert not non_empty.sindex.is_empty

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -86,6 +86,18 @@ class TestSeriesSindex:
         assert s.sindex.size == 1
         assert s.values._sindex is not None
 
+    def test_rebuild_on_item_change(self):
+        s = GeoSeries([Point(0, 0)])
+        original_index = s.sindex
+        s.iloc[0] = Point(0, 0)
+        assert s.sindex is not original_index
+
+    def test_rebuild_on_slice(self):
+        s = GeoSeries([Point(0, 0), Point(0, 0)])
+        original_index = s.sindex
+        sliced = s.iloc[:1]
+        assert sliced.sindex is not original_index
+
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="fails on AppVeyor")
 @pytest.mark.skipif(not sindex.has_sindex(), reason="Spatial index absent, skipping")

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -45,7 +45,9 @@ class TestNoSindex:
 class TestSeriesSindex:
     def test_empty_geoseries(self):
         """Tests creating a spatial index from an empty GeoSeries."""
-        assert not GeoSeries(dtype=object).sindex
+        s = GeoSeries(dtype=object)
+        assert not s.sindex
+        assert len(s.sindex) == 0
 
     def test_point(self):
         s = GeoSeries([Point(0, 0)])
@@ -58,8 +60,8 @@ class TestSeriesSindex:
     def test_empty_point(self):
         """Tests that a single empty Point results in an empty tree."""
         s = GeoSeries([Point()])
-
         assert not s.sindex
+        assert len(s.sindex) == 0
 
     def test_polygons(self):
         t1 = Polygon([(0, 0), (1, 0), (1, 1)])

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -155,7 +155,7 @@ class TestFrameSindex:
 
     @pytest.mark.skipif(
         str(pd.__version__) <= LooseVersion("1.0.0"),
-        reason="Column selection returns a copy on pd<=1.0.0"
+        reason="Column selection returns a copy on pd<=1.0.0",
     )
     def test_rebuild_on_col_selection(self):
         """Selecting columns should not rebuild the spatial index."""

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -94,8 +94,17 @@ class TestSeriesSindex:
 
     def test_rebuild_on_slice(self):
         s = GeoSeries([Point(0, 0), Point(0, 0)])
+        # Select a couple
         original_index = s.sindex
         sliced = s.iloc[:1]
+        assert sliced.sindex is not original_index
+        # Select all
+        original_index = s.sindex
+        sliced = s.iloc[:]
+        assert sliced.sindex is original_index
+        # Select all flip
+        original_index = s.sindex
+        sliced = s.iloc[::-1]
         assert sliced.sindex is not original_index
 
 
@@ -130,6 +139,32 @@ class TestFrameSindex:
             [Point(x, y) for x, y in zip(range(5, 10), range(5, 10))], inplace=True
         )
         assert self.df.sindex is not original_index
+    
+    def test_rebuild_on_row_slice(self):
+        # Select a couple
+        original_index = self.df.sindex
+        sliced = self.df.iloc[:1]
+        assert sliced.sindex is not original_index
+        # Select all
+        original_index = self.df.sindex
+        sliced = self.df.iloc[:]
+        assert sliced.sindex is original_index
+        # Select all inverse
+        sliced = self.df.iloc[::-1]
+        assert sliced.sindex is not original_index
+    
+    def test_rebuild_on_col_selection(self):
+        """Selecting columns should not rebuild the spatial index."""
+        # Selecting geometry column
+        original_index = self.df.sindex
+        geometry_col = self.df["location"]
+        assert geometry_col.sindex is original_index
+        assert original_index is self.df.sindex
+        # Selecting a subset of columns
+        subset1 = self.df[["location", "A"]]
+        assert subset1.sindex is original_index
+        subset2 = self.df[["A", "location"]]
+        assert subset2.sindex is original_index
 
 
 # Skip to accommodate Shapely geometries being unhashable

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import sys
 
 from shapely.geometry import (
@@ -16,7 +15,6 @@ from geopandas import _compat as compat
 from geopandas import GeoDataFrame, GeoSeries, read_file, sindex, datasets
 
 import pytest
-import pandas as pd
 import numpy as np
 
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -89,14 +89,46 @@ def _basic_checks(left_df, right_df, how, lsuffix, rsuffix):
             " joined".format(index_left, index_right)
         )
 
-    # Attempt to re-use spatial indexes, otherwise generate the spatial index
-    # for the longer dataframe. If we are joining to an empty dataframe,
-    # don't bother generating the index.
-    if right_df.geometry.values._sindex or (
-        not left_df.geometry.values._sindex and right_df.shape[0] > left_df.shape[0]
-    ):
-        tree_idx = right_df.sindex if len(left_df) > 0 else None
-        tree_idx_right = True
+
+def _geom_predicate_query(left_df, right_df, op):
+    """Compute geometric comparisons and get matching indices.
+
+    Parameters
+    ----------
+    left_df : GeoDataFrame
+    right_df : GeoDataFrame
+    op : string
+        Binary predicate to query.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame with matching indices in
+        columns named `_key_left` and `_key_right`.
+    """
+    with warnings.catch_warnings():
+        # We don't need to show our own warning here
+        # TODO remove this once the deprecation has been enforced
+        warnings.filterwarnings(
+            "ignore", "Generated spatial index is empty", FutureWarning
+        )
+        if op == "within":
+            # within is implemented as the inverse of contains
+            # contains is a faster predicate
+            # see discussion at https://github.com/geopandas/geopandas/pull/1421
+            predicate = "contains"
+            sindex = left_df.sindex
+            input_geoms = right_df.geometry
+        else:
+            # all other predicates are symmetric
+            # keep them the same
+            predicate = op
+            sindex = right_df.sindex
+            input_geoms = left_df.geometry
+
+    if sindex:
+        l_idx, r_idx = sindex.query_bulk(input_geoms, predicate=predicate, sort=False)
+        indices = pd.DataFrame({"_key_left": l_idx, "_key_right": r_idx})
     else:
         # when sindex is empty / has no valid geometries
         indices = pd.DataFrame(columns=["_key_left", "_key_right"], dtype=float)


### PR DESCRIPTION
Crossref #1439.

This does the following (roughly steps 1 & 2 in #1439):
1. Drop the `objects` parameter completely.
2. Move the management of the spatial index to `GeometryArray`.

I don't expect this to be merged until after 0.8.0, but I'm submitting for some preliminary feedback.