### PR TITLE
ENH: Add `aspect=None` option to plotting, to keep the original aspect.

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -313,14 +313,15 @@ def plot_series(
     figsize : pair of floats (default None)
         Size of the resulting matplotlib.figure.Figure. If the argument
         ax is given explicitly, figsize is ignored.
-    aspect : 'auto', 'equal' or float (default 'auto')
+    aspect : 'auto', 'equal', None or float (default 'auto')
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
         the GeoSeries (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. It can also be set manually (float) as the ratio
-        of y-unit to x-unit.
+        Equirectangular projection. If None, the aspect of ax won't be changed, useful
+        when passing in an existing ax and needing to keep the original aspect. It can 
+        also be set manually (float) as the ratio of y-unit to x-unit.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
@@ -366,7 +367,9 @@ def plot_series(
             # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
-    else:
+    elif aspect == "equal":
+        ax.set_aspect("equal")
+    elif aspect is not None:
         ax.set_aspect(aspect)
 
     if s.empty:
@@ -535,14 +538,15 @@ def plot_dataframe(
         to be passed on to geometries with missing values in addition to
         or overwriting other style kwds. If None, geometries with missing
         values are not plotted.
-    aspect : 'auto', 'equal' or float (default 'auto')
+    aspect : 'auto', 'equal', None or float (default 'auto')
         Set aspect of axis. If 'auto', the default aspect for map plots is 'equal'; if
         however data are not projected (coordinates are long/lat), the aspect is by
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
         the GeoDataFrame (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. It can also be set manually (float) as the ratio
-        of y-unit to x-unit.
+        Equirectangular projection. If None, the aspect of ax won't be changed, useful
+        when passing in an existing ax and needing to keep the original aspect. It can 
+        also be set manually (float) as the ratio of y-unit to x-unit.
 
     **style_kwds : dict
         Style options to be passed on to the actual plot function, such
@@ -597,7 +601,9 @@ def plot_dataframe(
             # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
-    else:
+    elif aspect == "equal":
+        ax.set_aspect("equal")
+    elif aspect is not None:
         ax.set_aspect(aspect)
 
     if df.empty:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -319,7 +319,7 @@ def plot_series(
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
         the GeoSeries (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed. It can 
+        Equirectangular projection. If None, the aspect of ax won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -541,7 +541,7 @@ def plot_dataframe(
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
         the GeoDataFrame (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed. It can 
+        Equirectangular projection. If None, the aspect of ax won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
 
     **style_kwds : dict

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -366,8 +366,6 @@ def plot_series(
             # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
-    elif aspect == "equal":
-        ax.set_aspect("equal")
     elif aspect is not None:
         ax.set_aspect(aspect)
 
@@ -599,8 +597,6 @@ def plot_dataframe(
             # https://github.com/edzer/sp/blob/master/R/mapasp.R
         else:
             ax.set_aspect("equal")
-    elif aspect == "equal":
-        ax.set_aspect("equal")
     elif aspect is not None:
         ax.set_aspect(aspect)
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -541,7 +541,7 @@ def plot_dataframe(
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
         the GeoDataFrame (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed. It can
+        Equirectangular projection. If None, the aspect of `ax` won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
 
     **style_kwds : dict

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -319,8 +319,7 @@ def plot_series(
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
         the GeoSeries (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed, useful
-        when passing in an existing ax and needing to keep the original aspect. It can 
+        Equirectangular projection. If None, the aspect of ax won't be changed. It can 
         also be set manually (float) as the ratio of y-unit to x-unit.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
@@ -544,8 +543,7 @@ def plot_dataframe(
         default set to 1/cos(df_y * pi/180) with df_y the y coordinate of the middle of
         the GeoDataFrame (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed, useful
-        when passing in an existing ax and needing to keep the original aspect. It can 
+        Equirectangular projection. If None, the aspect of ax won't be changed. It can 
         also be set manually (float) as the ratio of y-unit to x-unit.
 
     **style_kwds : dict

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -319,7 +319,7 @@ def plot_series(
         default set to 1/cos(s_y * pi/180) with s_y the y coordinate of the middle of
         the GeoSeries (the mean of the y range of bounding box) so that a long/lat
         square appears square in the middle of the plot. This implies an
-        Equirectangular projection. If None, the aspect of ax won't be changed. It can
+        Equirectangular projection. If None, the aspect of `ax` won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -877,21 +877,39 @@ class TestGeographicAspect:
     def test_manual(self):
         ax = self.north.geometry.plot(aspect="equal")
         assert ax.get_aspect() in ["equal", 1.0]
+        self.north.geometry.plot(ax=ax, aspect=None)
+        assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.geometry.plot(aspect=0.5)
+        assert ax2.get_aspect() == 0.5
+        self.north.geometry.plot(ax=ax2, aspect=None)
         assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.geometry.plot(aspect=0.5)
         assert ax3.get_aspect() == 0.5
+        self.north_proj.geometry.plot(ax=ax3, aspect=None)
+        assert ax3.get_aspect() == 0.5
         ax = self.north.plot(aspect="equal")
+        assert ax.get_aspect() in ["equal", 1.0]
+        self.north.plot(ax=ax, aspect=None)
         assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.plot(aspect=0.5)
         assert ax2.get_aspect() == 0.5
+        self.north.plot(ax=ax2, aspect=None)
+        assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.plot(aspect=0.5)
+        assert ax3.get_aspect() == 0.5
+        self.north_proj.plot(ax=ax3, aspect=None)
         assert ax3.get_aspect() == 0.5
         ax = self.north.plot("pop_est", aspect="equal")
         assert ax.get_aspect() in ["equal", 1.0]
+        self.north.plot("pop_est", ax=ax, aspect=None)
+        assert ax.get_aspect() in ["equal", 1.0]
         ax2 = self.north.plot("pop_est", aspect=0.5)
         assert ax2.get_aspect() == 0.5
+        self.north.plot("pop_est", ax=ax2, aspect=None)
+        assert ax2.get_aspect() == 0.5
         ax3 = self.north_proj.plot("pop_est", aspect=0.5)
+        assert ax3.get_aspect() == 0.5
+        self.north_proj.plot("pop_est", ax=ax3, aspect=None)
         assert ax3.get_aspect() == 0.5
 
 


### PR DESCRIPTION
For issue #1489. Now when `aspect=None`, the aspect won't be changed. Also, before this, `aspect="equal"` actually does nothing, which means it assumes that the original aspect of `ax` is always `equal`. I suppose this is probably mostly right, better to be explicit.