### PR TITLE
BUG: implement custom __contains__ for GeometryArray

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1098,7 +1098,7 @@ class GeometryArray(ExtensionArray):
         """
         Return for `item in self`.
         """
-        if pd.api.types.is_scalar(item) and pd.core.dtypes.missing.isna(item):
+        if _isna(item):
             if (
                 item is self.dtype.na_value
                 or isinstance(item, self.dtype.type)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1099,7 +1099,11 @@ class GeometryArray(ExtensionArray):
         Return for `item in self`.
         """
         if pd.api.types.is_scalar(item) and pd.core.dtypes.missing.isna(item):
-            if item is self.dtype.na_value or isinstance(item, self.dtype.type):
+            if (
+                item is self.dtype.na_value
+                or isinstance(item, self.dtype.type)
+                or item is None
+            ):
                 return self.isna().any()
             else:
                 return False

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -144,7 +144,7 @@ def _shapely_to_geom(geom):
 
 def _is_scalar_geometry(geom):
     if compat.USE_PYGEOS:
-        return isinstance(geom, pygeos.Geometry)
+        return isinstance(geom, (pygeos.Geometry, BaseGeometry))
     else:
         return isinstance(geom, BaseGeometry)
 
@@ -1063,7 +1063,9 @@ class GeometryArray(ExtensionArray):
 
     def _binop(self, other, op):
         def convert_values(param):
-            if isinstance(param, ExtensionArray) or pd.api.types.is_list_like(param):
+            if not _is_scalar_geometry(param) and (
+                isinstance(param, ExtensionArray) or pd.api.types.is_list_like(param)
+            ):
                 ovalues = param
             else:  # Assume its an object
                 ovalues = [param] * len(self)
@@ -1091,3 +1093,14 @@ class GeometryArray(ExtensionArray):
 
     def __ne__(self, other):
         return self._binop(other, operator.ne)
+
+    def __contains__(self, item):
+        """
+        Return for `item in self`.
+        """
+        if pd.api.types.is_scalar(item) and pd.core.dtypes.missing.isna(item):
+            if item is self.dtype.na_value or isinstance(item, self.dtype.type):
+                return self.isna().any()
+            else:
+                return False
+        return (self == item).any()

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -769,6 +769,15 @@ def test_equality_ops():
     res = a1 != a2
     assert res.tolist() == [False, True, False]
 
+    # check the correct expansion of list-like geometry
+    multi_poly = shapely.geometry.MultiPolygon(
+        [shapely.geometry.box(0, 0, 1, 1), shapely.geometry.box(3, 3, 4, 4)]
+    )
+    a3 = from_shapely([points[1], points[2], points[3], multi_poly])
+
+    res = a3 == multi_poly
+    assert res.tolist() == [False, False, False, True]
+
 
 def test_dir():
     assert "contains" in dir(P)

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -301,6 +301,7 @@ class TestInterface(extension_tests.BaseInterfaceTests):
 
         assert None in data_missing
         assert None not in data
+        assert pd.NaT not in data_missing
 
 
 class TestConstructors(extension_tests.BaseConstructorsTests):

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -287,7 +287,20 @@ class TestDtype(extension_tests.BaseDtypeTests):
 
 
 class TestInterface(extension_tests.BaseInterfaceTests):
-    pass
+    def test_contains(self, data, data_missing):
+        # overrided due to the inconsistency between
+        # GeometryDtype.na_value = np.nan
+        # and None being used as NA in array
+
+        # ensure data without missing values
+        data = data[~data.isna()]
+
+        # first elements are non-missing
+        assert data[0] in data
+        assert data_missing[0] in data_missing
+
+        assert None in data_missing
+        assert None not in data
 
 
 class TestConstructors(extension_tests.BaseConstructorsTests):


### PR DESCRIPTION
This should fix the CI failure with pandas master. 

I have fixed an expansion of scalar geometry which was mistakenly seen as a list and reimplemented `__contains__` following pandas example with a difference of switching the check (we have `(self == item).any()` whilst pandas `(item == self).any()`). To be honest, I am not sure how come that pandas implementation works with the switched order :).

pandas implementation for a reference:

https://github.com/pandas-dev/pandas/blob/6e1802312b019a061209f3bd75b12a039457f14e/pandas/core/arrays/base.py#L358-L373