### PR TITLE
Compatibility with Shapely 1.8 deprecation warnings (array interface, asShape)

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -122,7 +122,9 @@ if shapely_warning is not None and not SHAPELY_GE_20:
     @contextlib.contextmanager
     def ignore_shapely2_warnings():
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Iteration", shapely_warning)
+            warnings.filterwarnings(
+                "ignore", "Iteration|The array interface", shapely_warning
+            )
             yield
 
 

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -122,10 +122,7 @@ def from_shapely(data):
             else:
                 out.append(geom)
         elif hasattr(geom, "__geo_interface__"):
-            geom = shapely.geometry.asShape(geom)
-            # asShape returns GeometryProxy -> trigger actual materialization
-            # with one of its methods
-            geom.wkb
+            geom = shapely.geometry.shape(geom)
             if compat.USE_PYGEOS:
                 out.append(_shapely_to_pygeos(geom))
             else:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -200,7 +200,7 @@ def _plot_linestring_collection(
 
     _expand_kwargs(kwargs, multiindex)
 
-    segments = [np.array(linestring)[:, :2] for linestring in geoms]
+    segments = [np.array(linestring.coords)[:, :2] for linestring in geoms]
     collection = LineCollection(segments, **kwargs)
 
     if values is not None:


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/geopandas/pull/1659

This further fixes warnings about trying to convert a geometry to an array (`np.array(geom)` instead of `np.array(geom.coords)`). This again mostly happens under the hood in numpy, so adding it to the context manager I added in #1659