### PR TITLE
BUG: fix pygeos geom types mapping

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -24,6 +24,7 @@ except ImportError:
 
 
 _names = {
+    "MISSING": None,
     "NAG": None,
     "POINT": "Point",
     "LINESTRING": "LineString",
@@ -38,10 +39,7 @@ _names = {
 if compat.USE_PYGEOS:
     type_mapping = {p.value: _names[p.name] for p in pygeos.GeometryType}
     geometry_type_ids = list(type_mapping.keys())
-    geometry_type_ids.insert(0, -1)
-    type_mapping_list = list(type_mapping.values())
-    type_mapping_list.insert(0, None)
-    geometry_type_values = np.array(type_mapping_list, dtype=object)
+    geometry_type_values = np.array(list(type_mapping.values()), dtype=object)
 else:
     type_mapping, geometry_type_ids, geometry_type_values = None, None, None
 


### PR DESCRIPTION
Continuation of #1641. Pygeos now put `-1` back, just as `MISSING`. This should be backward compatible.

ref https://github.com/pygeos/pygeos/pull/204