### PR TITLE
TST: Use less precise option for testing appending to file

### DIFF
--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -261,7 +261,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert "geometry" in df
     assert len(df) == (5 * 2)
     expected = pd.concat([df_nybb] * 2, ignore_index=True)
-    assert_geodataframe_equal(df, expected)
+    assert_geodataframe_equal(df, expected, check_less_precise=True)
 
     # Write layer with null geometry out to file
     tempfilename = os.path.join(str(tmpdir), "null_geom." + ext)
@@ -272,7 +272,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert "geometry" in df
     assert len(df) == (2 * 2)
     expected = pd.concat([df_null] * 2, ignore_index=True)
-    assert_geodataframe_equal(df, expected)
+    assert_geodataframe_equal(df, expected, check_less_precise=True)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1606

Due to adding `a` to the `GeoJSON` driver, the GeoJSON test was no longer skipped (https://github.com/Toblerity/Fiona/commit/79e1b5a2caf8cdcf525b6ee255215e0ab12dc8fc). It failed because one of the geometries was not exactly the same. This addresses the issue.