### PR TITLE
REGR: fix pickle issues

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -427,7 +427,7 @@ class GeometryArray(ExtensionArray):
         if compat.USE_PYGEOS:
             geoms = pygeos.from_wkb(state[0])
             self._crs = state[1]
-            self._sindex = None
+            self._sindex = None  # pygeos.STRtree could not be pickled yet
             self.data = geoms
             self.base = None
         else:

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -417,20 +417,19 @@ class GeometryArray(ExtensionArray):
         #             "and CRS of existing geometries."
         #         )
 
-    if compat.USE_PYGEOS:
-
-        def __getstate__(self):
+    def __getstate__(self):
+        if compat.USE_PYGEOS:
             return (pygeos.to_wkb(self.data), self._crs)
+        else:
+            return self.__dict__
 
-        def __setstate__(self, state):
+    def __setstate__(self, state):
+        if compat.USE_PYGEOS:
             geoms = pygeos.from_wkb(state[0])
             self._crs = state[1]
             self.data = geoms
             self.base = None
-
-    else:
-
-        def __setstate__(self, state):
+        else:
             if "_crs" not in state:
                 state["_crs"] = None
             self.__dict__.update(state)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -427,6 +427,7 @@ class GeometryArray(ExtensionArray):
         if compat.USE_PYGEOS:
             geoms = pygeos.from_wkb(state[0])
             self._crs = state[1]
+            self._sindex = None
             self.data = geoms
             self.base = None
         else:

--- a/geopandas/io/tests/test_pickle.py
+++ b/geopandas/io/tests/test_pickle.py
@@ -70,13 +70,13 @@ def test_round_trip_current(tmpdir, current_pickle_data):
         assert isinstance(result.has_sindex, bool)
 
 
-@pytest.mark.skipif(not compat.USE_PYGEOS, reason="requires pygeos to test #1745")
+@pytest.mark.skipif(not compat.HAS_PYGEOS, reason="requires pygeos to test #1745")
 def test_pygeos_switch(tmpdir, with_use_pygeos_false):
     gdf_crs = geopandas.GeoDataFrame(
         {"a": [0.1, 0.2, 0.3], "geometry": [Point(1, 1), Point(2, 2), Point(3, 3)]},
         crs="EPSG:4326",
     )
-    path = str(tmpdir / "{}.pickle".format(gdf_crs))
+    path = str(tmpdir / "gdf_crs.pickle")
     gdf_crs.to_pickle(path)
     result = pd.read_pickle(path)
     assert_geodataframe_equal(result, gdf_crs)

--- a/geopandas/io/tests/test_pickle.py
+++ b/geopandas/io/tests/test_pickle.py
@@ -73,3 +73,4 @@ def test_pygeos_switch(tmpdir):
     gdf_crs.to_pickle(path)
     result = pd.read_pickle(path)
     assert_geodataframe_equal(result, gdf_crs)
+    geopandas.options.use_pygeos = True

--- a/geopandas/io/tests/test_pickle.py
+++ b/geopandas/io/tests/test_pickle.py
@@ -59,6 +59,7 @@ def test_round_trip_current(tmpdir, current_pickle_data):
         value.to_pickle(path)
         result = pd.read_pickle(path)
         assert_geodataframe_equal(result, value)
+        assert isinstance(result.has_sindex, bool)
 
 
 @pytest.mark.skipif(not compat.USE_PYGEOS, reason="requires pygeos to test #1745")

--- a/geopandas/io/tests/test_pickle.py
+++ b/geopandas/io/tests/test_pickle.py
@@ -14,7 +14,8 @@ import pyproj
 import pytest
 from geopandas.testing import assert_geodataframe_equal
 from geopandas import _compat as compat
-
+import geopandas
+from shapely.geometry import Point
 
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
@@ -58,3 +59,16 @@ def test_round_trip_current(tmpdir, current_pickle_data):
         value.to_pickle(path)
         result = pd.read_pickle(path)
         assert_geodataframe_equal(result, value)
+
+
+@pytest.mark.skipif(not compat.USE_PYGEOS, reason="requires pygeos to test #1745")
+def test_pygeos_switch(tmpdir):
+    geopandas.options.use_pygeos = False
+    gdf_crs = geopandas.GeoDataFrame(
+        {"a": [0.1, 0.2, 0.3], "geometry": [Point(1, 1), Point(2, 2), Point(3, 3)]},
+        crs="EPSG:4326",
+    )
+    path = str(tmpdir / "{}.pickle".format(gdf_crs))
+    gdf_crs.to_pickle(path)
+    result = pd.read_pickle(path)
+    assert_geodataframe_equal(result, gdf_crs)


### PR DESCRIPTION
Closes #1745
Closes #1746

Moving conditions into `__setstate__` and `__getstate__` to make sure it reacts to `geopandas.options.use_pygeos = False`.

_edit:_ I have also included a patch for #1746 now. Since `pygeos.STRtree` cannot be pickled now, it is ignored during pickling and `_sindex` is set to `None` during un-pickling.