### PR TITLE
Suppress warning when calling repr of empty GeoSeries. Fixes #1647

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -981,7 +981,9 @@ class GeometryArray(ExtensionArray):
             if precision is None:
                 # dummy heuristic based on 10 first geometries that should
                 # work in most cases
-                xmin, ymin, xmax, ymax = self[~self.isna()][:10].total_bounds
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", category=RuntimeWarning)
+                    xmin, ymin, xmax, ymax = self[~self.isna()][:10].total_bounds
                 if (
                     (-180 <= xmin <= 180)
                     and (-180 <= xmax <= 180)


### PR DESCRIPTION
Closes #1647 

The lines I've added suppress the warning when calling both `__repr__` and `total_bounds`.
This is not exactly the fix what was asked in the issue, but I have noticed that `total_bounds` could already return silently nans before this edit.

Maybe a warning message about returning nans can be printed for both cases ?