### PR TITLE
TST/ENH: support array-like alpha + fix plotting tests for matplotlib dev version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,7 +88,6 @@ jobs:
 
       - name: Test without PyGEOS
         shell: bash
-        continue-on-error: ${{ matrix.dev }}
         env:
           USE_PYGEOS: 0
         run: |
@@ -97,7 +96,6 @@ jobs:
 
       - name: Test with PyGEOS
         shell: bash
-        continue-on-error: ${{ matrix.dev }}
         if: env.HAS_PYGEOS == 1
         env:
           USE_PYGEOS: 1

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -67,7 +67,8 @@ def _expand_kwargs(kwargs, multiindex):
     from matplotlib.colors import is_color_like
     from typing import Iterable
 
-    if matplotlib.__version__ > LooseVersion("3.3.2"):
+    mpl = matplotlib.__version__
+    if mpl >= LooseVersion("3.4") or (mpl > LooseVersion("3.3.2") and "post" in mpl):
         # alpha is supported as array argument with matplotlib 3.4+
         scalar_kwargs = ["marker"]
     else:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -68,7 +68,7 @@ def _expand_kwargs(kwargs, multiindex):
     from typing import Iterable
 
     mpl = matplotlib.__version__
-    if mpl >= LooseVersion("3.4") or (mpl > LooseVersion("3.3.2") and "post" in mpl):
+    if mpl >= LooseVersion("3.4") or (mpl > LooseVersion("3.3.2") and "+" in mpl):
         # alpha is supported as array argument with matplotlib 3.4+
         scalar_kwargs = ["marker"]
     else:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -63,8 +63,15 @@ def _expand_kwargs(kwargs, multiindex):
     it (in place) to the correct length/formats with help of 'multiindex', unless
     the value appears to already be a valid (single) value for the key.
     """
+    import matplotlib
     from matplotlib.colors import is_color_like
     from typing import Iterable
+
+    if matplotlib.__version__ > LooseVersion("3.3.2"):
+        # alpha is supported as array argument with matplotlib 3.4+
+        scalar_kwargs = ["marker"]
+    else:
+        scalar_kwargs = ["marker", "alpha"]
 
     for att, value in kwargs.items():
         if "color" in att:  # color(s), edgecolor(s), facecolor(s)
@@ -78,7 +85,7 @@ def _expand_kwargs(kwargs, multiindex):
                 and isinstance(value[1], Iterable)
             ):
                 continue
-        elif att in ["marker", "alpha"]:
+        elif att in scalar_kwargs:
             # For these attributes, only a single value is allowed, so never expand.
             continue
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -171,8 +171,13 @@ class TestPointPlotting:
     def test_style_kwargs_alpha(self):
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
+        try:
             ax = self.df.plot(alpha=[0.7, 0.2])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_legend(self):
         with warnings.catch_warnings(record=True) as _:  # don't print warning
@@ -260,8 +265,13 @@ class TestPointPlotting:
     def test_multipoints_alpha(self):
         ax = self.df2.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
+        try:
             ax = self.df2.plot(alpha=[0.7, 0.2])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_categories(self):
         self.df["cats_object"] = ["cat1", "cat2"] * 5
@@ -441,8 +451,13 @@ class TestLineStringPlotting:
     def test_style_kwargs_alpha(self):
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
+        try:
             ax = self.df.plot(alpha=[0.7, 0.2])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_subplots_norm(self):
         # colors of subplots are the same as for plot (norm is applied)
@@ -602,8 +617,13 @@ class TestPolygonPlotting:
         # alpha
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
+        try:
             ax = self.df.plot(alpha=[0.7, 0.2])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_legend_kwargs(self):
 
@@ -700,8 +720,13 @@ class TestPolygonPlotting:
     def test_multipolygons_alpha(self):
         ax = self.df2.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
-            ax = self.df2.plot(alpha=[0.7, 0.2])
+        try:
+            ax = self.df.plot(alpha=[0.7, 0.2])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_subplots_norm(self):
         # colors of subplots are the same as for plot (norm is applied)
@@ -846,8 +871,15 @@ class TestNonuniformGeometryPlotting:
     def test_style_kwargs_alpha(self):
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        with pytest.raises(TypeError):  # no list allowed for alpha
+        try:
             ax = self.df.plot(alpha=[0.7, 0.2, 0.9])
+        except TypeError:
+            # no list allowed for alpha up to matplotlib 3.3
+            pass
+        else:
+            np.testing.assert_array_equal(
+                [0.7, 0.2, 0.9], ax.collections[0].get_alpha()
+            )
 
 
 class TestGeographicAspect:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -172,12 +172,14 @@ class TestPointPlotting:
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
         try:
-            ax = self.df.plot(alpha=[0.7, 0.2])
+            ax = self.df.plot(alpha=np.linspace(0, 0.0, 1.0, self.N))
         except TypeError:
             # no list allowed for alpha up to matplotlib 3.3
             pass
         else:
-            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
+            np.testing.assert_array_equal(
+                np.linspace(0, 0.0, 1.0, self.N), ax.collections[0].get_alpha()
+            )
 
     def test_legend(self):
         with warnings.catch_warnings(record=True) as _:  # don't print warning
@@ -454,12 +456,14 @@ class TestLineStringPlotting:
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
         try:
-            ax = self.df.plot(alpha=[0.7, 0.2])
+            ax = self.df.plot(alpha=np.linspace(0, 0.0, 1.0, self.N))
         except TypeError:
             # no list allowed for alpha up to matplotlib 3.3
             pass
         else:
-            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
+            np.testing.assert_array_equal(
+                np.linspace(0, 0.0, 1.0, self.N), ax.collections[0].get_alpha()
+            )
 
     def test_subplots_norm(self):
         # colors of subplots are the same as for plot (norm is applied)
@@ -875,15 +879,17 @@ class TestNonuniformGeometryPlotting:
     def test_style_kwargs_alpha(self):
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
-        try:
-            ax = self.df.plot(alpha=[0.7, 0.2, 0.9])
-        except TypeError:
-            # no list allowed for alpha up to matplotlib 3.3
-            pass
-        else:
-            np.testing.assert_array_equal(
-                [0.7, 0.2, 0.9], ax.collections[0].get_alpha()
-            )
+        # TODO splitting array-like arguments for the different plot types
+        # is not yet supported
+        # try:
+        #     ax = self.df.plot(alpha=[0.7, 0.2, 0.9])
+        # except TypeError:
+        #     # no list allowed for alpha up to matplotlib 3.3
+        #     pass
+        # else:
+        #     np.testing.assert_array_equal(
+        #         [0.7, 0.2, 0.9], ax.collections[0].get_alpha()
+        #     )
 
 
 class TestGeographicAspect:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -271,7 +271,9 @@ class TestPointPlotting:
             # no list allowed for alpha up to matplotlib 3.3
             pass
         else:
-            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
+            np.testing.assert_array_equal(
+                [0.7] * 10 + [0.2] * 10, ax.collections[0].get_alpha()
+            )
 
     def test_categories(self):
         self.df["cats_object"] = ["cat1", "cat2"] * 5
@@ -721,12 +723,14 @@ class TestPolygonPlotting:
         ax = self.df2.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
         try:
-            ax = self.df.plot(alpha=[0.7, 0.2])
+            ax = self.df2.plot(alpha=[0.7, 0.2])
         except TypeError:
             # no list allowed for alpha up to matplotlib 3.3
             pass
         else:
-            np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
+            np.testing.assert_array_equal(
+                [0.7, 0.7, 0.2, 0.2], ax.collections[0].get_alpha()
+            )
 
     def test_subplots_norm(self):
         # colors of subplots are the same as for plot (norm is applied)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -880,7 +880,7 @@ class TestNonuniformGeometryPlotting:
         ax = self.df.plot(alpha=0.7)
         np.testing.assert_array_equal([0.7], ax.collections[0].get_alpha())
         # TODO splitting array-like arguments for the different plot types
-        # is not yet supported
+        # is not yet supported - https://github.com/geopandas/geopandas/issues/1379
         # try:
         #     ax = self.df.plot(alpha=[0.7, 0.2, 0.9])
         # except TypeError:


### PR DESCRIPTION
The dev build was failing related to matplotlib, which started to support array-like argument for the `alpha` style keyword (see https://matplotlib.org/devdocs/users/next_whats_new/alpha_array.html), but which we explicitly tested that it raised an error.

Also enabling the dev github actions build to be visible if there are failures, since we currently don't have any (we can always skip it again if there turn up failures we can't directly fix).