### PR TITLE
ENH: fallback to DataFrame.explode() when the specified column is not the geometry column

### DIFF
--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -96,13 +96,14 @@ Affine transformations
    GeoSeries.skew
    GeoSeries.translate
 
-Aggregating methods
--------------------
+Aggregating and exploding
+-------------------------
 
 .. autosummary::
    :toctree: api/
 
    GeoSeries.unary_union
+   GeoSeries.explode
 
 Reading and writing files
 -------------------------

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1200,53 +1200,53 @@ GeometryCollection
             "skew", self, xs, ys, origin=origin, use_radians=use_radians
         )
 
-    def explode(self):
-        """
-        Explode multi-part geometries into multiple single geometries.
-
-        Single rows can become multiple rows.
-        This is analogous to PostGIS's ST_Dump(). The 'path' index is the
-        second level of the returned MultiIndex
-
-        Returns
-        ------
-        A GeoSeries with a MultiIndex. The levels of the MultiIndex are the
-        original index and a zero-based integer index that counts the
-        number of single geometries within a multi-part geometry.
-
-        Examples
-        --------
-        >>> from shapely.geometry import MultiPoint
-        >>> s = geopandas.GeoSeries(
-        ...     [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
-        ... )
-        >>> s
-        0        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
-        1    MULTIPOINT (2.00000 2.00000, 3.00000 3.00000, ...
-        dtype: geometry
-
-        >>> s.explode()
-        0  0    POINT (0.00000 0.00000)
-           1    POINT (1.00000 1.00000)
-        1  0    POINT (2.00000 2.00000)
-           1    POINT (3.00000 3.00000)
-           2    POINT (4.00000 4.00000)
-        dtype: geometry
-
-        """
-        index = []
-        geometries = []
-        for idx, s in self.geometry.iteritems():
-            if s.type.startswith("Multi") or s.type == "GeometryCollection":
-                geoms = s.geoms
-                idxs = [(idx, i) for i in range(len(geoms))]
-            else:
-                geoms = [s]
-                idxs = [(idx, 0)]
-            index.extend(idxs)
-            geometries.extend(geoms)
-        index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-        return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
+    # def explode(self):
+    #     """
+    #     Explode multi-part geometries into multiple single geometries.
+    #
+    #     Single rows can become multiple rows.
+    #     This is analogous to PostGIS's ST_Dump(). The 'path' index is the
+    #     second level of the returned MultiIndex
+    #
+    #     Returns
+    #     ------
+    #     A GeoSeries with a MultiIndex. The levels of the MultiIndex are the
+    #     original index and a zero-based integer index that counts the
+    #     number of single geometries within a multi-part geometry.
+    #
+    #     Examples
+    #     --------
+    #     >>> from shapely.geometry import MultiPoint
+    #     >>> s = geopandas.GeoSeries(
+    #     ...     [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
+    #     ... )
+    #     >>> s
+    #     0        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
+    #     1    MULTIPOINT (2.00000 2.00000, 3.00000 3.00000, ...
+    #     dtype: geometry
+    #
+    #     >>> s.explode()
+    #     0  0    POINT (0.00000 0.00000)
+    #        1    POINT (1.00000 1.00000)
+    #     1  0    POINT (2.00000 2.00000)
+    #        1    POINT (3.00000 3.00000)
+    #        2    POINT (4.00000 4.00000)
+    #     dtype: geometry
+    #
+    #     """
+    #     index = []
+    #     geometries = []
+    #     for idx, s in self.geometry.iteritems():
+    #         if s.type.startswith("Multi") or s.type == "GeometryCollection":
+    #             geoms = s.geoms
+    #             idxs = [(idx, i) for i in range(len(geoms))]
+    #         else:
+    #             geoms = [s]
+    #             idxs = [(idx, 0)]
+    #         index.extend(idxs)
+    #         geometries.extend(geoms)
+    #     index = MultiIndex.from_tuples(index, names=self.index.names + [None])
+    #     return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
     @property
     def cx(self):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2,13 +2,11 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-from pandas import DataFrame, MultiIndex, Series
+from pandas import DataFrame, Series
 
 from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import cascaded_union
-
-import geopandas as gpd
 
 from .array import GeometryArray, GeometryDtype
 
