### PR TITLE
Check for duplicate column name in rename_geometry

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -289,10 +289,15 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         geodataframe : GeoDataFrame
         """
         geometry_col = self.geometry.name
-        if not inplace:
-            return self.rename(columns={geometry_col: col}).set_geometry(col, inplace)
-        self.rename(columns={geometry_col: col}, inplace=inplace)
-        self.set_geometry(col, inplace=inplace)
+        if col in self.columns:
+            raise ValueError("Column named %s already exists" % col)
+        else:
+            if not inplace:
+                return self.rename(columns={geometry_col: col}).set_geometry(
+                    col, inplace
+                )
+            self.rename(columns={geometry_col: col}, inplace=inplace)
+            self.set_geometry(col, inplace=inplace)
 
     @property
     def crs(self):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -290,7 +290,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         """
         geometry_col = self.geometry.name
         if col in self.columns:
-            raise ValueError("Column named %s already exists" % col)
+            raise ValueError(f"Column named {col} already exists")
         else:
             if not inplace:
                 return self.rename(columns={geometry_col: col}).set_geometry(

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -209,6 +209,13 @@ class TestDataFrame:
         assert df2 is None
         assert self.df.geometry.name == "new_name"
 
+        # existing column error
+        msg = "Column named Shape_Area already exists"
+        with pytest.raises(ValueError, match=msg):
+            df2 = self.df.rename_geometry("Shape_Area")
+        with pytest.raises(ValueError, match=msg):
+            self.df.rename_geometry("Shape_Area", inplace=True)
+
     def test_set_geometry(self):
         geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
         original_geom = self.df.geometry


### PR DESCRIPTION
Fixes #1593

Return a more meaningful error when an existing column is passed in `rename_geometry` 
added some tests for the same