### PR TITLE
BUG: Override shift in GeometryArray to preserve CRS

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -17,6 +17,7 @@ import shapely.geos
 PANDAS_GE_025 = str(pd.__version__) >= LooseVersion("0.25.0")
 PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("1.0.0")
 PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0")
+PANDAS_GE_115 = str(pd.__version__) >= LooseVersion("1.1.5")
 PANDAS_GE_12 = str(pd.__version__) >= LooseVersion("1.2.0")
 
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1150,7 +1150,7 @@ class GeometryArray(ExtensionArray):
         pandas.factorize
         ExtensionArray.factorize
         """
-        return from_wkb(values)
+        return from_wkb(values, crs=original.crs)
 
     def _values_for_argsort(self):
         # type: () -> np.ndarray

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1077,6 +1077,41 @@ class GeometryArray(ExtensionArray):
     def nbytes(self):
         return self.data.nbytes
 
+    def shift(self, periods: int = 1, fill_value: object = None) -> "GeometryArray":
+        """
+        Shift values by desired number.
+
+        Newly introduced missing values are filled with
+        ``self.dtype.na_value``.
+
+        Parameters
+        ----------
+        periods : int, default 1
+            The number of periods to shift. Negative values are allowed
+            for shifting backwards.
+
+        fill_value : object, optional
+            The scalar value to use for newly introduced missing values.
+            The default is ``self.dtype.na_value``.
+
+        Returns
+        -------
+        GeometryArray
+            Shifted.
+
+        Notes
+        -----
+        If ``self`` is empty or ``periods`` is 0, a copy of ``self`` is
+        returned.
+
+        If ``periods > len(self)``, then an array of size
+        len(self) is returned, with all values filled with
+        ``self.dtype.na_value``.
+        """
+        shifted = super(GeometryArray, self).shift(periods, fill_value)
+        shifted.crs = self.crs
+        return shifted
+
     # -------------------------------------------------------------------------
     # ExtensionArray specific
     # -------------------------------------------------------------------------

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -30,6 +30,12 @@ from . import _vectorized as vectorized
 from .sindex import _get_sindex_class
 
 
+class class_or_instancemethod(classmethod):
+    def __get__(self, instance, type_):
+        descr_get = super().__get__ if instance is None else self.__func__.__get__
+        return descr_get(instance, type_)
+
+
 class GeometryDtype(ExtensionDtype):
     type = BaseGeometry
     name = "geometry"
@@ -1077,47 +1083,12 @@ class GeometryArray(ExtensionArray):
     def nbytes(self):
         return self.data.nbytes
 
-    def shift(self, periods=1, fill_value=None):
-        """
-        Shift values by desired number.
-
-        Newly introduced missing values are filled with
-        ``self.dtype.na_value``.
-
-        Parameters
-        ----------
-        periods : int, default 1
-            The number of periods to shift. Negative values are allowed
-            for shifting backwards.
-
-        fill_value : object, optional (default None)
-            The scalar value to use for newly introduced missing values.
-            The default is ``self.dtype.na_value``.
-
-        Returns
-        -------
-        GeometryArray
-            Shifted.
-
-        Notes
-        -----
-        If ``self`` is empty or ``periods`` is 0, a copy of ``self`` is
-        returned.
-
-        If ``periods > len(self)``, then an array of size
-        len(self) is returned, with all values filled with
-        ``self.dtype.na_value``.
-        """
-        shifted = super(GeometryArray, self).shift(periods, fill_value)
-        shifted.crs = self.crs
-        return shifted
-
     # -------------------------------------------------------------------------
     # ExtensionArray specific
     # -------------------------------------------------------------------------
 
-    @classmethod
-    def _from_sequence(cls, scalars, dtype=None, copy=False):
+    @class_or_instancemethod
+    def _from_sequence(cls_or_self, scalars, dtype=None, copy=False):
         """
         Construct a new ExtensionArray from a sequence of scalars.
 
