### PR TITLE
CI: keep pygeos master in dev environment only

### DIFF
--- a/ci/travis/36-pd025.yaml
+++ b/ci/travis/36-pd025.yaml
@@ -22,8 +22,8 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow
+  - pygeos
   - pip:
       - pyproj==2.3.1
       - geopy
       - mapclassify==2.2.0
-      - git+https://github.com/pygeos/pygeos.git

--- a/ci/travis/36-pd025.yaml
+++ b/ci/travis/36-pd025.yaml
@@ -22,8 +22,8 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow
-  - pygeos
   - pip:
       - pyproj==2.3.1
       - geopy
       - mapclassify==2.2.0
+      - pygeos

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -22,7 +22,8 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow
+  - pygeos
   - pip:
     - geopy
     - mapclassify
-    - git+https://github.com/pygeos/pygeos.git
+    - pygeos

--- a/ci/travis/37-latest-defaults.yaml
+++ b/ci/travis/37-latest-defaults.yaml
@@ -22,8 +22,7 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow
-  - pygeos
   - pip:
-    - geopy
-    - mapclassify
-    - pygeos
+      - geopy
+      - mapclassify
+      - pygeos


### PR DESCRIPTION
Keeping pygeos installed from github master only in dev environment. The recent change on pygeos master killed our CI.