@@ -1199,54 +1197,6 @@ GeometryCollection
         return _delegate_geo_method(
             "skew", self, xs, ys, origin=origin, use_radians=use_radians
         )
-
-    # def explode(self):
-    #     """
-    #     Explode multi-part geometries into multiple single geometries.
-    #
-    #     Single rows can become multiple rows.
-    #     This is analogous to PostGIS's ST_Dump(). The 'path' index is the
-    #     second level of the returned MultiIndex
-    #
-    #     Returns
-    #     ------
-    #     A GeoSeries with a MultiIndex. The levels of the MultiIndex are the
-    #     original index and a zero-based integer index that counts the
-    #     number of single geometries within a multi-part geometry.
-    #
-    #     Examples
-    #     --------
-    #     >>> from shapely.geometry import MultiPoint
-    #     >>> s = geopandas.GeoSeries(
-    #     ...     [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
-    #     ... )
-    #     >>> s
-    #     0        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
-    #     1    MULTIPOINT (2.00000 2.00000, 3.00000 3.00000, ...
-    #     dtype: geometry
-    #
-    #     >>> s.explode()
-    #     0  0    POINT (0.00000 0.00000)
-    #        1    POINT (1.00000 1.00000)
-    #     1  0    POINT (2.00000 2.00000)
-    #        1    POINT (3.00000 3.00000)
-    #        2    POINT (4.00000 4.00000)
-    #     dtype: geometry
-    #
-    #     """
-    #     index = []
-    #     geometries = []
-    #     for idx, s in self.geometry.iteritems():
-    #         if s.type.startswith("Multi") or s.type == "GeometryCollection":
-    #             geoms = s.geoms
-    #             idxs = [(idx, i) for i in range(len(geoms))]
-    #         else:
-    #             geoms = [s]
-    #             idxs = [(idx, 0)]
-    #         index.extend(idxs)
-    #         geometries.extend(geoms)
-    #     index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-    #     return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
     @property
     def cx(self):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1340,7 +1340,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             column = self.geometry.name
         # If the specified column is not a geometry dtype then fall back to pandas native explode method
         if not isinstance(self[column].dtype, GeometryDtype):
-            return super(GeoPandasBase, self).explode(column, **kwargs)
+            return super(GeoDataFrame, self).explode(column, **kwargs)
             # exploded_df = pd.DataFrame(self).explode(column, **kwargs)
             # return GeoDataFrame(exploded_df, geometry=self.geometry.name, crs=self.crs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1288,8 +1288,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
 
         return aggregated
 
-    # overrides GeoPandasBase method
-    # also overrides the pandas native explode method to break up features geometrically
+    # overrides the pandas native explode method to break up features geometrically
     def explode(self, column=None, **kwargs):
         """
         Explode muti-part geometries into multiple single geometries.
@@ -1338,11 +1337,10 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         # If no column is specified then default to the active geometry column
         if column is None:
             column = self.geometry.name
-        # If the specified column is not a geometry dtype then fall back to pandas native explode method
+        # If the specified column is not a geometry dtype use pandas explode
         if not isinstance(self[column].dtype, GeometryDtype):
             return super(GeoDataFrame, self).explode(column, **kwargs)
-            # exploded_df = pd.DataFrame(self).explode(column, **kwargs)
-            # return GeoDataFrame(exploded_df, geometry=self.geometry.name, crs=self.crs)
+            # TODO: make sure index behaviour is consistent
 
         df_copy = self.copy()
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1289,7 +1289,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         return aggregated
 
     # overrides GeoPandasBase method
-    def explode(self):
+    def explode(self, column=None, **kwargs):
         """
         Explode muti-part geometries into multiple single geometries.
 
