### PR TITLE
DOC/CI: enable doctest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,7 +93,7 @@ jobs:
           USE_PYGEOS: 0
         run: |
           source activate test
-          pytest -v -r s -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+          pytest -v -r s -n auto --doctest-modules --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with PyGEOS
         shell: bash
@@ -103,7 +103,7 @@ jobs:
           USE_PYGEOS: 1
         run: |
           source activate test
-          pytest -v -r s -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+          pytest -v -r s -n auto --doctest-modules --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with PostGIS
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,6 +116,15 @@ jobs:
           source activate test
           conda install postgis -c conda-forge
           source ci/travis/setup_postgres.sh
-          pytest -v -r s --doctest-modules -color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
+          pytest -v -r s -color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
+      - name: Test doctsrings
+        shell: bash
+        if: contains(matrix.env, '38-latest-conda-forge.yaml') && contains(matrix.os, 'ubuntu')
+        env:
+          USE_PYGEOS: 1
+        run: |
+          source activate test
+          pytest --doctest-only geopandas --ignore=geopandas/datasets
+      
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -116,7 +116,7 @@ jobs:
           source activate test
           conda install postgis -c conda-forge
           source ci/travis/setup_postgres.sh
-          pytest -v -r s -color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
+          pytest -v -r s --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
       - name: Test doctsrings
         shell: bash
@@ -125,6 +125,6 @@ jobs:
           USE_PYGEOS: 1
         run: |
           source activate test
-          pytest --doctest-only geopandas --ignore=geopandas/datasets
+          pytest -v --color=yes --doctest-only geopandas --ignore=geopandas/datasets
       
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1.0.5
+        uses: s-weigand/setup-conda@v1.0.4
         with:
           activate-conda: false
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1.0.4
+        uses: s-weigand/setup-conda@v1.0.5
         with:
           activate-conda: false
 
@@ -93,7 +93,7 @@ jobs:
           USE_PYGEOS: 0
         run: |
           source activate test
-          pytest -v -r s -n auto --doctest-modules --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+          pytest -v -r s -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with PyGEOS
         shell: bash
@@ -103,7 +103,7 @@ jobs:
           USE_PYGEOS: 1
         run: |
           source activate test
-          pytest -v -r s -n auto --doctest-modules --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+          pytest -v -r s -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with PostGIS
         shell: bash
@@ -116,6 +116,6 @@ jobs:
           source activate test
           conda install postgis -c conda-forge
           source ci/travis/setup_postgres.sh
-          pytest -v -r s -color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
+          pytest -v -r s --doctest-modules -color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
       - uses: codecov/codecov-action@v1

--- a/ci/travis/38-latest-conda-forge.yaml
+++ b/ci/travis/38-latest-conda-forge.yaml
@@ -27,6 +27,5 @@ dependencies:
   - libspatialite
   - geoalchemy2
   - pyarrow
-  - pip
-  - pip:
-      - pytest-doctestplus
+  # doctest testing
+  - pytest-doctestplus

--- a/ci/travis/38-latest-conda-forge.yaml
+++ b/ci/travis/38-latest-conda-forge.yaml
@@ -27,4 +27,6 @@ dependencies:
   - libspatialite
   - geoalchemy2
   - pyarrow
- 
+  - pip
+  - pip:
+      - pytest-doctestplus

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -29,13 +29,17 @@ from . import _compat as compat
 from . import _vectorized as vectorized
 from .sindex import get_sindex_class
 
-import geopandas
-import pytest
+try:
+    import pytest
+    import geopandas
+
+    @pytest.fixture(autouse=True)
+    def add_geopandas(doctest_namespace):
+        doctest_namespace["geopandas"] = geopandas
 
 
-@pytest.fixture(autouse=True)
-def add_geopandas(doctest_namespace):
-    doctest_namespace["geopandas"] = geopandas
+except ImportError:
+    pass
 
 
 class GeometryDtype(ExtensionDtype):

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -29,6 +29,14 @@ from . import _compat as compat
 from . import _vectorized as vectorized
 from .sindex import get_sindex_class
 
