### PR TITLE
TST: skip test_argreduce_series

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -506,6 +506,10 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argmin_argmax_all_na(self):
         pass
 
+    @no_sorting
+    def test_argreduce_series(self):
+        pass
+
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass


### PR DESCRIPTION
Skipping new extension array test `test_argreduce_series` since we do not support sorting in `GeometryArray`. 
This should make CI green again.