### PR TITLE
DOC: Copy pandas commit message conventions

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -316,3 +316,32 @@ From the root of the geopandas repository, you should then install the
 Then ``black`` and ``flake8`` will be run automatically
 each time you commit changes. You can skip these checks with
 ``git commit --no-verify``.
+
+Commit message conventions
+--------------------------
+
+Commit your changes to your local repository with an explanatory message. geopandas
+uses the pandas convention for commit message prefixes and layout.  Here are
+some common prefixes along with general guidelines for when to use them:
+
+* ENH: Enhancement, new functionality
+* BUG: Bug fix
+* DOC: Additions/updates to documentation
+* TST: Additions/updates to tests
+* BLD: Updates to the build process/scripts
+* PERF: Performance improvement
+* TYP: Type annotations
+* CLN: Code cleanup
+
+The following defines how a commit message should be structured.  Please reference the
+relevant GitHub issues in your commit message using GH1234 or #1234.  Either style
+is fine, but the former is generally preferred:
+
+* a subject line with `< 80` chars.
+* One blank line.
+* Optionally, a commit message body.
+
+Now you can commit your changes in your local repository::
+
+    git commit -m
+    

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -320,7 +320,7 @@ each time you commit changes. You can skip these checks with
 Commit message conventions
 --------------------------
 
-Commit your changes to your local repository with an explanatory message. geopandas
+Commit your changes to your local repository with an explanatory message. GeoPandas
 uses the pandas convention for commit message prefixes and layout.  Here are
 some common prefixes along with general guidelines for when to use them:
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -333,7 +333,7 @@ some common prefixes along with general guidelines for when to use them:
 * TYP: Type annotations
 * CLN: Code cleanup
 
-The following defines how a commit message should be structured.  Please reference the
+The following defines how a commit message should be structured. Please refer to the
 relevant GitHub issues in your commit message using GH1234 or #1234. Either style
 is fine, but the former is generally preferred:
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -321,7 +321,7 @@ Commit message conventions
 --------------------------
 
 Commit your changes to your local repository with an explanatory message. GeoPandas
-uses the pandas convention for commit message prefixes and layout.  Here are
+uses the pandas convention for commit message prefixes and layout. Here are
 some common prefixes along with general guidelines for when to use them:
 
 * ENH: Enhancement, new functionality

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -334,7 +334,7 @@ some common prefixes along with general guidelines for when to use them:
 * CLN: Code cleanup
 
 The following defines how a commit message should be structured.  Please reference the
-relevant GitHub issues in your commit message using GH1234 or #1234.  Either style
+relevant GitHub issues in your commit message using GH1234 or #1234. Either style
 is fine, but the former is generally preferred:
 
 * a subject line with `< 80` chars.


### PR DESCRIPTION
Following on from pull request discussion in #1425

> "... read through pandas contribution guide - should have done before - and found commit message convention that geopandas uses which could copy into geopandas' contribution guide if desired"

I believe (though may be mistaken!) that geopandas follows the pandas commit message conventions so I've just copied across 'em across to the end of the `contributing to geopandas` docs as I was a little lost (for more reasons than this one!) during #1425