+import geopandas
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas
+
 
 class GeometryDtype(ExtensionDtype):
     type = BaseGeometry
@@ -243,10 +251,17 @@ def points_from_xy(x, y, z=None, crs=None):
 
     Examples
     --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'x': [0, 1, 2], 'y': [0, 1, 2], 'z': [0, 1, 2]})
+    >>> df
+       x  y  z
+    0  0  0  0
+    1  1  1  1
+    2  2  2  2
     >>> geometry = geopandas.points_from_xy(x=[1, 0], y=[0, 1])
     >>> geometry = geopandas.points_from_xy(df['x'], df['y'], df['z'])
     >>> gdf = geopandas.GeoDataFrame(
-            df, geometry=geopandas.points_from_xy(df['x'], df['y']))
+    ...     df, geometry=geopandas.points_from_xy(df['x'], df['y']))
 
     Returns
     -------

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -29,18 +29,6 @@ from . import _compat as compat
 from . import _vectorized as vectorized
 from .sindex import get_sindex_class
 
-try:
-    import pytest
-    import geopandas
-
-    @pytest.fixture(autouse=True)
-    def add_geopandas(doctest_namespace):
-        doctest_namespace["geopandas"] = geopandas
-
-
-except ImportError:
-    pass
-
 
 class GeometryDtype(ExtensionDtype):
     type = BaseGeometry

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -8,10 +8,10 @@ from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
 
+import geopandas as gpd
+
 from .array import GeometryArray, GeometryDtype
 from .sindex import has_sindex
-
-import geopandas
 
 # for backwards compat
 # this will be static (will NOT follow USE_PYGEOS changes)
@@ -1219,7 +1219,7 @@ GeometryCollection
             index.extend(idxs)
             geometries.extend(geoms)
         index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-        return geopandas.GeoSeries(geometries, index=index).__finalize__(self)
+        return gpd.GeoSeries(geometries, index=index).__finalize__(self)
 
     @property
     def cx(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -8,10 +8,17 @@ from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
 
-import geopandas as gpd
-
 from .array import GeometryArray, GeometryDtype
 from .sindex import has_sindex
+
+import geopandas
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas
+
 
 # for backwards compat
 # this will be static (will NOT follow USE_PYGEOS changes)
@@ -142,7 +149,7 @@ class GeoPandasBase(object):
         Examples
         --------
 
-        >>> s.crs
+        >>> s.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
         Axis Info [ellipsoidal]:
@@ -175,9 +182,9 @@ class GeoPandasBase(object):
         ... LineString([(0, 0), (1, 1)])]}
         >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
         >>> gdf.geom_type
-        0                 Point
-        1               Polygon
-        2            LineString
+        0         Point
+        1       Polygon
+        2    LineString
         dtype: object
         """
         return _delegate_property("geom_type", self)
@@ -210,7 +217,7 @@ GeometryCollection
         >>> s
         0    LINESTRING (0.00000 0.00000, 1.00000 1.00000, ...
         1    LINESTRING (10.00000 0.00000, 10.00000 5.00000...
-        2    MULTILINESTRING ((0.00000 0.00000, 1.00000 1.0...
+        2    MULTILINESTRING ((0.00000 0.00000, 1.00000 0.0...
         3    POLYGON ((0.00000 0.00000, 1.00000 1.00000, 0....
         4                              POINT (0.00000 1.00000)
         5    GEOMETRYCOLLECTION (POINT (1.00000 0.00000), L...
@@ -351,8 +358,8 @@ GeometryCollection
 
         >>> s.is_ring
         0    False
-        1    True
-        2    True
+        1     True
+        2     True
         dtype: bool
 
         """
