### PR TITLE
ENH: Add basic driver detection for to_file

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1059,7 +1059,8 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             File path or file handle to write to.
         driver : string, default None
             The OGR format driver used to write the vector file.
-            If not specified, it attempt to infer it from the file extension.
+            If not specified, it attempts to infer it from the file extension.
+            If no extension is specified, it saves ESRI Shapefile to a folder.
         schema : dict, default: None
             If specified, the schema dictionary is passed to Fiona to
             better control how the file is written.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1043,9 +1043,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
 
         _to_feather(self, path, index=index, compression=compression, **kwargs)
 
-    def to_file(
-        self, filename, driver="ESRI Shapefile", schema=None, index=None, **kwargs
-    ):
+    def to_file(self, filename, driver=None, schema=None, index=None, **kwargs):
         """Write the ``GeoDataFrame`` to a file.
 
         By default, an ESRI shapefile is written, but any OGR data source
@@ -1059,8 +1057,9 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         ----------
         filename : string
             File path or file handle to write to.
-        driver : string, default: 'ESRI Shapefile'
+        driver : string, default None
             The OGR format driver used to write the vector file.
+            If not specified, it attempt to infer it from the file extension.
         schema : dict, default: None
             If specified, the schema dictionary is passed to Fiona to
             better control how the file is written.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -476,7 +476,7 @@ class GeoSeries(GeoPandasBase, Series):
 
         return GeoDataFrame({"geometry": self}).__geo_interface__
 
-    def to_file(self, filename, driver="ESRI Shapefile", index=None, **kwargs):
+    def to_file(self, filename, driver=None, index=None, **kwargs):
         """Write the ``GeoSeries`` to a file.
 
         By default, an ESRI shapefile is written, but any OGR data source
@@ -486,8 +486,9 @@ class GeoSeries(GeoPandasBase, Series):
         ----------
         filename : string
             File path or file handle to write to.
-        driver : string, default: 'ESRI Shapefile'
+        driver : string, default None
             The OGR format driver used to write the vector file.
+            If not specified, it attempt to infer it from the file extension.
         index : bool, default None
             If True, write index into one or more columns (for MultiIndex).
             Default None writes the index into one or more columns only if

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -488,7 +488,8 @@ class GeoSeries(GeoPandasBase, Series):
             File path or file handle to write to.
         driver : string, default None
             The OGR format driver used to write the vector file.
