### PR TITLE
ENH: allow GeoDataFrame.dissolve(by=None)

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -934,7 +934,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Parameters
         ----------
         by : string, default None
-            Column whose values define groups to be dissolved
+            Column whose values define groups to be dissolved. If None,
+            whole GeoDataFrame is considered a single group.
         aggfunc : function or string, default "first"
             Aggregation function for manipulation of data associated
             with each group. Passed to pandas `groupby.agg` method.
@@ -945,6 +946,14 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         -------
         GeoDataFrame
         """
+
+        if by is None:
+            self["__dummy"] = True
+            by = "__dummy"
+            drop = True
+            as_index = False
+        else:
+            drop = False
 
         # Process non-spatial component
         data = self.drop(labels=self.geometry.name, axis=1)
@@ -966,7 +975,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         # Reset if requested
         if not as_index:
-            aggregated = aggregated.reset_index()
+            aggregated = aggregated.reset_index(drop=drop)
 
         return aggregated
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -948,12 +948,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
 
         if by is None:
-            self["__dummy"] = True
-            by = "__dummy"
-            drop = True
-            as_index = False
-        else:
-            drop = False
+            by = np.zeros(len(self), dtype="int64")
 
         # Process non-spatial component
         data = self.drop(labels=self.geometry.name, axis=1)
@@ -975,7 +970,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         # Reset if requested
         if not as_index:
-            aggregated = aggregated.reset_index(drop=drop)
+            aggregated = aggregated.reset_index()
 
         return aggregated
 

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -99,3 +99,32 @@ def test_reset_index(nybb_polydf, first):
     test = nybb_polydf.dissolve("manhattan_bronx", as_index=False)
     comparison = first.reset_index()
     assert_frame_equal(comparison, test, check_column_type=False)
+
+
+def test_dissolve_none(nybb_polydf):
+    test = nybb_polydf.dissolve(by=None)
+    expected = GeoDataFrame(
+        {
+            nybb_polydf.geometry.name: [nybb_polydf.geometry.unary_union],
+            "BoroName": ["Staten Island"],
+            "BoroCode": [5],
+            "manhattan_bronx": [5],
+        },
+        geometry=nybb_polydf.geometry.name,
+        crs=nybb_polydf.crs,
+    )
+    assert_frame_equal(expected, test, check_column_type=False)
+
+
+def test_dissolve_none_mean(nybb_polydf):
+    test = nybb_polydf.dissolve(aggfunc="mean")
+    expected = GeoDataFrame(
+        {
+            nybb_polydf.geometry.name: [nybb_polydf.geometry.unary_union],
+            "BoroCode": [3.0],
+            "manhattan_bronx": [5.4],
+        },
+        geometry=nybb_polydf.geometry.name,
+        crs=nybb_polydf.crs,
+    )
+    assert_frame_equal(expected, test, check_column_type=False)


### PR DESCRIPTION
Resolves #1380

If no column is passed to `GeoDataFrame.dissolve()`, whole GeoDataFrame is considered a single group and all geometries are dissolved to a single one. It is done using a `__dummy` column. Since `aggfunc` needs to be passed to `groupby`, we can't create gdf directly using `unary_union` and `agg` (e.g. `DataFrame.agg('first)` and `DataFrame.groupby.agg('first)` are different methods).