### PR TITLE
CLN: Remove unused make_valid argument

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -137,7 +137,7 @@ def _overlay_union(df1, df2):
     return dfunion.reindex(columns=columns)
 
 
-def overlay(df1, df2, how="intersection", make_valid=True, keep_geom_type=True):
+def overlay(df1, df2, how="intersection", keep_geom_type=True):
     """Perform spatial overlay between two GeoDataFrames.
 
     Currently only supports data GeoDataFrames with uniform geometry types,


### PR DESCRIPTION
While trying to figure out an issue with an overlay returning surprising results, I realized that the `make_valid` argument in overlay wasn't actually used anywhere. I can imagine some cases where there would be some utility in that, but let's remove it in the meantime. A question though: do we need to provide a deprecation warning first for removing an argument that hasn't actually been doing anything (and a quick search through history makes it unclear whether it has ever done anything, but I'm not sure
about that).