### PR TITLE
GH: Add geopandas-feedstock in installion template

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -11,6 +11,9 @@ labels: "installation"
 
 - [ ] I have looked through [issues labeled "installation"](https://github.com/geopandas/geopandas/labels/installation) in the geopandas repo.
 
+- [ ] If using conda, I have looked through [issues on conda-forge geopandas-feedstock](https://github.com/conda-forge/geopandas-feedstock) (or
+check if not relevant).
+
 ---
 
 #### System information

--- a/.github/ISSUE_TEMPLATE/installation_issue.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue.md
@@ -11,7 +11,7 @@ labels: "installation"
 
 - [ ] I have looked through [issues labeled "installation"](https://github.com/geopandas/geopandas/labels/installation) in the geopandas repo.
 
-- [ ] If using conda, I have looked through [issues on conda-forge geopandas-feedstock](https://github.com/conda-forge/geopandas-feedstock) (or
+- [ ] If using conda and the third party channel conda-forge, I have looked through [issues on conda-forge geopandas-feedstock](https://github.com/conda-forge/geopandas-feedstock) (or
 check if not relevant).
 
 ---


### PR DESCRIPTION
Per @ocefpaf comment here: https://github.com/geopandas/geopandas/issues/982#issuecomment-720506732,
add the conda-forge geopandas-feedstock as part of the installation
template.
