### PR TITLE
DOC: Prompt Contributor to Install Pre-commit

### DIFF
--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -206,7 +206,7 @@ can be done by installing ``pre-commit``::
 
    $ python -m pip install pre-commit
 
-See `<contributing_style>`
+See :ref:`Contributing Style <contributing.contributing_style>` for more information
 
 This should install all necessary dependencies.
 
@@ -294,7 +294,7 @@ submit a pull request to have them integrated into the *GeoPandas* code base.
 
 You can find a pull request (or PR) tutorial in the `GitHub's Help Docs <https://help.github.com/articles/using-pull-requests/>`_.
 
-.. _contributing_style:
+.. __contributing.contributing_style:
 
 Style Guide & Linting
 ---------------------

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -196,6 +196,18 @@ To run *GeoPandas* in an development environment, you must first install
 
     conda install -c conda-forge pandas fiona shapely pyproj rtree pytest
 
+Install development dependencies via::
+
+    pip install -r requirements-dev.txt
+
+Optionally (but recommended), you can setup `pre-commit hooks <https://pre-commit.com/>`_
+to automatically run ``black`` and ``flake8`` when you make a git commit. This
+can be done by installing ``pre-commit``::
+
+   $ python -m pip install pre-commit
+
+See `<contributing_style>`
+
 This should install all necessary dependencies.
 
 


### PR DESCRIPTION
I for one keep forgetting to blacken my code prior to submitting a PR which wastes CI resources needlessly...

If usage of `pre-commit` was forced upon me I could have skipped this as `black` would be run automatically.

This PR is prompted by me forgetting to blacken my code during #1610... 