### PR TITLE
CI: pin mapclassify

### DIFF
--- a/ci/travis/36-pd025.yaml
+++ b/ci/travis/36-pd025.yaml
@@ -25,5 +25,5 @@ dependencies:
       - pyproj==2.3.1
       - codecov
       - geopy
-      - mapclassify>=2.2.0
+      - mapclassify==2.2.0
       - git+https://github.com/pygeos/pygeos.git


### PR DESCRIPTION
Closes #1542

Pin mapclassify coming from pip to 2.2.0. Newer requires pandas 1.0.