### PR TITLE
BUG: Copy legend_kwds so we don't update inplace

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -600,6 +600,10 @@ def plot_dataframe(
     else:
         ax.set_aspect(aspect)
 
+    # if legend_kwds set, copy so we don't update it in place
+    if legend_kwds is not None:
+        legend_kwds = legend_kwds.copy()
+
     if df.empty:
         warnings.warn(
             "The GeoDataFrame you are attempting to plot is "

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -600,6 +600,7 @@ def plot_dataframe(
     else:
         ax.set_aspect(aspect)
 
+    # GH 1555
     # if legend_kwds set, copy so we don't update it in place
     if legend_kwds is not None:
         legend_kwds = legend_kwds.copy()


### PR DESCRIPTION
Resolves #1555. In cases where legend_kwds was being passed, we were
updating legend_kwds with the cax/ax passed in on that function call.
Within a loop over multiple axes, this meant placing all colorbars on
the first placed axis. This just creates a copy of legend_kwds, when
placed, so we don't update in place.