### PR TITLE
ENH: support pd.NA value as missing value

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -55,7 +55,7 @@ if compat.PANDAS_GE_024:
 
 def _isna(value):
     """
-    Check if scalar value is NA-like (None or np.nan).
+    Check if scalar value is NA-like (None, np.nan or pd.NA).
 
     Custom version that only works for scalars (returning True or False),
     as `pd.isna` also works for array-like input returning a boolean array.
@@ -64,7 +64,7 @@ def _isna(value):
         return True
     elif isinstance(value, float) and np.isnan(value):
         return True
-    elif compat.PANDAS_GE_10 and isinstance(value, type(pd.NA)):
+    elif compat.PANDAS_GE_10 and value is pd.NA:
         return True
     else:
         return False

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -64,6 +64,8 @@ def _isna(value):
         return True
     elif isinstance(value, float) and np.isnan(value):
         return True
+    elif compat.PANDAS_GE_10 and isinstance(value, type(pd.NA)):
+        return True
     else:
         return False
 

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -822,3 +822,11 @@ def test_check_crs():
     assert _check_crs(t1, T) is False
     assert _check_crs(t1, t1) is True
     assert _check_crs(t1, T, allow_none=True) is True
+
+
+@pytest.mark.skipif(not compat.PANDAS_GE_10, reason="pd.NA introduced in pandas 1.0")
+@pytest.mark.parametrize("NA", [None, np.nan, pd.NA])
+def test_isna(NA):
+    t1 = T.copy()
+    t1[0] = NA
+    assert t1[0] is None

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -824,9 +824,15 @@ def test_check_crs():
     assert _check_crs(t1, T, allow_none=True) is True
 
 
-@pytest.mark.skipif(not compat.PANDAS_GE_10, reason="pd.NA introduced in pandas 1.0")
-@pytest.mark.parametrize("NA", [None, np.nan, pd.NA])
+@pytest.mark.parametrize("NA", [None, np.nan])
 def test_isna(NA):
     t1 = T.copy()
     t1[0] = NA
+    assert t1[0] is None
+
+
+@pytest.mark.skipif(not compat.PANDAS_GE_10, reason="pd.NA introduced in pandas 1.0")
+def test_isna_pdNA():
+    t1 = T.copy()
+    t1[0] = pd.NA
     assert t1[0] is None


### PR DESCRIPTION
Closes #1335

Added support for `pandas.NA` as a missing value in our `_isna` function.