### PR TITLE
Filter warning about geometry column not holding geometries when writing to postgis

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -249,13 +249,11 @@ def _convert_to_ewkb(gdf, geom_name, srid):
         geoms = [dumps(geom, srid=srid, hex=True) for geom in gdf[geom_name]]
 
     # The gdf will warn that the geometry column doesn't hold in-memory geometries
-    # now that they are EWKB. Ignore this warning.
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "Geometry column does not contain geometry.", UserWarning
-        )
-        gdf[geom_name] = geoms
-    return gdf
+    # now that they are EWKB, so convert back to a regular dataframe to avoid warning
+    # the user that the dtypes are unexpected.
+    df = pd.DataFrame(gdf, copy=False)
+    df[geom_name] = geoms
+    return df
 
 
 def _psql_insert_copy(tbl, conn, keys, data_iter):

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -248,7 +248,13 @@ def _convert_to_ewkb(gdf, geom_name, srid):
 
         geoms = [dumps(geom, srid=srid, hex=True) for geom in gdf[geom_name]]
 
-    gdf[geom_name] = geoms
+    # The gdf will warn that the geometry column doesn't hold in-memory geometries
+    # now that they are EWKB. Ignore this warning.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "Geometry column does not contain geometry.", UserWarning
+        )
+        gdf[geom_name] = geoms
     return gdf
 
 


### PR DESCRIPTION
Filter warning about geometry column not holding geometries when writing to postgis, as the dtype conversion is intentional.

Fixes #1497 