### PR TITLE
TST: skip pandas EA test

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -510,6 +510,10 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argreduce_series(self):
         pass
 
+    @no_sorting
+    def test_argmax_argmin_no_skipna_notimplemented(self):
+        pass
+
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass


### PR DESCRIPTION
Skipping another pandas ExtensionArray test not supported on geometries.

xref  (pandas-dev/pandas#38733)