### PR TITLE
BUG: Add doc/source/_build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ examples/nybb_*.zip
 doc/source/gallery
 doc/source/savefig
 doc/source/reference
+doc/source/_build
 
 geopandas.egg-info
 geopandas/version.py


### PR DESCRIPTION
When I ran `make html` in doc during #1532 and #1533
and _build was generated.  I noticed that there is no
doc/source/_build in master so removed this
directory after building html prior to committing.

In the case that this directory should be ignored I've added
a line to .gitignore.  Otherwise please ignore this PR!