### PR TITLE
BUG: is_ring returns False even for all LineStrings and LinearRings

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -477,7 +477,7 @@ def is_ring(data):
     warnings.warn(
         "is_ring currently returns True for Polygons, which is not correct. "
         "This will be corrected to False in a future release.",
-        FutureWarning,
+        FutureWarning, stacklevel=3
     )
     if compat.USE_PYGEOS:
         return pygeos.is_ring(data) | pygeos.is_ring(pygeos.get_exterior_ring(data))

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -474,11 +474,13 @@ def is_simple(data):
 
 
 def is_ring(data):
+    warnings.warn(
+        "is_ring currently returns True for Polygons, which is not correct. "
+        "This will be corrected to False in a future release.",
+        FutureWarning,
+    )
     if compat.USE_PYGEOS:
-        polygons = np.isin(pygeos.get_type_id(data), [3, 6])
-        copy_data = data.copy()
-        copy_data[polygons] = pygeos.get_exterior_ring(data[polygons])
-        return pygeos.is_ring(copy_data)
+        return pygeos.is_ring(data) | pygeos.is_ring(pygeos.get_exterior_ring(data))
     else:
         # for polygons operates on the exterior, so can't use _unary_op()
         results = []

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -474,11 +474,13 @@ def is_simple(data):
 
 
 def is_ring(data):
-    warnings.warn(
-        "is_ring currently returns True for Polygons, which is not correct. "
-        "This will be corrected to False in a future release.",
-        FutureWarning, stacklevel=3
-    )
+    if "Polygon" in geom_type(data):
+        warnings.warn(
+            "is_ring currently returns True for Polygons, which is not correct. "
+            "This will be corrected to False in a future release.",
+            FutureWarning,
+            stacklevel=3,
+        )
     if compat.USE_PYGEOS:
         return pygeos.is_ring(data) | pygeos.is_ring(pygeos.get_exterior_ring(data))
     else:

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -479,6 +479,22 @@ def test_unary_predicates(attr):
     assert result.tolist() == expected
 
 
+def test_is_ring():
+    g = [
+        shapely.geometry.LinearRing([(0, 0), (1, 1), (1, -1)]),
+        shapely.geometry.LineString([(0, 0), (1, 1), (1, -1)]),
+        shapely.geometry.LineString([(0, 0), (1, 1), (1, -1), (0, 0)]),
+        shapely.geometry.Polygon([(0, 0), (1, 1), (1, -1)]),
+        shapely.geometry.Polygon(),
+        None,
+    ]
+    expected = [True, False, True, True, False, False]
+
+    result = from_shapely(g).is_ring
+
+    assert result.tolist() == expected
+
+
 @pytest.mark.parametrize("attr", ["area", "length"])
 def test_unary_float(attr):
     na_value = np.nan


### PR DESCRIPTION
Fixes #1615 

Correctly assess `is_ring` based on geometry type. Directly for LineString and LinearRing, as the exterior for Polygon. No other geometry can return True by definition.