@@ -1139,7 +1110,9 @@ class GeometryArray(ExtensionArray):
         # GH 1413
         if isinstance(scalars, BaseGeometry):
             scalars = [scalars]
-        return from_shapely(scalars)
+
+        crs = None if isinstance(cls_or_self, type) else cls_or_self.crs
+        return from_shapely(scalars, crs=crs)
 
     def _values_for_factorize(self):
         # type: () -> Tuple[np.ndarray, Any]

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1077,7 +1077,7 @@ class GeometryArray(ExtensionArray):
     def nbytes(self):
         return self.data.nbytes
 
-    def shift(self, periods: int = 1, fill_value: object = None) -> "GeometryArray":
+    def shift(self, periods=1, fill_value=None):
         """
         Shift values by desired number.
 
@@ -1090,7 +1090,7 @@ class GeometryArray(ExtensionArray):
             The number of periods to shift. Negative values are allowed
             for shifting backwards.
 
-        fill_value : object, optional
+        fill_value : object, optional (default None)
             The scalar value to use for newly introduced missing values.
             The default is ``self.dtype.na_value``.
 

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -894,6 +894,12 @@ def test_shift_has_crs():
     assert t.shift(-1).crs == t.crs
 
 
+def test_unique_has_crs():
+    t = T.copy()
+    t.crs = 4326
+    assert t.unique().crs == t.crs
+
+
 class TestEstimateUtmCrs:
     def setup_method(self):
         self.esb = shapely.geometry.Point(-73.9847, 40.7484)

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -894,6 +894,9 @@ def test_shift_has_crs():
     assert t.shift(-1).crs == t.crs
 
 
+@pytest.mark.skipif(
+    not compat.PANDAS_GE_115, reason="crs only preserved in unique after pandas 1.1.5"
+)
 def test_unique_has_crs():
     t = T.copy()
     t.crs = 4326

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -886,6 +886,14 @@ def test_isna_pdNA():
     assert t1[0] is None
 
 
+def test_shift_has_crs():
+    t = T.copy()
+    t.crs = 4326
+    assert t.shift(1).crs == t.crs
+    assert t.shift(0).crs == t.crs
+    assert t.shift(-1).crs == t.crs
+
+
 class TestEstimateUtmCrs:
     def setup_method(self):
         self.esb = shapely.geometry.Point(-73.9847, 40.7484)

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -529,12 +529,6 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argmax_argmin_no_skipna_notimplemented(self):
         pass
 
-    def test_shift_has_crs(self, data):
-        data.crs = 4326
-        assert data.shift(1).crs == data.crs
-        assert data.shift(0).crs == data.crs
-        assert data.shift(-1).crs == data.crs
-
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -529,6 +529,12 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argmax_argmin_no_skipna_notimplemented(self):
         pass
 
+    def test_shift_has_crs(self, data):
+        data.crs = 4326
+        assert data.shift(1).crs == data.crs
+        assert data.shift(0).crs == data.crs
+        assert data.shift(-1).crs == data.crs
+
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass


### PR DESCRIPTION
Overrides `ExtensionArray.shift` in `GeometryArray` to preserve the `crs`.

I considered an alternative implementation of overriding `_from_sequence`. That's what `ExtensionArray.shift` calls to make a new array and where the CRS is lost. (see https://github.com/pandas-dev/pandas/blob/653f6944eba664d19e8d93e850340ac039ec452e/pandas/core/arrays/base.py#L677-L692). So I figured if I could preserve the CRS there, it would fix this issue in `shift` but also potentially other places where `_from_sequence` is used. The problem is `_from_sequence` is a class method, not an instance method. So even though it is called with `self._from_sequence` it doesn't actually have access to anything within `self` and thus doesn't have the `crs`. It is possible to make a custom descriptor that would give `_from_sequence` a class method implementation and an instance method implementation, thus preserving the existing behavior if called with `GeometryArray._from_sequence` and adding new behavior if called with `self._from_sequence` on an instance. But that seems like a bit much considering that overriding `shift` is so simple.

Closes #1648 