-            If not specified, it attempt to infer it from the file extension.
+            If not specified, it attempts to infer it from the file extension.
+            If no extension is specified, it saves ESRI Shapefile to a folder.
         index : bool, default None
             If True, write index into one or more columns (for MultiIndex).
             Default None writes the index into one or more columns only if

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -283,7 +283,8 @@ def _to_file(
         File path or file handle to write to.
     driver : string, default None
         The OGR format driver used to write the vector file.
-        If not specified, it attempt to infer it from the file extension.
+        If not specified, it attempts to infer it from the file extension.
+        If no extension is specified, it saves ESRI Shapefile to a folder.
     schema : dict, default None
         If specified, the schema dictionary is passed to Fiona to
         better control how the file is written. If None, GeoPandas

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -37,6 +37,31 @@ from urllib.parse import uses_netloc, uses_params, uses_relative
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")
 
+try:
+    from fiona.drvsupport import extension_to_driver as _EXTENSION_TO_DRIVER
+except ImportError:
+    _EXTENSION_TO_DRIVER = {
+        "bna": "BNA",
+        "dxf": "DXF",
+        "csv": "CSV",
+        "shp": "ESRI Shapefile",
+        "dbf": "ESRI Shapefile",
+        "json": "GeoJSON",
+        "geojson": "GeoJSON",
+        "geojsonl": "GeoJSONSeq",
+        "geojsons": "GeoJSONSeq",
+        "gpkg": "GPKG",
+        "gml": "GML",
+        "xml": "GML",
+        "gpx": "GPX",
+        "gtm": "GPSTrackMaker",
+        "gtz": "GPSTrackMaker",
+        "tab": "MapInfo File",
+        "mif": "MapInfo File",
+        "mid": "MapInfo File",
+        "dgn": "DGN",
+    }
+
 
 def _check_fiona(func):
     if fiona is None:
@@ -234,15 +259,6 @@ def to_file(*args, **kwargs):
     return _to_file(*args, **kwargs)
 
 
-_DRIVER_EXTENSION_MAP = {
-    ".shp": "ESRI Shapefile",
-    "": "ESRI Shapefile",  # shapefile folder
-    ".gpkg": "GPKG",
-    ".geojson": "GeoJSON",
-    ".json": "GeoJSON",
-}
-
-
 def _detect_driver(path):
     """
     Attempt to auto-detect driver based on the extension
@@ -253,10 +269,9 @@ def _detect_driver(path):
     except AttributeError:
         pass
     try:
-        return _DRIVER_EXTENSION_MAP[Path(path).suffix.lower()]
+        return _EXTENSION_TO_DRIVER[Path(path).suffix.lower()]
     except KeyError:
-        # pass to fiona to handle the missing driver
-        return None
+        return "ESRI Shapefile"  # assume it is a shapefile folder
 
 
 def _to_file(

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -236,8 +236,10 @@ def to_file(*args, **kwargs):
 
 _DRIVER_EXTENSION_MAP = {
     ".shp": "ESRI Shapefile",
+    "": "ESRI Shapefile",  # shapefile folder
     ".gpkg": "GPKG",
     ".geojson": "GeoJSON",
+    ".json": "GeoJSON",
 }
 
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -255,7 +255,8 @@ def _detect_driver(path):
     try:
         return _DRIVER_EXTENSION_MAP[Path(path).suffix.lower()]
     except KeyError:
-        raise RuntimeError("Unable to detect driver. Please specify driver.")
+        # pass to fiona to handle the missing driver
+        return None
 
 
 def _to_file(

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -37,30 +37,27 @@ from urllib.parse import uses_netloc, uses_params, uses_relative
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")
 
-try:
-    from fiona.drvsupport import extension_to_driver as _EXTENSION_TO_DRIVER
-except ImportError:
-    _EXTENSION_TO_DRIVER = {
-        "bna": "BNA",
-        "dxf": "DXF",
-        "csv": "CSV",
-        "shp": "ESRI Shapefile",
-        "dbf": "ESRI Shapefile",
-        "json": "GeoJSON",
-        "geojson": "GeoJSON",
-        "geojsonl": "GeoJSONSeq",
-        "geojsons": "GeoJSONSeq",
-        "gpkg": "GPKG",
-        "gml": "GML",
-        "xml": "GML",
-        "gpx": "GPX",
-        "gtm": "GPSTrackMaker",
-        "gtz": "GPSTrackMaker",
-        "tab": "MapInfo File",
-        "mif": "MapInfo File",
-        "mid": "MapInfo File",
-        "dgn": "DGN",
-    }
+_EXTENSION_TO_DRIVER = {
+    ".bna": "BNA",
+    ".dxf": "DXF",
+    ".csv": "CSV",
+    ".shp": "ESRI Shapefile",
+    ".dbf": "ESRI Shapefile",
+    ".json": "GeoJSON",
+    ".geojson": "GeoJSON",
+    ".geojsonl": "GeoJSONSeq",
+    ".geojsons": "GeoJSONSeq",
+    ".gpkg": "GPKG",
+    ".gml": "GML",
+    ".xml": "GML",
+    ".gpx": "GPX",
+    ".gtm": "GPSTrackMaker",
+    ".gtz": "GPSTrackMaker",
+    ".tab": "MapInfo File",
+    ".mif": "MapInfo File",
+    ".mid": "MapInfo File",
+    ".dgn": "DGN",
+}
 
 
 def _check_fiona(func):
@@ -271,7 +268,10 @@ def _detect_driver(path):
     try:
         return _EXTENSION_TO_DRIVER[Path(path).suffix.lower()]
     except KeyError:
-        return "ESRI Shapefile"  # assume it is a shapefile folder
+        # Assume it is a shapefile folder for now. In the future,
+        # will likely raise an exception when the expected
+        # folder writing behavior is more clearly defined.
+        return "ESRI Shapefile"
 
 
 def _to_file(

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -285,7 +285,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_empty_crs(tmpdir, driver, ext):
     """Test handling of undefined CRS with GPKG driver (GH #1975)."""
-    if driver == "GPKG":
+    if ext == ".gpkg":
         pytest.xfail("GPKG is read with Undefined geographic SRS.")
 
     tempfilename = os.path.join(str(tmpdir), "boros" + ext)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -817,5 +817,7 @@ def test_write_index_to_file(tmpdir, df_points, driver, ext):
 
 
 def test_to_file__undetermined_driver(tmp_path, df_nybb):
-    with pytest.raises(fiona.errors.DriverError):
-        df_nybb.to_file(tmp_path / "boros.invalid")
+    shpdir = tmp_path / "boros.invalid"
+    df_nybb.to_file(shpdir)
+    assert shpdir.is_dir()
+    assert list(shpdir.glob("*.shp"))

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -288,7 +288,7 @@ def test_empty_crs(tmpdir, driver, ext):
     if driver == "GPKG":
         pytest.xfail("GPKG is read with Undefined geographic SRS.")
 
-    tempfilename = os.path.join(str(tmpdir), "boros." + ext)
+    tempfilename = os.path.join(str(tmpdir), "boros" + ext)
     df = GeoDataFrame(
         {
             "a": [1, 2, 3],
@@ -299,7 +299,7 @@ def test_empty_crs(tmpdir, driver, ext):
     df.to_file(tempfilename, driver=driver)
     result = read_file(tempfilename)
 
-    if driver == "GeoJSON":
+    if ext == ".geojson":
         # geojson by default assumes epsg:4326
         df.crs = "EPSG:4326"
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -817,7 +817,5 @@ def test_write_index_to_file(tmpdir, df_points, driver, ext):
 
 
 def test_to_file__undetermined_driver(tmp_path, df_nybb):
-    with pytest.raises(
-        RuntimeError, match="Unable to detect driver. Please specify driver."
-    ):
+    with pytest.raises(fiona.errors.DriverError):
         df_nybb.to_file(tmp_path / "boros.invalid")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -120,9 +120,6 @@ def test_to_file_bool(tmpdir, driver, ext):
 
     df.to_file(tempfilename, driver=driver)
     result = read_file(tempfilename)
-    if ext.endswith("json"):
-        # geojson by default assumes epsg:4326
-        result.crs = None
     if ext in (".shp", ""):
         # Shapefile does not support boolean, so is read back as int
         df["b"] = df["b"].astype("int64")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -62,12 +62,13 @@ def df_points():
 # -----------------------------------------------------------------------------
 
 driver_ext_pairs = [
-    ("ESRI Shapefile", "shp"),
-    ("GeoJSON", "geojson"),
-    ("GPKG", "gpkg"),
-    (None, "shp"),
-    (None, "geojson"),
-    (None, "gpkg"),
+    ("ESRI Shapefile", ".shp"),
+    ("GeoJSON", ".geojson"),
+    ("GPKG", ".gpkg"),
+    (None, ".shp"),
+    (None, ""),
+    (None, ".geojson"),
+    (None, ".gpkg"),
 ]
 
 
@@ -83,7 +84,7 @@ def test_to_file(tmpdir, df_nybb, df_null, driver, ext):
     assert np.alltrue(df["BoroName"].values == df_nybb["BoroName"])
 
     # Write layer with null geometry out to file
-    tempfilename = os.path.join(str(tmpdir), "null_geom." + ext)
+    tempfilename = os.path.join(str(tmpdir), "null_geom" + ext)
     df_null.to_file(tempfilename, driver=driver)
     # Read layer back in
     df = GeoDataFrame.from_file(tempfilename)
@@ -119,10 +120,10 @@ def test_to_file_bool(tmpdir, driver, ext):
 
     df.to_file(tempfilename, driver=driver)
     result = read_file(tempfilename)
-    if ext == "geojson":
+    if ext.endswith("json"):
         # geojson by default assumes epsg:4326
         result.crs = None
-    if ext == "shp":
+    if ext in (".shp", ""):
         # Shapefile does not support boolean, so is read back as int
         df["b"] = df["b"].astype("int64")
     assert_geodataframe_equal(result, df)
@@ -143,7 +144,7 @@ def test_to_file_datetime(tmpdir):
 def test_to_file_with_point_z(tmpdir, ext, driver):
     """Test that 3D geometries are retained in writes (GH #612)."""
 
-    tempfilename = os.path.join(str(tmpdir), "test_3Dpoint." + ext)
+    tempfilename = os.path.join(str(tmpdir), "test_3Dpoint" + ext)
     point3d = Point(0, 0, 500)
     point2d = Point(1, 1)
     df = GeoDataFrame({"a": [1, 2]}, geometry=[point3d, point2d], crs=_CRS)
@@ -156,7 +157,7 @@ def test_to_file_with_point_z(tmpdir, ext, driver):
 def test_to_file_with_poly_z(tmpdir, ext, driver):
     """Test that 3D geometries are retained in writes (GH #612)."""
 
-    tempfilename = os.path.join(str(tmpdir), "test_3Dpoly." + ext)
+    tempfilename = os.path.join(str(tmpdir), "test_3Dpoly" + ext)
     poly3d = Polygon([[0, 0, 5], [0, 1, 5], [1, 1, 5], [1, 0, 5]])
     poly2d = Polygon([[0, 0], [0, 1], [1, 1], [1, 0]])
     df = GeoDataFrame({"a": [1, 2]}, geometry=[poly3d, poly2d], crs=_CRS)
@@ -258,7 +259,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     """Test to_file with append mode and from_file"""
     from fiona import supported_drivers
 
-    tempfilename = os.path.join(str(tmpdir), "boros." + ext)
+    tempfilename = os.path.join(str(tmpdir), "boros" + ext)
     driver = driver if driver else _detect_driver(tempfilename)
     if "a" not in supported_drivers[driver]:
         return None
@@ -273,7 +274,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert_geodataframe_equal(df, expected, check_less_precise=True)
 
     # Write layer with null geometry out to file
-    tempfilename = os.path.join(str(tmpdir), "null_geom." + ext)
+    tempfilename = os.path.join(str(tmpdir), "null_geom" + ext)
     df_null.to_file(tempfilename, driver=driver)
     df_null.to_file(tempfilename, mode="a", driver=driver)
     # Read layer back in


### PR DESCRIPTION
xref #1607

It doesn't support everything, but it does support the main 3 and raises an error when the extension is undetermined. I think the error will be very helpful to prevent https://github.com/geopandas/geopandas/issues/1607#issuecomment-688488076.