### PR TITLE
TST: Fix CI for pandas 1.1.0

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -12,7 +12,7 @@ import shapely
 
 PANDAS_GE_025 = str(pd.__version__) >= LooseVersion("0.25.0")
 PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("0.26.0.dev")
-PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0.dev")
+PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -279,7 +279,7 @@ def test_numerical_operations(s, df):
     with pytest.raises(TypeError):
         s.max()
 
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, ValueError)):
         s.idxmax()
 
     # numerical ops raise an error

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -272,7 +272,7 @@ def test_numerical_operations(s, df):
     exp = pd.Series([3, 4], index=["value1", "value2"])
     assert_series_equal(df.sum(), exp)
 
-    # series methods raise error
+    # series methods raise error (not supported for geometry)
     with pytest.raises(TypeError):
         s.sum()
 
@@ -280,6 +280,7 @@ def test_numerical_operations(s, df):
         s.max()
 
     with pytest.raises((TypeError, ValueError)):
+        # TODO: remove ValueError after pandas-dev/pandas#32749
         s.idxmax()
 
     # numerical ops raise an error


### PR DESCRIPTION
Closes #1543 
Closes #1541 

Fixed condition to check for pandas 1.1.0 version and added `ValueError` as an option for `idxmax`.