### PR TITLE
CI: codecov yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%    # the required coverage value
+        threshold: 0.2%  # the leniency in hitting the target


### PR DESCRIPTION
Adding `codecov.yml` to avoid unintentional failure of the coverage check. There are common cases where codecov reports 100% coverage of the patch, but a decrease of coverage of the project (usually by 0.X%), causing check failure. We now require at least 95% coverage and allow 0.2% drop.

I still don't know why a bot does not comment, but it could be fixable via reconnecting Codecov integration in settings. cc @jorisvandenbossche 

Closes #1628 