### PR TITLE
CI: schedule daily tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
   Linting:


### PR DESCRIPTION
On Travis we had a cron schedule to run tests daily, to catch potential issues. Setting the same on GHA.