@@ -480,6 +487,7 @@ GeometryCollection
         2    MULTIPOINT (0.00000 0.00000, 1.00000 1.00000, ...
         3        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
         4                              POINT (0.00000 0.00000)
+        dtype: geometry
 
         >>> s.convex_hull
         0    POLYGON ((0.00000 0.00000, 0.00000 1.00000, 1....
@@ -1188,17 +1196,21 @@ GeometryCollection
 
         Examples
         --------
-        >>> gdf  # gdf is GeoSeries of MultiPoints
-        0         MULTIPOINT (0 0, 1 1)
-        1    MULTIPOINT (2 2, 3 3, 4 4)
+        >>> from shapely.geometry import MultiPoint
+        >>> s = geopandas.GeoSeries(
+        ...     [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
+        ... )
+        >>> s
+        0        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
+        1    MULTIPOINT (2.00000 2.00000, 3.00000 3.00000, ...
         dtype: geometry
 
-        >>> gdf.explode()
-        0  0    POINT (0 0)
-           1    POINT (1 1)
-        1  0    POINT (2 2)
-           1    POINT (3 3)
-           2    POINT (4 4)
+        >>> s.explode()
+        0  0    POINT (0.00000 0.00000)
+           1    POINT (1.00000 1.00000)
+        1  0    POINT (2.00000 2.00000)
+           1    POINT (3.00000 3.00000)
+           2    POINT (4.00000 4.00000)
         dtype: geometry
 
         """
@@ -1214,7 +1226,7 @@ GeometryCollection
             index.extend(idxs)
             geometries.extend(geoms)
         index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-        return gpd.GeoSeries(geometries, index=index).__finalize__(self)
+        return geopandas.GeoSeries(geometries, index=index).__finalize__(self)
 
     @property
     def cx(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -11,13 +11,17 @@ from shapely.ops import cascaded_union
 from .array import GeometryArray, GeometryDtype
 from .sindex import has_sindex
 
-import geopandas
-import pytest
+try:
+    import pytest
+    import geopandas
+
+    @pytest.fixture(autouse=True)
+    def add_geopandas(doctest_namespace):
+        doctest_namespace["geopandas"] = geopandas
 
 
-@pytest.fixture(autouse=True)
-def add_geopandas(doctest_namespace):
-    doctest_namespace["geopandas"] = geopandas
+except ImportError:
+    pass
 
 
 # for backwards compat

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -11,18 +11,7 @@ from shapely.ops import cascaded_union
 from .array import GeometryArray, GeometryDtype
 from .sindex import has_sindex
 
-try:
-    import pytest
-    import geopandas
-
-    @pytest.fixture(autouse=True)
-    def add_geopandas(doctest_namespace):
-        doctest_namespace["geopandas"] = geopandas
-
-
-except ImportError:
-    pass
-
+import geopandas
 
 # for backwards compat
 # this will be static (will NOT follow USE_PYGEOS changes)

--- a/geopandas/conftest.py
+++ b/geopandas/conftest.py
@@ -1,9 +1,0 @@
-def pytest_ignore_collect(path):
-    """
-    Pytest doctest configuration to skip test of docstrings in certain files.
-    """
-    if "datasets" in str(path):
-        return True
-    if "test_api" in str(path):
-        return True
-    return False

--- a/geopandas/conftest.py
+++ b/geopandas/conftest.py
@@ -1,0 +1,9 @@
+def pytest_ignore_collect(path):
+    """
+    Pytest doctest configuration to skip test of docstrings in certain files.
+    """
+    if "datasets" in str(path):
+        return True
+    if "test_api" in str(path):
+        return True
+    return False

--- a/geopandas/conftest.py
+++ b/geopandas/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import geopandas
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -17,6 +17,14 @@ from geopandas.geoseries import GeoSeries
 import geopandas.io
 from geopandas.plotting import plot_dataframe
 
+import geopandas
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas
+
 
 DEFAULT_GEO_COLUMN_NAME = "geometry"
 
@@ -337,7 +345,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Examples
         --------
 
-        >>> gdf.crs
+        >>> gdf.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
         Axis Info [ellipsoidal]:
@@ -1209,7 +1217,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         2  name1  POINT (0.00000 1.00000)
 
         >>> dissolved = gdf.dissolve('col1')
-        >>> dissolved
+        >>> dissolved  # doctest: +SKIP
                                                     geometry
         col1
         name1  MULTIPOINT (0.00000 1.00000, 1.00000 2.00000)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -232,7 +232,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Using existing column:
 
         >>> gdf["buffered"] = gdf.buffer(2)
-        >>> df2 = df.set_geometry("buffered")
+        >>> df2 = gdf.set_geometry("buffered")
         >>> df2.geometry
         0    POLYGON ((3.00000 2.00000, 2.99037 1.80397, 2....
         1    POLYGON ((4.00000 1.00000, 3.99037 0.80397, 3....
@@ -308,6 +308,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Examples
         --------
+        >>> from shapely.geometry import Point
+        >>> d = {'col1': ['name1', 'name2'], 'geometry': [Point(1, 2), Point(2, 1)]}
+        >>> df = geopandas.GeoDataFrame(d, crs="EPSG:4326")
         >>> df1 = df.rename_geometry('geom1')
         >>> df1.geometry.name
         'geom1'
@@ -507,7 +510,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         ... }
         >>> df = geopandas.GeoDataFrame.from_features(feature_coll)
         >>> df
-                        geometry   col1
+                          geometry   col1
         0  POINT (1.00000 2.00000)  name1
         1  POINT (2.00000 1.00000)  name2
 
@@ -584,9 +587,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         Examples
         --------
         >>> sql = "SELECT geom, highway FROM roads"
+
         SpatiaLite
         >>> sql = "SELECT ST_Binary(geom) AS geom, highway FROM roads"
-        >>> df = geopandas.GeoDataFrame.from_postgis(sql, con)
+        >>> df = geopandas.GeoDataFrame.from_postgis(sql, con)  # doctest: +SKIP
         """
 
         df = geopandas.io.sql._read_postgis(
@@ -816,7 +820,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         Examples
         --------
 
-        >>> gdf.to_parquet('data.parquet')
+        >>> gdf.to_parquet('data.parquet')  # doctest: +SKIP
         """
 
         from geopandas.io.arrow import _to_parquet
@@ -859,7 +863,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         Examples
         --------
 
-        >>> gdf.to_feather('data.feather')
+        >>> gdf.to_feather('data.feather')  # doctest: +SKIP
         """
 
         from geopandas.io.arrow import _to_feather
@@ -876,7 +880,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         providers is available via:
 
         >>> import fiona
-        >>> fiona.supported_drivers
+        >>> fiona.supported_drivers  # doctest: +SKIP
 
         Parameters
         ----------
@@ -913,11 +917,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         Examples
         --------
 
-        >>> gdf.to_file('dataframe.shp')
+        >>> gdf.to_file('dataframe.shp')  # doctest: +SKIP
 
-        >>> gdf.to_file('dataframe.gpkg', driver='GPKG', layer='name1')
+        >>> gdf.to_file('dataframe.gpkg', driver='GPKG', layer='name')  # doctest: +SKIP
 
-        >>> gdf.to_file('dataframe.geojson', driver='GeoJSON')
+        >>> gdf.to_file('dataframe.geojson', driver='GeoJSON')  # doctest: +SKIP
         """
         from geopandas.io.file import _to_file
 
@@ -965,7 +969,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         True
 
         >>> gdf = gdf.set_crs('epsg:3857')
-        >>> gdf.crs
+        >>> gdf.crs  # doctest: +SKIP
         <Projected CRS: EPSG:3857>
         Name: WGS 84 / Pseudo-Mercator
         Axis Info [cartesian]:
@@ -1033,9 +1037,9 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         >>> gdf = geopandas.GeoDataFrame(d, crs=4326)
         >>> gdf
             col1                 geometry
-        0  name1  POINT (1.00000 1.00000)
-        1  name2  POINT (2.00000 2.00000)
-        >>> gdf.crs
+        0  name1  POINT (1.00000 2.00000)
+        1  name2  POINT (2.00000 1.00000)
+        >>> gdf.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
         Axis Info [ellipsoidal]:
@@ -1053,7 +1057,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             col1                       geometry
         0  name1  POINT (111319.491 222684.209)
         1  name2  POINT (222638.982 111325.143)
-        >>> gdf.crs
+        >>> gdf.crs  # doctest: +SKIP
         <Projected CRS: EPSG:3857>
         Name: WGS 84 / Pseudo-Mercator
         Axis Info [cartesian]:
@@ -1394,8 +1398,8 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
 
         >>> from sqlalchemy import create_engine
         >>> engine = create_engine("postgres://myusername:mypassword@myhost:5432\
-/mydatabase";)
-        >>> gdf.to_postgis("my_table", engine)
+/mydatabase")  # doctest: +SKIP
+        >>> gdf.to_postgis("my_table", engine)  # doctest: +SKIP
         """
         geopandas.io.sql._write_postgis(
             self, name, con, schema, if_exists, index, index_label, chunksize, dtype

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -17,14 +17,6 @@ from geopandas.geoseries import GeoSeries
 import geopandas.io
 from geopandas.plotting import plot_dataframe
 
-import geopandas
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def add_geopandas(doctest_namespace):
-    doctest_namespace["geopandas"] = geopandas
-
 
 DEFAULT_GEO_COLUMN_NAME = "geometry"
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -430,7 +430,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         >>> path = geopandas.datasets.get_path('nybb')
         >>> gdf = geopandas.GeoDataFrame.from_file(path)
-        >>> gdf
+        >>> gdf  # doctest: +SKIP
            BoroCode       BoroName     Shape_Leng    Shape_Area                 \
                           geometry
         0         5  Staten Island  330470.010332  1.623820e+09  MULTIPOLYGON ((\

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -651,7 +651,6 @@ class GeoSeries(GeoPandasBase, Series):
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
 
-
         Overriding existing CRS:
 
         >>> s = s.set_crs(4326, allow_override=True)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -16,6 +16,14 @@ from .array import GeometryArray, GeometryDtype, from_shapely
 from .base import is_geometry_type
 from . import _vectorized as vectorized
 
+import geopandas
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas
+
 
 _SERIES_WARNING_MSG = """\
     You are passing non-geometry data to the GeoSeries constructor. Currently,
@@ -85,9 +93,9 @@ class GeoSeries(GeoPandasBase, Series):
     >>> from shapely.geometry import Point
     >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
     >>> s
-    0    POINT (1 1)
-    1    POINT (2 2)
-    2    POINT (3 3)
+    0    POINT (1.00000 1.00000)
+    1    POINT (2.00000 2.00000)
+    2    POINT (3.00000 3.00000)
     dtype: geometry
 
     See Also
@@ -345,11 +353,11 @@ class GeoSeries(GeoPandasBase, Series):
         Examples
         --------
 
-        >>> s.to_file('series.shp')
+        >>> s.to_file('series.shp')  # doctest: +SKIP
 
-        >>> s.to_file('series.gpkg', driver='GPKG', layer='name1')
+        >>> s.to_file('series.gpkg', driver='GPKG', layer='name1')  # doctest: +SKIP
 
-        >>> s.to_file('series.geojson', driver='GeoJSON')
+        >>> s.to_file('series.geojson', driver='GeoJSON')  # doctest: +SKIP
         """
         from geopandas import GeoDataFrame
 
@@ -382,7 +390,7 @@ class GeoSeries(GeoPandasBase, Series):
     def __getitem__(self, key):
         return self._wrapped_pandas_method("__getitem__", key)
 
-    @inherit_doc(pd.Series)
+    # @inherit_doc(pd.Series) - doctest failure
     def sort_index(self, *args, **kwargs):
         return self._wrapped_pandas_method("sort_index", *args, **kwargs)
 
@@ -627,6 +635,7 @@ class GeoSeries(GeoPandasBase, Series):
         0    POINT (1.00000 1.00000)
         1    POINT (2.00000 2.00000)
         2    POINT (3.00000 3.00000)
+        dtype: geometry
 
         Setting CRS to a GeoSeries without one:
 
@@ -634,7 +643,7 @@ class GeoSeries(GeoPandasBase, Series):
         True
 
         >>> s = s.set_crs('epsg:3857')
-        >>> s.crs
+        >>> s.crs  # doctest: +SKIP
         <Projected CRS: EPSG:3857>
         Name: WGS 84 / Pseudo-Mercator
         Axis Info [cartesian]:
@@ -649,6 +658,7 @@ class GeoSeries(GeoPandasBase, Series):
         Datum: World Geodetic System 1984
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
+
 
         Overriding existing CRS:
 
@@ -714,7 +724,8 @@ class GeoSeries(GeoPandasBase, Series):
         0    POINT (1.00000 1.00000)
         1    POINT (2.00000 2.00000)
         2    POINT (3.00000 3.00000)
-        >>> s.crs
+        dtype: geometry
+        >>> s.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
         Axis Info [ellipsoidal]:
@@ -732,7 +743,8 @@ class GeoSeries(GeoPandasBase, Series):
         0    POINT (111319.491 111325.143)
         1    POINT (222638.982 222684.209)
         2    POINT (333958.472 334111.171)
-        >>> s.crs
+        dtype: geometry
+        >>> s.crs  # doctest: +SKIP
         <Projected CRS: EPSG:3857>
         Name: WGS 84 / Pseudo-Mercator
         Axis Info [cartesian]:
@@ -792,6 +804,7 @@ class GeoSeries(GeoPandasBase, Series):
         0    POINT (1.00000 1.00000)
         1    POINT (2.00000 2.00000)
         2    POINT (3.00000 3.00000)
+        dtype: geometry
 
         >>> s.to_json()
         '{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "pr\

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -16,13 +16,18 @@ from .array import GeometryArray, GeometryDtype, from_shapely
 from .base import is_geometry_type
 from . import _vectorized as vectorized
 
-import geopandas
-import pytest
+
+try:
+    import pytest
+    import geopandas
+
+    @pytest.fixture(autouse=True)
+    def add_geopandas(doctest_namespace):
+        doctest_namespace["geopandas"] = geopandas
 
 
-@pytest.fixture(autouse=True)
-def add_geopandas(doctest_namespace):
-    doctest_namespace["geopandas"] = geopandas
+except ImportError:
+    pass
 
 
 _SERIES_WARNING_MSG = """\

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -382,7 +382,7 @@ class GeoSeries(GeoPandasBase, Series):
     def __getitem__(self, key):
         return self._wrapped_pandas_method("__getitem__", key)
 
-    # @inherit_doc(pd.Series) - doctest failure
+    @inherit_doc(pd.Series)
     def sort_index(self, *args, **kwargs):
         return self._wrapped_pandas_method("sort_index", *args, **kwargs)
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -17,19 +17,6 @@ from .base import is_geometry_type
 from . import _vectorized as vectorized
 
 
-try:
-    import pytest
-    import geopandas
-
-    @pytest.fixture(autouse=True)
-    def add_geopandas(doctest_namespace):
-        doctest_namespace["geopandas"] = geopandas
-
-
-except ImportError:
-    pass
-
-
 _SERIES_WARNING_MSG = """\
     You are passing non-geometry data to the GeoSeries constructor. Currently,
     it falls back to returning a pandas Series. But in the future, we will start

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -77,7 +77,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
 
     Examples
     --------
-    >>> df = geopandas.read_file("nybb.shp")
+    >>> df = geopandas.read_file("nybb.shp")  # doctest: +SKIP
 
     Returns
     -------
@@ -212,7 +212,7 @@ def _to_file(
 
     A dictionary of supported OGR providers is available via:
     >>> import fiona
-    >>> fiona.supported_drivers
+    >>> fiona.supported_drivers  # doctest: +SKIP
 
     Parameters
     ----------

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -107,9 +107,10 @@ def _read_postgis(
     --------
     PostGIS
     >>> sql = "SELECT geom, kind FROM polygons"
+
     SpatiaLite
     >>> sql = "SELECT ST_AsBinary(geom) AS geom, kind FROM polygons"
-    >>> df = geopandas.read_postgis(sql, con)
+    >>> df = geopandas.read_postgis(sql, con)  # doctest: +SKIP
     """
 
     if chunksize is None:
@@ -322,10 +323,10 @@ def _write_postgis(
     Examples
     --------
 
-    >>> from sqlalchemy import create_engine
+    >>> from sqlalchemy import create_engine  # doctest: +SKIP
     >>> engine = create_engine("postgres://myusername:mypassword@myhost:5432\
-/mydatabase";)
-    >>> gdf.to_postgis("my_table", engine)
+/mydatabase";)  # doctest: +SKIP
+    >>> gdf.to_postgis("my_table", engine)  # doctest: +SKIP
     """
     try:
         from geoalchemy2 import Geometry

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -9,7 +9,7 @@ def test_no_additional_imports():
     # development dependencies
     blacklist = {
         # "pytest", # pytest gets imported if installed
-        # "py", # py gets imported if installed
+        # "py", # py gets imported by pytest if installed
         "ipython",
         # "matplotlib",  # matplotlib gets imported by pandas, see below
         "descartes",

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -8,10 +8,10 @@ def test_no_additional_imports():
     # test that 'import geopandas' does not import any of the optional or
     # development dependencies
     blacklist = {
-        "pytest",
-        "py",
+        # "pytest", # pytest gets imported if installed
+        # "py", # py gets imported if installed
         "ipython",
-        # 'matplotlib',  # matplotlib gets imported by pandas, see below
+        "matplotlib",  # matplotlib gets imported by pandas, see below
         "descartes",
         "mapclassify",
         # 'rtree',  # rtree actually gets imported if installed

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -8,8 +8,8 @@ def test_no_additional_imports():
     # test that 'import geopandas' does not import any of the optional or
     # development dependencies
     blacklist = {
-        # "pytest", # pytest gets imported if installed
-        # "py", # py gets imported by pytest if installed
+        "pytest",
+        "py",
         "ipython",
         # "matplotlib",  # matplotlib gets imported by pandas, see below
         "descartes",

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -11,7 +11,7 @@ def test_no_additional_imports():
         # "pytest", # pytest gets imported if installed
         # "py", # py gets imported if installed
         "ipython",
-        "matplotlib",  # matplotlib gets imported by pandas, see below
+        # "matplotlib",  # matplotlib gets imported by pandas, see below
         "descartes",
         "mapclassify",
         # 'rtree',  # rtree actually gets imported if installed

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -107,7 +107,6 @@ def clip(gdf, mask, keep_geom_type=False):
     Clip points (global cities) with a polygon (the South American continent):
 
     >>> import geopandas
-    >>> path =
     >>> world = geopandas.read_file(
     ...     geopandas.datasets.get_path('naturalearth_lowres'))
     >>> south_america = world[world['continent'] == "South America"]

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -6,12 +6,17 @@ import pandas as pd
 from shapely.geometry import Point
 
 import geopandas
-import pytest
+
+try:
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def add_geopandas(doctest_namespace):
+        doctest_namespace["geopandas"] = geopandas
 
 
-@pytest.fixture(autouse=True)
-def add_geopandas(doctest_namespace):
-    doctest_namespace["geopandas"] = geopandas
+except ImportError:
+    pass
 
 
 def _get_throttle_time(provider):

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -58,7 +58,7 @@ def geocode(strings, provider=None, **kwargs):
 
     Examples
     --------
-    >>> df = geopandas.tools.geocode(
+    >>> df = geopandas.tools.geocode(  # doctest: +SKIP
     ...         ["boston, ma", "1600 pennsylvania ave. washington, dc"]
     ...     )
     >>> df  # doctest: +SKIP
@@ -113,7 +113,7 @@ def reverse_geocode(points, provider=None, **kwargs):
     Examples
     --------
     >>> from shapely.geometry import Point
-    >>> df = geopandas.tools.reverse_geocode(
+    >>> df = geopandas.tools.reverse_geocode(  # doctest: +SKIP
     ...     [Point(-71.0594869, 42.3584697), Point(-77.0365305, 38.8977332)]
     ... )
     >>> df  # doctest: +SKIP

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -7,17 +7,6 @@ from shapely.geometry import Point
 
 import geopandas
 
-try:
-    import pytest
-
-    @pytest.fixture(autouse=True)
-    def add_geopandas(doctest_namespace):
-        doctest_namespace["geopandas"] = geopandas
-
-
-except ImportError:
-    pass
-
 
 def _get_throttle_time(provider):
     """

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -6,6 +6,12 @@ import pandas as pd
 from shapely.geometry import Point
 
 import geopandas
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_geopandas(doctest_namespace):
+    doctest_namespace["geopandas"] = geopandas
 
 
 def _get_throttle_time(provider):
@@ -52,14 +58,13 @@ def geocode(strings, provider=None, **kwargs):
 
     Examples
     --------
-    >>> df = geocode(['boston, ma', '1600 pennsylvania ave. washington, dc'])
-    >>> df
-                                                 address  \\
-    0                                    Boston, MA, USA
-    1  1600 Pennsylvania Avenue Northwest, President'...
-                             geometry
-    0  POINT (-71.0597732 42.3584308)
-    1  POINT (-77.0365305 38.8977332)
+    >>> df = geopandas.tools.geocode(
+    ...         ["boston, ma", "1600 pennsylvania ave. washington, dc"]
+    ...     )
+    >>> df  # doctest: +SKIP
+                        geometry                                            address
+    0  POINT (-71.05863 42.35899)                          Boston, MA, United States
+    1  POINT (-77.03651 38.89766)  1600 Pennsylvania Ave NW, Washington, DC 20006...
     """
 
     if provider is None:
@@ -107,15 +112,14 @@ def reverse_geocode(points, provider=None, **kwargs):
 
     Examples
     --------
-    >>> df = reverse_geocode([Point(-71.0594869, 42.3584697),
-                              Point(-77.0365305, 38.8977332)])
-    >>> df
-                                             address  \\
-    0             29 Court Square, Boston, MA 02108, USA
-    1  1600 Pennsylvania Avenue Northwest, President'...
-                             geometry
-    0  POINT (-71.0594869 42.3584697)
-    1  POINT (-77.0365305 38.8977332)
+    >>> from shapely.geometry import Point
+    >>> df = geopandas.tools.reverse_geocode(
+    ...     [Point(-71.0594869, 42.3584697), Point(-77.0365305, 38.8977332)]
+    ... )
+    >>> df  # doctest: +SKIP
+                         geometry                                            address
+    0  POINT (-71.05941 42.35837)       29 Court Sq, Boston, MA 02108, United States
+    1  POINT (-77.03641 38.89766)  1600 Pennsylvania Ave NW, Washington, DC 20006...
     """
 
     if provider is None:


### PR DESCRIPTION
This PR adds one step to CI, checking docstring examples using `pytest` as suggested in #1617. That involves a bit more changes than I initially expected, notably required import of `pytest` on top of every file with examples to avoid the necessity to do `import geopandas` in every single example.

I have added one step to CI checking only docstrings, using pytest plugin `pytest-doctestplus` which allows checking docstrings only. It is run in a single environment, as those with missing dependencies are failing (naturally).

You don't have to check the actual docstrings as changes included in this PR are minimal to make doctest pass.