### PR TITLE
CI: add Python3.9 to CI matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           - ci/envs/37-latest-defaults.yaml
           - ci/envs/37-latest-conda-forge.yaml
           - ci/envs/38-latest-conda-forge.yaml
+          - ci/envs/39-latest-conda-forge.yaml
         include:
           - env: ci/envs/37-latest-conda-forge.yaml
             os: macos-latest

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -1,0 +1,31 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  # required
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  - pygeos
+  # testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - fsspec
+  # optional
+  - rtree
+  - matplotlib
+  - descartes
+  - mapclassify
+  - geopy
+  # installed in tests.yaml, because not available on windows
+  # - postgis
+  - SQLalchemy
+  - psycopg2
+  - libspatialite
+  - geoalchemy2
+  - pyarrow
+  # doctest testing
+  - pytest-doctestplus


### PR DESCRIPTION
Adding an environment with Python 3.9 to be tested on ubuntu.