### PR TITLE
TST: skip argmin/argmax extension array tests

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -497,6 +497,18 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argsort_missing_array(self):
         pass
 
+    @no_sorting
+    def test_argmin_argmax(self):
+        pass
+
+    @no_sorting
+    def test_argmin_argmax_empty_array(self):
+        pass
+
+    @no_sorting
+    def test_argmin_argmax_all_na(self):
+        pass
+
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass


### PR DESCRIPTION
Some new tests were added in pandas master, and we don't support argmin/argmax methods (we don't support min/max sorting related methods generally).