### PR TITLE
DOC: correct Examples rubric titles

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -748,8 +748,8 @@ class GeoPandasBase(object):
         original index and a zero-based integer index that counts the
         number of single geometries within a multi-part geometry.
 
-        Example
-        -------
+        Examples
+        --------
         >>> gdf  # gdf is GeoSeries of MultiPoints
         0         MULTIPOINT (0 0, 1 1)
         1    MULTIPOINT (2 2, 3 3, 4 4)

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -103,8 +103,8 @@ def _read_postgis(
     -------
     GeoDataFrame
 
-    Example
-    -------
+    Examples
+    --------
     PostGIS
     >>> sql = "SELECT geom, kind FROM polygons"
     SpatiaLite

--- a/geopandas/tools/_show_versions.py
+++ b/geopandas/tools/_show_versions.py
@@ -124,9 +124,12 @@ def show_versions():
     """
     Print system information and installed module versions.
 
-    Example
-    -------
-    > python -c "import geopandas; geopandas.show_versions()"
+    Examples
+    --------
+
+    ::
+
+        $ python -c "import geopandas; geopandas.show_versions()"
     """
     sys_info = _get_sys_info()
     deps_info = _get_deps_info()


### PR DESCRIPTION
Numpydoc requires the exact correct name ("Examples"), otherwise it doesn't show up, eg https://geopandas.readthedocs.io/en/latest/reference/geopandas.read_postgis.html