### PR TITLE
REGR: CRS lost in GeoSeries.explode()

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1219,7 +1219,7 @@ GeometryCollection
             index.extend(idxs)
             geometries.extend(geoms)
         index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-        return gpd.GeoSeries(geometries, index=index).__finalize__(self)
+        return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
     @property
     def cx(self):

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -691,7 +691,8 @@ class TestGeomMethods:
 
     def test_explode_geoseries(self):
         s = GeoSeries(
-            [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
+            [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])],
+            crs=4326,
         )
         s.index.name = "test_index_name"
         expected_index_name = ["test_index_name", None]
@@ -699,6 +700,7 @@ class TestGeomMethods:
         expected = GeoSeries(
             [Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3), Point(4, 4)],
             index=MultiIndex.from_tuples(index, names=expected_index_name),
+            crs=4326,
         )
         assert_geoseries_equal(expected, s.explode())
 


### PR DESCRIPTION
`GeoSeries.explode()` does not preserve CRS. Fixed.

To reproduce a bug:

```python
nybb = gpd.read_file(gpd.datasets.get_path('nybb'))
nybb.geometry.explode().crs
```