### PR TITLE
Compatibility with Shapely 1.8 deprecation warnings (iteration)

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -1,3 +1,4 @@
+import contextlib
 from distutils.version import LooseVersion
 import importlib
 import os
@@ -21,6 +22,8 @@ PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0")
 
 
 SHAPELY_GE_17 = str(shapely.__version__) >= LooseVersion("1.7.0")
+SHAPELY_GE_18 = str(shapely.__version__) >= LooseVersion("1.8")
+SHAPELY_GE_20 = str(shapely.__version__) >= LooseVersion("2.0")
 
 HAS_PYGEOS = None
 USE_PYGEOS = None
@@ -99,6 +102,35 @@ def set_use_pygeos(val=None):
 
 
 set_use_pygeos()
+
+
+# compat related to deprecation warnings introduced in Shapely 1.8
+# -> creating a numpy array from a list-like of Multi-part geometries,
+# although doing the correct thing (not expanding in its parts), still raises
+# the warning about iteration being deprecated
+# This adds a context manager to explicitly ignore this warning
+
+
+try:
+    from shapely.errors import ShapelyDeprecationWarning as shapely_warning
+except ImportError:
+    shapely_warning = None
+
+
+if shapely_warning is not None and not SHAPELY_GE_20:
+
+    @contextlib.contextmanager
+    def ignore_shapely2_warnings():
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Iteration", shapely_warning)
+            yield
+
+
+else:
+
+    @contextlib.contextmanager
+    def ignore_shapely2_warnings():
+        yield
 
 
 def import_optional_dependency(name: str, extra: str = ""):

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -365,7 +365,8 @@ class GeometryArray(ExtensionArray):
                 raise TypeError("should be valid geometry")
             if isinstance(key, (slice, list, np.ndarray)):
                 value_array = np.empty(1, dtype=object)
-                value_array[:] = [value]
+                with compat.ignore_shapely2_warnings():
+                    value_array[:] = [value]
                 self.data[key] = value_array
             else:
                 self.data[key] = value

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -16,6 +16,7 @@ from geopandas.base import GeoPandasBase, is_geometry_type
 from geopandas.geoseries import GeoSeries
 import geopandas.io
 from geopandas.plotting import plot_dataframe
+from . import _compat as compat
 
 
 DEFAULT_GEO_COLUMN_NAME = "geometry"
@@ -86,7 +87,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     def __init__(self, *args, **kwargs):
         crs = kwargs.pop("crs", None)
         geometry = kwargs.pop("geometry", None)
-        super(GeoDataFrame, self).__init__(*args, **kwargs)
+        with compat.ignore_shapely2_warnings():
+            super(GeoDataFrame, self).__init__(*args, **kwargs)
 
         # need to set this before calling self['geometry'], because
         # getitem accesses crs

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -15,6 +15,7 @@ from geopandas.plotting import plot_series
 from .array import GeometryArray, GeometryDtype, from_shapely
 from .base import is_geometry_type
 from . import _vectorized as vectorized
+from ._compat import ignore_shapely2_warnings
 
 
 _SERIES_WARNING_MSG = """\
@@ -155,7 +156,8 @@ class GeoSeries(GeoPandasBase, Series):
             # https://github.com/pandas-dev/pandas/issues/26469
             kwargs.pop("dtype", None)
             # Use Series constructor to handle input data
-            s = pd.Series(data, index=index, name=name, **kwargs)
+            with ignore_shapely2_warnings():
+                s = pd.Series(data, index=index, name=name, **kwargs)
             # prevent trying to convert non-geometry objects
             if s.dtype != object:
                 if s.empty:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -46,7 +46,7 @@ def _flatten_multi_geoms(geoms, prefix="Multi"):
 
     for ix, geom in enumerate(geoms):
         if geom.type.startswith(prefix):
-            for poly in geom:
+            for poly in geom.geoms:
                 components.append(poly)
                 component_index.append(ix)
         else:

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -557,7 +557,7 @@ class TestDataFrame:
 
     def test_dataframe_to_geodataframe(self):
         df = pd.DataFrame(
-            {"A": range(len(self.df)), "location": list(self.df.geometry)},
+            {"A": range(len(self.df)), "location": np.array(self.df.geometry)},
             index=self.df.index,
         )
         gf = df.set_geometry("location", crs=self.df.crs)


### PR DESCRIPTION
I had hoped this being less involved, but apparently, even with our workaround of 

```
out = np.empty(.., dtype=object)
out[:] = [...]
```

to avoid that numpy expands Multi-part geometries upon array construction, the above snippet *still* triggers the warning about Multi-part geometries no longer being iterable (not really sure why, since numpy doesn't actually iterate through them in that case to create the result, but internally in numpy it still happens). 

So therefore, I added a context manager around all those cases where we create a ndarray in this way, and for shapely 1.8 it supresses this warning, otherwise it is a no-op context manager.