### PR TITLE
DEP: lazily import fiona only when used (to make it possible to not have it installed)

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -40,7 +40,7 @@ _VALID_URLS.discard("")
 def _check_fiona(func):
     if fiona is None:
         raise ImportError(
-            f"the {func} requires the fiona package, but it is not installed or does "
+            f"the {func} requires the 'fiona' package, but it is not installed or does "
             f"not import correctly.\nImporting fiona resulted in: {fiona_import_error}"
         )
 

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -11,7 +11,8 @@ def test_no_additional_imports():
         "pytest",
         "py",
         "ipython",
-        "fiona",
+        # fiona actually gets imported if installed (but error suppressed until used)
+        # "fiona",
         # "matplotlib",  # matplotlib gets imported by pandas, see below
         "mapclassify",
         # 'rtree',  # rtree actually gets imported if installed

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -11,6 +11,7 @@ def test_no_additional_imports():
         "pytest",
         "py",
         "ipython",
+        "fiona",
         # "matplotlib",  # matplotlib gets imported by pandas, see below
         "mapclassify",
         # 'rtree',  # rtree actually gets imported if installed

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -7,7 +7,6 @@ from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 
-import fiona
 import pyproj
 from pyproj import CRS
 from pyproj.exceptions import CRSError
@@ -480,6 +479,7 @@ class TestDataFrame:
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, 5:])
 
     def test_from_features(self):
+        fiona = pytest.importorskip("fiona")
         nybb_filename = geopandas.datasets.get_path("nybb")
         with fiona.open(nybb_filename) as f:
             features = list(f)


### PR DESCRIPTION
A first possible step towards https://github.com/geopandas/geopandas/issues/1313

I did this a while ago, so thought to at least open it as a PR. 
While this already works fine as is, I think the main question is if we actually want to test this / allow to run our tests without fiona (to make it a proper optional dependency). Because given how *many* of our tests use fiona to read in a test dataset, it might be a bit invasive to change this. 