### PR TITLE
ENH: support both sqlalchemy Connection and Engine in to_postgis

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -577,7 +577,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Parameters
         ----------
         sql : string
-        con : DB connection object or SQLAlchemy engine
+        con : sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         geom_col : string, default 'geom'
             column name to convert to shapely geometries
         crs : optional
@@ -1455,7 +1455,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         ----------
         name : str
             Name of the target table.
-        con : sqlalchemy.engine.Engine
+        con : sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
             Active connection to the PostGIS database.
         if_exists : {'fail', 'replace', 'append'}, default 'fail'
             How to behave if the table already exists:

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -11,7 +11,7 @@ import pandas as pd
 import geopandas
 from geopandas import GeoDataFrame, read_file, read_postgis
 
-from geopandas.io.sql import _write_postgis as write_postgis
+from geopandas.io.sql import _get_conn as get_conn, _write_postgis as write_postgis
 from geopandas.tests.util import create_postgis, create_spatialite, validate_boro_df
 import pytest
 
@@ -111,11 +111,11 @@ def connection_spatialite():
     con.close()
 
 
-def drop_table_if_exists(engine, table):
+def drop_table_if_exists(conn_or_engine, table):
     sqlalchemy = pytest.importorskip("sqlalchemy")
 
-    if engine.has_table(table):
-        metadata = sqlalchemy.MetaData(engine)
+    if conn_or_engine.dialect.has_table(conn_or_engine, table):
+        metadata = sqlalchemy.MetaData(conn_or_engine)
         metadata.reflect()
         table = metadata.tables.get(table)
         if table is not None:
@@ -188,6 +188,19 @@ def df_3D_geoms():
 
 
 class TestIO:
+    def test_get_conn(self, engine_postgis):
+        Connection = pytest.importorskip("sqlalchemy.engine.base").Connection
+
+        engine = engine_postgis
+        with get_conn(engine) as output:
+            assert isinstance(output, Connection)
+        with engine.connect() as conn:
+            with get_conn(conn) as output:
+                assert isinstance(output, Connection)
+        with pytest.raises(ValueError):
+            with get_conn(object()):
+                pass
+
     def test_read_postgis_default(self, connection_postgis, df_nybb):
         con = connection_postgis
         create_postgis(con, df_nybb)
@@ -330,6 +343,21 @@ class TestIO:
         sql = "SELECT * FROM {table};".format(table=table)
         df = read_postgis(sql, engine, geom_col="geometry")
         validate_boro_df(df)
+
+    def test_write_postgis_sqlalchemy_connection(self, engine_postgis, df_nybb):
+        """Tests that GeoDataFrame can be written to PostGIS with defaults."""
+        with engine_postgis.begin() as con:
+            table = "nybb_con"
+
+            # If table exists, delete it before trying to write with defaults
+            drop_table_if_exists(con, table)
+
+            # Write to db
+            write_postgis(df_nybb, con=con, name=table, if_exists="fail")
+            # Validate
+            sql = "SELECT * FROM {table};".format(table=table)
+            df = read_postgis(sql, con, geom_col="geometry")
+            validate_boro_df(df)
 
     def test_write_postgis_fail_when_table_exists(self, engine_postgis, df_nybb):
         """


### PR DESCRIPTION
The `gdf.to_postgis` method/helpers were calling `.begin()`, which is not compatible between `Engine`s and `Connection`s (unfortunately...). This adds a little extra logic to ensure we retrieve the right value. This supports wrapping `to_postgis` calls within a larger transaction/connection.

I also replaced the (to be [deprecated in 1.14](https://github.com/sqlalchemy/sqlalchemy/blob/cea03be/doc/build/changelog/unreleased_14/4755.rst)) `run_callable` use. Even though `Connectable.has_table` method will also be deprecated, the `dialect` one doesn't seem to be.

Hmm, test failures seem unrelated(?)