### PR TITLE
GHA: Automatic release to GitHub and PyPI

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -13,13 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.x"
 
       - name: Build a binary wheel and a source tarball
         run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
           python setup.py sdist bdist_wheel
 
       - name: Publish distribution to PyPI

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -22,7 +22,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel
-          python setup.py sdist bdist_wheel
+          python setup.py sdist
+          python setup.py bdist_wheel --universal
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -1,0 +1,29 @@
+name: Publish geopandas to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish geopandas to PyPI
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -28,4 +28,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel
-          python setup.py sdist
-          python setup.py bdist_wheel --universal
+          python setup.py sdist bdist_wheel
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -1,4 +1,4 @@
-name: Publish geopandas to PyPI
+name: Publish geopandas to PyPI / GitHub
 
 on:
   push:
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout source
+        uses: actions/checkout@v2
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -29,3 +30,31 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
+
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish geopandas to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Adding Github Actions workflow which pushes tagged release to PyPI automatically.

@jorisvandenbossche to make this work, I need you to add [PyPI API token](https://pypi.org/help/#apitoken) to `secrets` as `PYPI_PASSWORD`.

The release checklist would then be following (I'll update wiki once we merge):

<details>
Releasing:

* Make an empty release commit: ``git commit --allow-empty -m 'RLS: v0.2.1'``
* Tag the commit using an annotated tag. ``git tag -a v0.2.1 -m "Version 0.2.1"``
* Push the RLS commit ``git push upstream master``
* Also push the tag! ``git push upstream --tags ``
* Create sdist: ``python setup.py sdist``
* Make github release (ensure to add the sdist as asset)

Packaging:

* update on conda-forge should be done automatically once the github release is made
* update on PyPI should be done automatically once the github release is made (GitHub Action)
* update docs on readthedocs (trigger any build, to trigger that the new tag / version gets added)
* send announcement (based on the github release notes)

Update geopandas.org with the latest docs as well (push to gh-pages branch)
</details>

Note to the checklist: I think that RTD does not have to be triggered manually.