### PR TITLE
Remove failing test of duplicate columns on read of parquet

### DIFF
--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -416,22 +416,6 @@ def test_subset_columns(tmpdir, file_format):
         reader(filename, columns=["name"])
 
 
-def test_parquet_repeat_columns(tmpdir):
-    """Reading repeated columns should return first value of each repeated column
-    """
-
-    test_dataset = "naturalearth_lowres"
-    df = read_file(get_path(test_dataset))
-
-    filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename)
-
-    columns = ["name", "name", "iso_a3", "name", "geometry"]
-    pq_df = read_parquet(filename, columns=columns)
-
-    assert pq_df.columns.tolist() == ["name", "iso_a3", "geometry"]
-
-
 def test_promote_secondary_geometry(tmpdir, file_format):
     """Reading a subset of columns that does not include the primary geometry
     column should promote the first geometry column present.


### PR DESCRIPTION
Resolves #1536

This removes the test of reading multiple columns from parquet.  On `pyarrow<=0.17` requesting multiple columns was silently ignored and only unique columns were read.  On `pyarrow>=1.0` it raises a `ValueError`.

In either case, geopandas should propagate the behavior from the associated pyarrow version; there is no need for a test of this behavior here.