### PR TITLE
BUG: fix overridden GeoSeries.apply method to accept convert_dtype keyword

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -313,8 +313,8 @@ class GeoSeries(GeoPandasBase, Series):
         return self._wrapped_pandas_method("select", *args, **kwargs)
 
     @inherit_doc(pd.Series)
-    def apply(self, func, args=(), **kwargs):
-        result = super().apply(func, args=args, **kwargs)
+    def apply(self, func, convert_dtype=True, args=(), **kwargs):
+        result = super().apply(func, convert_dtype=convert_dtype, args=args, **kwargs)
         if isinstance(result, GeoSeries):
             if self.crs is not None:
                 result.set_crs(self.crs, inplace=True)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -512,3 +512,9 @@ def test_apply_loc_len1(df):
     result = subset.apply(lambda geom: geom.is_empty)
     expected = subset.is_empty
     np.testing.assert_allclose(result, expected)
+
+
+def test_apply_convert_dtypes_keyword(s):
+    # ensure the convert_dtypes keyword is accepted
+    res = s.apply(lambda x: x, convert_dtype=True, args=())
+    assert_geoseries_equal(res, s)


### PR DESCRIPTION
When I added `GeoSeries.apply` in #1478, I apparently forgot one keyword that the pandas version has

To fix https://github.com/jsignell/dask-geopandas/issues/18, 