### PR TITLE
ENH: speed up emptiness and size checks for rtree

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -256,7 +256,7 @@ if compat.HAS_RTREE:
                 size = self._size
             else:
                 # self.leaves are lists of tuples of (int, lists...)
-                # index [0][1] always has an element
+                # index [0][1] always has an element, even for empty sindex
                 # for an empty index, it will be an empty list
                 size = len(self.leaves()[0][1])
                 self._size = size

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -255,6 +255,9 @@ if compat.HAS_RTREE:
             if hasattr(self, "_size"):
                 size = self._size
             else:
+                # self.leaves are lists of tuples of (int, lists...)
+                # index [0][1] always has an element
+                # for an empty index, it will be an empty list
                 size = len(self.leaves()[0][1])
                 self._size = size
             return size

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -252,11 +252,16 @@ if compat.HAS_RTREE:
 
         @property
         def size(self):
-            return len(self.leaves()[0][1])
+            if hasattr(self, "_size"):
+                size = self._size
+            else:
+                size = len(self.leaves()[0][1])
+                self._size = size
+            return size
 
         @property
         def is_empty(self):
-            return self.size == 0
+            return self.geometries.size == 0 or self.size == 0
 
         def __len__(self):
             return self.size


### PR DESCRIPTION
Address points 2 & 3 of #1529. Point 1 requires unrelated changes to `Base` to check if it has a geometry column, then if that column has a spatial index generated or not.