@@ -1333,6 +1333,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         1 0  name2  POINT (2.00000 1.00000)
           1  name2  POINT (0.00000 0.00000)
         """
+
+        if column != self.geometry.name:
+            exploded_df = pd.DataFrame(self).explode(column, **kwargs)
+            return GeoDataFrame(exploded_df, geometry=self.geometry.name, crs=self.crs)
+
         df_copy = self.copy()
 
         if "level_1" in df_copy.columns:  # GH1393

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1339,7 +1339,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         if column is None:
             column = self.geometry.name
         # If the specified column is not a geometry dtype then fall back to pandas native explode method
-        if type(self[column].dtype) != GeometryDtype:
+        if not isinstance(self[column].dtype, GeometryDtype):
             return super(GeoPandasBase, self).explode(column, **kwargs)
             # exploded_df = pd.DataFrame(self).explode(column, **kwargs)
             # return GeoDataFrame(exploded_df, geometry=self.geometry.name, crs=self.crs)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -623,6 +623,10 @@ class GeoSeries(GeoPandasBase, Series):
            2    POINT (4.00000 4.00000)
         dtype: geometry
 
+        See also
+        --------
+        GeoDataFrame.explode
+
         """
         index = []
         geometries = []

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -590,7 +590,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     plot.__doc__ = plot_series.__doc__
 
