### PR TITLE
DOC: add sections for PostGIS and Parquet/Feather to io.rst docs

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1,24 +1,32 @@
 .. _io:
 
 Reading and Writing Files
-=========================================
-
-
+=========================
 
 Reading Spatial Data
 ---------------------
 
-*geopandas* can read almost any vector-based spatial data format including ESRI shapefile, GeoJSON files and more using the command::
+*geopandas* can read almost any vector-based spatial data format including ESRI
+shapefile, GeoJSON files and more using the command::
 
     geopandas.read_file()
 
-which returns a GeoDataFrame object. (This is possible because *geopandas* makes use of the great `fiona <http://fiona.readthedocs.io/en/latest/manual.html>`_ library, which in turn makes use of a massive open-source program called `GDAL/OGR <http://www.gdal.org/>`_ designed to facilitate spatial data transformations).
+which returns a GeoDataFrame object. This is possible because *geopandas* makes
+use of the great `fiona <http://fiona.readthedocs.io/en/latest/manual.html>`_
+library, which in turn makes use of a massive open-source program called
+`GDAL/OGR <http://www.gdal.org/>`_ designed to facilitate spatial data
+transformations.
 
-Any arguments passed to :func:`geopandas.read_file` after the file name will be passed directly to ``fiona.open``, which does the actual data importation. In general, :func:`geopandas.read_file` is pretty smart and should do what you want without extra arguments, but for more help, type::
+Any arguments passed to :func:`geopandas.read_file` after the file name will be
+passed directly to ``fiona.open``, which does the actual data importation. In
+general, :func:`geopandas.read_file` is pretty smart and should do what you want
+without extra arguments, but for more help, type::
 
     import fiona; help(fiona.open)
 
-Among other things, one can explicitly set the driver (shapefile, GeoJSON) with the ``driver`` keyword, or pick a single layer from a multi-layered file with the ``layer`` keyword::
+Among other things, one can explicitly set the driver (shapefile, GeoJSON) with
+the ``driver`` keyword, or pick a single layer from a multi-layered file with
+the ``layer`` keyword::
 
     countries_gdf = geopandas.read_file("package.gpkg", layer='countries')
 
@@ -37,11 +45,13 @@ If the dataset is in a folder in the ZIP file, you have to append its name::
 
     zipfile = "zip:///Users/name/Downloads/gadm36_AFG_shp.zip!data"
 
-If there are multiple datasets in a folder in the ZIP file, you also have to specify the filename::
+If there are multiple datasets in a folder in the ZIP file, you also have to
+specify the filename::
 
     zipfile = "zip:///Users/name/Downloads/gadm36_AFG_shp.zip!data/gadm36_AFG_1.shp"
 
-It is also possible to read any file-like objects with a ``read()`` method, such as a file handler (e.g. via built-in ``open`` function) or ``StringIO``::
+It is also possible to read any file-like objects with a ``read()`` method, such
+as a file handler (e.g. via built-in ``open`` function) or ``StringIO``::
 
     filename = "test.geojson"
     file = open(filename)
@@ -52,9 +62,6 @@ You can also read path objects::
     import pathlib
     path_object = pathlib.path(filename)
     df = geopandas.read_file(path_object)
-
-*geopandas* can also get data from a PostGIS database using the :func:`geopandas.read_postgis` command.
-
 
 Reading subsets of the data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,9 +179,47 @@ by using the :meth:`geopandas.GeoDataFrame.to_postgis` method.
     countries_gdf.to_file("package.gpkg", layer='countries', driver="GPKG")
     cities_gdf.to_file("package.gpkg", layer='cities', driver="GPKG")
 
-**Writing to PostGIS**::
+
+Spatial databases
+-----------------
+
+*geopandas* can also get data from a PostGIS database using the
+:func:`geopandas.read_postgis` command.
+
+Writing to PostGIS::
 
     from sqlalchemy import create_engine
     db_connection_url = "postgres://myusername:mypassword@myhost:5432/mydatabase";
     engine = create_engine(db_connection_url)
-    countries_gdf.to_postgis(name="countries_table", con=engine)
+    countries_gdf.to_postgis("countries_table", con=engine)
+
+
+Apache Parquet and Feather file formats
+---------------------------------------
+
+.. versionadded:: 0.8.0
+
+GeoPandas supports writing and reading the Apache Parquet and Feather file
+formats.
+
+`Apache Parquet <https://parquet.apache.org/>`__ is an efficient, columnar
+storage format (originating from the Hadoop ecosystem). It is a widely used
+binary file format for tabular data. The Feather file format is the on-disk
+representation of the `Apache Arrow <https://arrow.apache.org/>`__ memory
+format, an open standard for in-memory columnar data.
+
+The :func:`geopandas.read_parquet`, :func:`geopandas.read_feather`,
+:meth:`GeoDataFrame.to_parquet` and :meth:`GeoDataFrame.to_feather` methods
+enable fast roundtrip from GeoPandas to those binary file formats, preserving
+the spatial information.
+
+.. warning::
+
+    This is an initial implementation of Parquet file support and
+    associated metadata. This is tracking version 0.1.0 of the metadata
+    specification at:
+    https://github.com/geopandas/geo-arrow-spec
+
+    This metadata specification does not yet make stability promises.  As such,
+    we do not yet recommend using this in a production setting unless you are
+    able to rewrite your Parquet or Feather files.

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -220,6 +220,6 @@ the spatial information.
     specification at:
     https://github.com/geopandas/geo-arrow-spec
 
-    This metadata specification does not yet make stability promises.  As such,
+    This metadata specification does not yet make stability promises. As such,
     we do not yet recommend using this in a production setting unless you are
     able to rewrite your Parquet or Feather files.


### PR DESCRIPTION
We need to expand those docs (certainly the part about databases), but this PR is doing something minimal: add a section about Parquet/Feather, and move the mention of read_postgis/to_postgis into its own section (for the rest are mainly newline changes by wrapping the existing text)