### PR TITLE
BUG: categories passed as a series are not properly sorted

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -636,6 +636,10 @@ def plot_dataframe(
             )
         else:
             values = column
+
+            # Make sure index of a Series matches index of df
+            if isinstance(values, pd.Series):
+                values = values.reindex(df.index)
     else:
         values = df[column]
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -86,22 +86,39 @@ class TestPointPlotting:
         expected_colors = cmap(np.arange(self.N) / (self.N - 1))
         _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
 
-    def test_color_reindex(self):
+    def test_series_color_no_index(self):
 
-        # Color order
+        # Color order with ordered index
+        colors_ord = pd.Series(["a", "b", "c", "a", "b", "c", "a", "b", "c", "a"])
+
+        # Plot using Series as color
+        ax1 = self.df.plot(colors_ord)
+
+        # Correct answer: Add as column to df and plot
+        self.df["colors_ord"] = colors_ord
+        ax2 = self.df.plot("colors_ord")
+
+        # Confirm out-of-order index re-sorted
+        point_colors1 = ax1.collections[0].get_facecolors()
+        point_colors2 = ax2.collections[0].get_facecolors()
+        np.testing.assert_array_equal(point_colors1[1], point_colors2[1])
+
+    def test_series_color_index(self):
+
+        # Color order with out-of-order index
         colors_ord = pd.Series(
             ["a", "a", "a", "a", "b", "b", "b", "c", "c", "c"],
             index=[0, 3, 6, 9, 1, 4, 7, 2, 5, 8],
         )
 
-        # Plot using Series
+        # Plot using Series as color
         ax1 = self.df.plot(colors_ord)
 
-        # Add as column to df and plot
+        # Correct answer: Add as column to df and plot
         self.df["colors_ord"] = colors_ord
         ax2 = self.df.plot("colors_ord")
 
-        # Check colors
+        # Confirm out-of-order index re-sorted
         point_colors1 = ax1.collections[0].get_facecolors()
         point_colors2 = ax2.collections[0].get_facecolors()
         np.testing.assert_array_equal(point_colors1[1], point_colors2[1])

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1,5 +1,4 @@
 import itertools
-import random
 import warnings
 
 import numpy as np

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1,4 +1,5 @@
 import itertools
+import random
 import warnings
 
 import numpy as np
@@ -85,6 +86,26 @@ class TestPointPlotting:
         cmap = plt.get_cmap()
         expected_colors = cmap(np.arange(self.N) / (self.N - 1))
         _check_colors(self.N, ax.collections[0].get_facecolors(), expected_colors)
+
+    def test_color_reindex(self):
+
+        # Color order
+        colors_ord = pd.Series(
+            ["a", "a", "a", "a", "b", "b", "b", "c", "c", "c"],
+            index=[0, 3, 6, 9, 1, 4, 7, 2, 5, 8],
+        )
+
+        # Plot using Series
+        ax1 = self.df.plot(colors_ord)
+
+        # Add as column to df and plot
+        self.df["colors_ord"] = colors_ord
+        ax2 = self.df.plot("colors_ord")
+
+        # Check colors
+        point_colors1 = ax1.collections[0].get_facecolors()
+        point_colors2 = ax2.collections[0].get_facecolors()
+        np.testing.assert_array_equal(point_colors1[1], point_colors2[1])
 
     def test_colormap(self):
 


### PR DESCRIPTION
This fixes #1634.

If categories are passed as a Series, call `.reindex()` so the index matches the data index when plotting.