### PR TITLE
DOC: fix simple typo, recommenend -> recommend

### DIFF
--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -240,7 +240,7 @@ For example, instead of:
 
    gdf.crs = "+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs"
 
-we recommenend to do:
+we recommend to do:
 
 .. code-block:: python
 


### PR DESCRIPTION
There is a small typo in doc/source/docs/user_guide/projections.rst.

Should read `recommend` rather than `recommenend`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md