### PR TITLE
ENH: Allow for more general file-like objects to be used when opening files.

### DIFF
--- a/ci/travis/36-minimal.yaml
+++ b/ci/travis/36-minimal.yaml
@@ -14,6 +14,9 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - fsspec
+  - requests
+  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/ci/travis/36-minimal.yaml
+++ b/ci/travis/36-minimal.yaml
@@ -15,8 +15,6 @@ dependencies:
   - pytest-cov
   - codecov
   - fsspec
-  - requests
-  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/ci/travis/36-pd025.yaml
+++ b/ci/travis/36-pd025.yaml
@@ -13,8 +13,6 @@ dependencies:
   - pytest
   - pytest-cov
   - fsspec
-  - requests
-  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/36-pd025.yaml
+++ b/ci/travis/36-pd025.yaml
@@ -12,6 +12,9 @@ dependencies:
   # testing
   - pytest
   - pytest-cov
+  - fsspec
+  - requests
+  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/37-dev.yaml
+++ b/ci/travis/37-dev.yaml
@@ -14,8 +14,6 @@ dependencies:
   - pytest
   - pytest-cov
   - fsspec
-  - requests
-  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/37-dev.yaml
+++ b/ci/travis/37-dev.yaml
@@ -13,6 +13,9 @@ dependencies:
   # testing
   - pytest
   - pytest-cov
+  - fsspec
+  - requests
+  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -13,6 +13,9 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - fsspec
+  - requests
+  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -14,8 +14,6 @@ dependencies:
   - pytest-cov
   - codecov
   - fsspec
-  - requests
-  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -13,8 +13,6 @@ dependencies:
   - pytest
   - pytest-cov
   - fsspec
-  - requests
-  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -12,6 +12,9 @@ dependencies:
   # testing
   - pytest
   - pytest-cov
+  - fsspec
+  - requests
+  - aiohttp
   #- codecov
   # optional
   - rtree

--- a/ci/travis/38-latest-conda-forge.yaml
+++ b/ci/travis/38-latest-conda-forge.yaml
@@ -13,6 +13,9 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+  - fsspec
+  - requests
+  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/ci/travis/38-latest-conda-forge.yaml
+++ b/ci/travis/38-latest-conda-forge.yaml
@@ -14,8 +14,6 @@ dependencies:
   - pytest-cov
   - codecov
   - fsspec
-  - requests
-  - aiohttp
   # optional
   - rtree
   - matplotlib

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -57,6 +57,14 @@ as a file handler (e.g. via built-in ``open`` function) or ``StringIO``::
     file = open(filename)
     df = geopandas.read_file(file)
 
+File-like objects from `fsspec <https://filesystem-spec.readthedocs.io/en/latest>`_
+can also be used to read data, allowing for any combination of storage backends and caching
+supported by that project::
+
+    path = "simplecache::http://download.geofabrik.de/antarctica-latest-free.shp.zip"
+    with fsspec.open(path) as file:
+        df = geopandas.read_file(file)
+
 You can also read path objects::
 
     import pathlib

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -104,7 +104,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
         # In order to match that behavior, attempt to add a zip scheme if missing.
         # Casting to a pathlib.Path allows the same check to work for plain strings
         # and pathlib.Path instances.
-        if pathlib.Path(filename).suffix == ".zip":
+        if pathlib.Path(filename).suffix[:4] == ".zip":
             parsed = fiona.parse_path(str(filename))
             if isinstance(parsed, fiona.path.ParsedPath):
                 # If fiona returns a parsed path, we can safely look at the scheme

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -107,10 +107,9 @@ def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
             if isinstance(parsed, fiona.path.ParsedPath):
                 # If fiona is able to parse the path, we can safely look at the scheme
                 # and update it to have a zip scheme if necessary.
