### PR TITLE
DOC: Use the CRS.utm_zone property to identify UTM CRS

### DIFF
--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -465,11 +465,11 @@ Or to check if a CRS was a certain UTM zone:
 
    '+proj=utm ' in gdf.crs
 
-could be replaced with the longer but more robust check:
+could be replaced with the more robust check (requires pyproj 2.6+):
 
 .. code-block:: python
 
-   gdf.crs.is_projected and gdf.crs.coordinate_operation.name.upper().startswith('UTM')
+   gdf.crs.utm_zone
 
 And there are many other methods available on the ``pyproj.CRS`` class to get
 information about the CRS.

--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -469,7 +469,7 @@ could be replaced with the more robust check (requires pyproj 2.6+):
 
 .. code-block:: python
 
-   gdf.crs.utm_zone
+   gdf.crs.utm_zone is not None
 
 And there are many other methods available on the ``pyproj.CRS`` class to get
 information about the CRS.


### PR DESCRIPTION
I originally added an function `def is_utm(crs)` in the example as well based on [CRS.utm_zone](https://github.com/pyproj4/pyproj/blob/9389f9db058283679ca9f672f6f8798817ad753a/pyproj/crs/crs.py#L979-L990), but I thought it was pretty complex and probably better to just do this. Thoughts?