### PR TITLE
GH: link geopandas-feedstock for conda-forge issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -1,7 +1,7 @@
 ---
 
-name: Installation Issue 
-about: Ask about installing geopandas 
+name: Installation Issue
+about: Ask about installing geopandas
 title: ""
 labels: "installation"
 
@@ -10,6 +10,8 @@ labels: "installation"
 - [ ] I have read the [documentation on installation](https://geopandas.org/install.html) and followed the instructions provided.
 
 - [ ] I have looked through [issues labeled "installation"](https://github.com/geopandas/geopandas/labels/installation) in the geopandas repo.
+
+- If your issue is related to installation using `conda-forge` channel, please open an issue in [geopandas-feedstock repository](https://github.com/conda-forge/geopandas-feedstock) instead.
 
 ---
 
@@ -23,7 +25,7 @@ using]
 <details>
 
 [if using conda, paste the output of `conda info` and `conda list`; if using
-pip, `pip freeze`] 
+pip, `pip freeze`]
 
 </details>
 

--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -11,7 +11,7 @@ labels: "installation"
 
 - [ ] I have looked through [issues labeled "installation"](https://github.com/geopandas/geopandas/labels/installation) in the geopandas repo.
 
-- If your issue is related to installation using `conda-forge` channel, please open an issue in [geopandas-feedstock repository](https://github.com/conda-forge/geopandas-feedstock) instead.
+- If your issue is related to installation using the `conda-forge` channel, please open an issue in [geopandas-feedstock repository](https://github.com/conda-forge/geopandas-feedstock) instead.
 
 ---
 


### PR DESCRIPTION
xref https://github.com/geopandas/geopandas/issues/982#issuecomment-720506732

> b/c conda-forge issues on geopandas installation are quite common, maybe we should add the feedstock link and a message on the issue template to guide people there.