-                if not parsed.scheme:
-                    parsed.scheme = "zip"
-                elif "zip" not in parsed.scheme.split("+"):
-                    parsed.scheme = "zip+" + parsed.scheme
+                schemes = (parsed.scheme or "").split("+")
+                if "zip" not in schemes:
+                    parsed.scheme = "+".join(["zip"] + schemes)
                 filename = parsed.name
             elif isinstance(parsed, fiona.path.UnparsedPath) and not str(
                 filename

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -392,6 +392,13 @@ def test_infer_zipped_file():
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
+def test_allow_legacy_gdal_path():
+    # Construct a GDAL-style zip path.
+    path = "/vsizip/" + geopandas.datasets.get_path("nybb")[6:]
+    gdf = read_file(path)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
 def test_read_file_filtered(df_nybb):
     full_df_shape = df_nybb.shape
     nybb_filename = geopandas.datasets.get_path("nybb")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -304,6 +304,16 @@ def test_read_file_remote_geojson_url():
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
+@pytest.mark.web
+def test_read_file_remote_zipfile_url():
+    url = (
+        "https://raw.githubusercontent.com/geopandas/geopandas/"
+        "master/geopandas/datasets/nybb_16a.zip"
+    )
+    gdf = read_file(url)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
 def test_read_file_textio(file_path):
     file_text_stream = open(file_path)
     file_stringio = io.StringIO(open(file_path).read())
@@ -373,6 +383,7 @@ def test_read_text_file_fsspec(file_path):
         assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
+@pytest.mark.web
 def test_read_remote_text_file_fsspec():
     fsspec = pytest.importorskip("fsspec")
     url = (
@@ -389,6 +400,10 @@ def test_infer_zipped_file():
     # check it and add it back.
     path = geopandas.datasets.get_path("nybb")[6:]
     gdf = read_file(path)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
+    # Check that it can sucessfully add a zip scheme to a path that already has a scheme
+    gdf = read_file("file+file://" + path)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 
 import fiona
-import fsspec
 from shapely.geometry import Point, Polygon, box
 
 import geopandas
@@ -358,6 +357,7 @@ def test_read_file_tempfile():
 
 
 def test_read_binary_file_fsspec():
+    fsspec = pytest.importorskip("fsspec")
     # Remove the zip scheme so fsspec doesn't open as a zipped file,
     # instead we want to read as bytes and let fiona decode it.
     path = geopandas.datasets.get_path("nybb")[6:]
@@ -367,12 +367,14 @@ def test_read_binary_file_fsspec():
 
 
 def test_read_text_file_fsspec(file_path):
+    fsspec = pytest.importorskip("fsspec")
     with fsspec.open(file_path, "r") as f:
         gdf = read_file(f)
         assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
 def test_read_remote_text_file_fsspec():
+    fsspec = pytest.importorskip("fsspec")
     url = (
         "https://raw.githubusercontent.com/geopandas/geopandas/"
         "master/examples/null_geom.geojson"

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -406,6 +406,12 @@ def test_infer_zipped_file():
     gdf = read_file("file+file://" + path)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
+    # Check that it can add a zip scheme for a path that includes a subpath
+    # within the archive.
+    gdf = read_file(path + "!nybb.shp")
+    print(gdf)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
 
 def test_allow_legacy_gdal_path():
     # Construct a GDAL-style zip path.

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -383,18 +383,6 @@ def test_read_text_file_fsspec(file_path):
         assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
-@pytest.mark.web
-def test_read_remote_text_file_fsspec():
-    fsspec = pytest.importorskip("fsspec")
-    url = (
-        "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "master/examples/null_geom.geojson"
-    )
-    with fsspec.open(url, "r") as f:
-        gdf = read_file(f)
-        assert isinstance(gdf, geopandas.GeoDataFrame)
-
-
 def test_infer_zipped_file():
     # Remove the zip scheme so that the test for a zipped file can
     # check it and add it back.

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 import fiona
+import fsspec
 from shapely.geometry import Point, Polygon, box
 
 import geopandas
@@ -354,6 +355,39 @@ def test_read_file_tempfile():
     gdf_tempfile = geopandas.read_file(temp)
     assert isinstance(gdf_tempfile, geopandas.GeoDataFrame)
     temp.close()
+
+
+def test_read_binary_file_fsspec():
+    # Remove the zip scheme so fsspec doesn't open as a zipped file,
+    # instead we want to read as bytes and let fiona decode it.
+    path = geopandas.datasets.get_path("nybb")[6:]
+    with fsspec.open(path, "rb") as f:
+        gdf = read_file(f)
+        assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
+def test_read_text_file_fsspec(file_path):
+    with fsspec.open(file_path, "r") as f:
+        gdf = read_file(f)
+        assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
+def test_read_remote_text_file_fsspec():
+    url = (
+        "https://raw.githubusercontent.com/geopandas/geopandas/"
+        "master/examples/null_geom.geojson"
+    )
+    with fsspec.open(url, "r") as f:
+        gdf = read_file(f)
+        assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
+def test_infer_zipped_file():
+    # Remove the zip scheme so that the test for a zipped file can
+    # check it and add it back.
+    path = geopandas.datasets.get_path("nybb")[6:]
+    gdf = read_file(path)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
 def test_read_file_filtered(df_nybb):

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -409,7 +409,6 @@ def test_infer_zipped_file():
     # Check that it can add a zip scheme for a path that includes a subpath
     # within the archive.
     gdf = read_file(path + "!nybb.shp")
-    print(gdf)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
 


### PR DESCRIPTION
Fixes #1531.

This allows for more general file-like objects to be used than just those deriving from `TextIOBase`.

It also attempts to infer if a local file should be treated as a zip file and automatically adds a `zip://` scheme to the path. This is so that there is no longer a difference in how local and remote zipped files are handled.

~~The part of #1531 that it does not cover is the difference between how compound URLs are handled with respect to remote data. GeoPandas currently does not use the vsicurl OGR virtual filesystem, but instead downloads the data and feeds the bytes to fiona. I'm not sure which is better at the moment.~~

~~TODO: write tests~~