### PR TITLE
BUG: explode() fails if 'level_1' is in columns

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -877,6 +877,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         df_copy = self.copy()
 
+        if "level_1" in df_copy.columns:  # GH1393
+            df_copy = df_copy.rename(columns={"level_1": "__level_1"})
+
         exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
         exploded_index = exploded_geom.columns[0]
 
@@ -887,6 +890,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # exploded GeoSeries index.
         df.set_index(exploded_index, append=True, inplace=True)
         df.index.names = list(self.index.names) + [None]
+
+        if "__level_1" in df.columns:
+            df = df.rename(columns={"__level_1": "level_1"})
+
         geo_df = df.set_geometry(self._geometry_column_name)
         return geo_df
 

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -658,6 +658,23 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
+    def test_explode_geodataframe_level_1(self):
+        # GH1393
+        s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
+        df = GeoDataFrame({"col": [1, 2], "geometry": s, "level_1": [0, 1]})
+
+        test_df = df.explode()
+
+        expected_s = GeoSeries([Point(1, 2), Point(2, 3), Point(5, 5)])
+        expected_df = GeoDataFrame(
+            {"col": [1, 1, 2], "level_1": [0, 0, 1], "geometry": expected_s}
+        )
+        expected_index = MultiIndex(
+            [[0, 1], [0, 1]], [[0, 0, 1], [0, 1, 0]],  # levels  # labels/codes
+        )
+        expected_df = expected_df.set_index(expected_index)
+        assert_frame_equal(test_df, expected_df)
+
     #
     # Test '&', '|', '^', and '-'
     #

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -658,17 +658,21 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
-    def test_explode_geodataframe_level_1(self):
+    @pytest.mark.parametrize("index_name", [None, "test"])
+    def test_explode_geodataframe_level_1(self, index_name):
         # GH1393
         s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
         df = GeoDataFrame({"level_1": [1, 2], "geometry": s})
+        df.index.name = index_name
 
         test_df = df.explode()
 
         expected_s = GeoSeries([Point(1, 2), Point(2, 3), Point(5, 5)])
         expected_df = GeoDataFrame({"level_1": [1, 1, 2], "geometry": expected_s})
         expected_index = MultiIndex(
-            [[0, 1], [0, 1]], [[0, 0, 1], [0, 1, 0]],  # levels  # labels/codes
+            [[0, 1], [0, 1]],  # levels
+            [[0, 0, 1], [0, 1, 0]],  # labels/codes
+            names=[index_name, None],
         )
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -661,14 +661,12 @@ class TestGeomMethods:
     def test_explode_geodataframe_level_1(self):
         # GH1393
         s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
-        df = GeoDataFrame({"col": [1, 2], "geometry": s, "level_1": [0, 1]})
+        df = GeoDataFrame({"level_1": [1, 2], "geometry": s})
 
         test_df = df.explode()
 
         expected_s = GeoSeries([Point(1, 2), Point(2, 3), Point(5, 5)])
-        expected_df = GeoDataFrame(
-            {"col": [1, 1, 2], "level_1": [0, 0, 1], "geometry": expected_s}
-        )
+        expected_df = GeoDataFrame({"level_1": [1, 1, 2], "geometry": expected_s})
         expected_index = MultiIndex(
             [[0, 1], [0, 1]], [[0, 0, 1], [0, 1, 0]],  # levels  # labels/codes
         )

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -12,6 +12,7 @@ from geopandas import GeoDataFrame, GeoSeries
 from geopandas.base import GeoPandasBase
 
 from geopandas.tests.util import assert_geoseries_equal, geom_almost_equals, geom_equals
+from geopandas._compat import PANDAS_GE_024
 from pandas.testing import assert_frame_equal, assert_series_equal
 import pytest
 
@@ -675,6 +676,8 @@ class TestGeomMethods:
             names=[index_name, None],
         )
         expected_df = expected_df.set_index(expected_index)
+        if not PANDAS_GE_024:
+            expected_df = expected_df[["level_1", "geometry"]]
         assert_frame_equal(test_df, expected_df)
 
     #


### PR DESCRIPTION
Fixes #1393 

If there is a column `'level_1'` present in GeoDataFrame, it will fail with `NotImplementedError`. We are using automatically created `level_1` column within explode, so I am renaming potentially conflicting column to `'__level_1'` and then back. 