### PR TITLE
BUG: fix geom types codes for pygeos master

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -38,7 +38,10 @@ _names = {
 if compat.USE_PYGEOS:
     type_mapping = {p.value: _names[p.name] for p in pygeos.GeometryType}
     geometry_type_ids = list(type_mapping.keys())
-    geometry_type_values = np.array(list(type_mapping.values()), dtype=object)
+    geometry_type_ids.insert(0, -1)
+    type_mapping_list = list(type_mapping.values())
+    type_mapping_list.insert(0, None)
+    geometry_type_values = np.array(type_mapping_list, dtype=object)
 else:
     type_mapping, geometry_type_ids, geometry_type_values = None, None, None
 


### PR DESCRIPTION
Fixes #1640

PyGEOS now returns -1 for missing geometry on geom_type check. Adding it to our mapping. Since it is fixing a bunch of failing tests, I guess no new tests are needed.