-    def explode(self, ignore_index: bool = False):
+    def explode(self):
         """
         Explode multi-part geometries into multiple single geometries.
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pandas import Series
+from pandas import Series, MultiIndex
 from pandas.core.internals import SingleBlockManager
 
 from pyproj import CRS, Transformer
@@ -589,6 +589,55 @@ class GeoSeries(GeoPandasBase, Series):
         return plot_series(self, *args, **kwargs)
 
     plot.__doc__ = plot_series.__doc__
+
+    def explode(self, ignore_index: bool = False):
+        """
+        Explode multi-part geometries into multiple single geometries.
+
+        Single rows can become multiple rows.
+        This is analogous to PostGIS's ST_Dump(). The 'path' index is the
+        second level of the returned MultiIndex
+
+        Returns
+        ------
+        A GeoSeries with a MultiIndex. The levels of the MultiIndex are the
+        original index and a zero-based integer index that counts the
+        number of single geometries within a multi-part geometry.
+
+        Examples
+        --------
+        >>> from shapely.geometry import MultiPoint
+        >>> s = geopandas.GeoSeries(
+        ...     [MultiPoint([(0, 0), (1, 1)]), MultiPoint([(2, 2), (3, 3), (4, 4)])]
+        ... )
+        >>> s
+        0        MULTIPOINT (0.00000 0.00000, 1.00000 1.00000)
+        1    MULTIPOINT (2.00000 2.00000, 3.00000 3.00000, ...
+        dtype: geometry
+
+        >>> s.explode()
+        0  0    POINT (0.00000 0.00000)
+           1    POINT (1.00000 1.00000)
+        1  0    POINT (2.00000 2.00000)
+           1    POINT (3.00000 3.00000)
+           2    POINT (4.00000 4.00000)
+        dtype: geometry
+
+        """
+        index = []
+        geometries = []
+        for idx, s in self.geometry.iteritems():
+            if s.type.startswith("Multi") or s.type == "GeometryCollection":
+                geoms = s.geoms
+                idxs = [(idx, i) for i in range(len(geoms))]
+            else:
+                geoms = [s]
+                idxs = [(idx, 0)]
+            index.extend(idxs)
+            geometries.extend(geoms)
+        index = MultiIndex.from_tuples(index, names=self.index.names + [None])
+        # return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
+        return self._constructor(geometries, index=index, crs=self.crs).__finalize__(self)
 
     #
     # Additional methods

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -636,8 +636,7 @@ class GeoSeries(GeoPandasBase, Series):
             index.extend(idxs)
             geometries.extend(geoms)
         index = MultiIndex.from_tuples(index, names=self.index.names + [None])
-        # return gpd.GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
-        return self._constructor(geometries, index=index, crs=self.crs).__finalize__(self)
+        return GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
     #
     # Additional methods

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -741,6 +741,10 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        not compat.PANDAS_GE_025,
+        reason="pandas explode introduced in pandas 0.25",
+    )
     def test_explode_pandas_fallback(self):
         d = {
             "col1": [["name1", "name2"], ["name3", "name4"]],

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -796,6 +796,34 @@ class TestGeomMethods:
         )
         assert_frame_equal(exploded_df, expected_df)
 
+    @pytest.mark.skipif(
+        not compat.PANDAS_GE_025,
+        reason="pandas explode introduced in pandas 0.25",
+    )
+    def test_explode_pandas_fallback_column_as_arg(self):
+        d = {
+            "col1": [["name1", "name2"], ["name3", "name4"]],
+            "geometry": [
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(2, 1), (0, 0)]),
+            ],
+        }
+        gdf = GeoDataFrame(d, crs=4326)
+        exploded_df = gdf.explode("col1")
+        expected_df = GeoDataFrame(
+            {
+                "col1": ["name1", "name2", "name3", "name4"],
+                "geometry": [
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                ],
+            },
+            index=[0, 0, 1, 1],
+        )
+        assert_frame_equal(exploded_df, expected_df)
+
     #
     # Test '&', '|', '^', and '-'
     #

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -800,7 +800,7 @@ class TestGeomMethods:
                     MultiPoint([(2, 1), (0, 0)]),
                 ],
             },
-            crs=4326
+            crs=4326,
         )
 
         # Test with column provided as arg

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -741,6 +741,48 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
+    def test_explode_pandas_fallback(self):
+        d = {
+            "col1": [["name1", "name2"], ["name3", "name4"]],
+            "geometry": [
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(2, 1), (0, 0)]),
+            ],
+        }
+        gdf = GeoDataFrame(d, crs=4326)
+        exploded_df = gdf.explode(column="col1")
+        expected_df = GeoDataFrame({
+            "col1": ["name1", "name2", "name3", "name4"],
+            "geometry": [
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(2, 1), (0, 0)]),
+                MultiPoint([(2, 1), (0, 0)]),
+            ],
+        }, index=[0, 0, 1, 1])
+        assert_frame_equal(exploded_df, expected_df)
+
+    def test_explode_pandas_fallback_ignore_index(self):
+        d = {
+            "col1": [["name1", "name2"], ["name3", "name4"]],
+            "geometry": [
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(2, 1), (0, 0)]),
+            ],
+        }
+        gdf = GeoDataFrame(d, crs=4326)
+        exploded_df = gdf.explode(column="col1", ignore_index=True)
+        expected_df = GeoDataFrame({
+            "col1": ["name1", "name2", "name3", "name4"],
+            "geometry": [
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(1, 2), (3, 4)]),
+                MultiPoint([(2, 1), (0, 0)]),
+                MultiPoint([(2, 1), (0, 0)]),
+            ],
+        })
+        assert_frame_equal(exploded_df, expected_df)
+
     #
     # Test '&', '|', '^', and '-'
     #

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -11,6 +11,7 @@ from shapely.ops import unary_union
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.base import GeoPandasBase
 
+from geopandas.testing import assert_geodataframe_equal
 from geopandas.tests.util import assert_geoseries_equal, geom_almost_equals, geom_equals
 from geopandas import _compat as compat
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -754,7 +755,6 @@ class TestGeomMethods:
             ],
         }
         gdf = GeoDataFrame(d, crs=4326)
-        exploded_df = gdf.explode(column="col1")
         expected_df = GeoDataFrame(
             {
                 "col1": ["name1", "name2", "name3", "name4"],
@@ -766,8 +766,16 @@ class TestGeomMethods:
                 ],
             },
             index=[0, 0, 1, 1],
+            crs=4326,
         )
-        assert_frame_equal(exploded_df, expected_df)
+
+        # Test with column provided as arg
+        exploded_df = gdf.explode("col1")
+        assert_geodataframe_equal(exploded_df, expected_df)
+
+        # Test with column provided as kwarg
+        exploded_df = gdf.explode(column="col1")
+        assert_geodataframe_equal(exploded_df, expected_df)
 
     @pytest.mark.skipif(
         not compat.PANDAS_GE_11,
@@ -782,34 +790,6 @@ class TestGeomMethods:
             ],
         }
         gdf = GeoDataFrame(d, crs=4326)
-        exploded_df = gdf.explode(column="col1", ignore_index=True)
-        expected_df = GeoDataFrame(
-            {
-                "col1": ["name1", "name2", "name3", "name4"],
-                "geometry": [
-                    MultiPoint([(1, 2), (3, 4)]),
-                    MultiPoint([(1, 2), (3, 4)]),
-                    MultiPoint([(2, 1), (0, 0)]),
-                    MultiPoint([(2, 1), (0, 0)]),
-                ],
-            }
-        )
-        assert_frame_equal(exploded_df, expected_df)
-
-    @pytest.mark.skipif(
-        not compat.PANDAS_GE_025,
-        reason="pandas explode introduced in pandas 0.25",
-    )
-    def test_explode_pandas_fallback_column_as_arg(self):
-        d = {
-            "col1": [["name1", "name2"], ["name3", "name4"]],
-            "geometry": [
-                MultiPoint([(1, 2), (3, 4)]),
-                MultiPoint([(2, 1), (0, 0)]),
-            ],
-        }
-        gdf = GeoDataFrame(d, crs=4326)
-        exploded_df = gdf.explode("col1")
         expected_df = GeoDataFrame(
             {
                 "col1": ["name1", "name2", "name3", "name4"],
@@ -820,9 +800,16 @@ class TestGeomMethods:
                     MultiPoint([(2, 1), (0, 0)]),
                 ],
             },
-            index=[0, 0, 1, 1],
+            crs=4326
         )
-        assert_frame_equal(exploded_df, expected_df)
+
+        # Test with column provided as arg
+        exploded_df = gdf.explode("col1", ignore_index=True)
+        assert_geodataframe_equal(exploded_df, expected_df)
+
+        # Test with column provided as kwarg
+        exploded_df = gdf.explode(column="col1", ignore_index=True)
+        assert_geodataframe_equal(exploded_df, expected_df)
 
     #
     # Test '&', '|', '^', and '-'

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -765,6 +765,10 @@ class TestGeomMethods:
         )
         assert_frame_equal(exploded_df, expected_df)
 
+    @pytest.mark.skipif(
+        not compat.PANDAS_GE_11,
+        reason="ignore_index keyword introduced in pandas 1.1.0",
+    )
     def test_explode_pandas_fallback_ignore_index(self):
         d = {
             "col1": [["name1", "name2"], ["name3", "name4"]],

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -751,15 +751,18 @@ class TestGeomMethods:
         }
         gdf = GeoDataFrame(d, crs=4326)
         exploded_df = gdf.explode(column="col1")
-        expected_df = GeoDataFrame({
-            "col1": ["name1", "name2", "name3", "name4"],
-            "geometry": [
-                MultiPoint([(1, 2), (3, 4)]),
-                MultiPoint([(1, 2), (3, 4)]),
-                MultiPoint([(2, 1), (0, 0)]),
-                MultiPoint([(2, 1), (0, 0)]),
-            ],
-        }, index=[0, 0, 1, 1])
+        expected_df = GeoDataFrame(
+            {
+                "col1": ["name1", "name2", "name3", "name4"],
+                "geometry": [
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                ],
+            },
+            index=[0, 0, 1, 1],
+        )
         assert_frame_equal(exploded_df, expected_df)
 
     def test_explode_pandas_fallback_ignore_index(self):
@@ -772,15 +775,17 @@ class TestGeomMethods:
         }
         gdf = GeoDataFrame(d, crs=4326)
         exploded_df = gdf.explode(column="col1", ignore_index=True)
-        expected_df = GeoDataFrame({
-            "col1": ["name1", "name2", "name3", "name4"],
-            "geometry": [
-                MultiPoint([(1, 2), (3, 4)]),
-                MultiPoint([(1, 2), (3, 4)]),
-                MultiPoint([(2, 1), (0, 0)]),
-                MultiPoint([(2, 1), (0, 0)]),
-            ],
-        })
+        expected_df = GeoDataFrame(
+            {
+                "col1": ["name1", "name2", "name3", "name4"],
+                "geometry": [
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(1, 2), (3, 4)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                    MultiPoint([(2, 1), (0, 0)]),
+                ],
+            }
+        )
         assert_frame_equal(exploded_df, expected_df)
 
     #


### PR DESCRIPTION
As in the title, this PR is a work in progress. Black and flake8 have not yet been run. I'll run them when the changes are deemed satisfactory.

I have given no special attention to the onoing "MultiIndex vs. Duplicate Index" debate, just added a snippet to naively forward the inputs to pandas if the geom col is not None and not the geometry column name.

However this could raise another interesting question - I often have two geometry-type columns in a geodataframe for alternate representations, and sort of "activate and deactivate" them as I please. Maybe it's not the best practice but nothing stops me from doing it. If the data type of the column is a shapely geometry, but is not the "active" geometry column, should it be geometrically or non-geometrically exploded?

Related to https://github.com/geopandas/geopandas/issues/1140 and https://github.com/geopandas/geopandas/issues/1719