### PR TITLE
Only use pygeos is a recent version is installed

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -176,9 +176,9 @@ experimental speedups by installing PyGEOS. This can be done with conda
 
 More specifically, whether the speedups are used or not is determined by:
 
-- If PyGEOS is installed, it will be used by default (but installing GeoPandas
-  will not yet automatically install PyGEOS as dependency, you need to do this
-  manually).
+- If PyGEOS >= 0.8 is installed, it will be used by default (but installing
+  GeoPandas will not yet automatically install PyGEOS as dependency, you need
+  to do this manually).
 
 - You can still toggle the use of PyGEOS when it is available, by:
 

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -33,7 +33,11 @@ PYGEOS_SHAPELY_COMPAT = None
 try:
     import pygeos  # noqa
 
-    HAS_PYGEOS = True
+    # only automatically use pygeos if version is high enough
+    if str(pygeos.__version__) >= LooseVersion("0.8"):
+        HAS_PYGEOS = True
+    else:
+        HAS_PYGEOS = False
 except ImportError:
     HAS_PYGEOS = False
 
@@ -68,7 +72,7 @@ def set_use_pygeos(val=None):
             import pygeos  # noqa
 
             # validate the pygeos version
-            if not str(pygeos.__version__) >= LooseVersion("0.6"):
+            if not str(pygeos.__version__) >= LooseVersion("0.8"):
                 raise ImportError(
                     "PyGEOS >= 0.6 is required, version {0} is installed".format(
                         pygeos.__version__

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -37,6 +37,11 @@ try:
     if str(pygeos.__version__) >= LooseVersion("0.8"):
         HAS_PYGEOS = True
     else:
+        warnings.warn(
+            "The installed version of PyGEOS is too old ({0} installed, 0.8 required),"
+            " and thus GeoPandas will not use PyGEOS.".format(pygeos.__version__),
+            UserWarning,
+        )
         HAS_PYGEOS = False
 except ImportError:
     HAS_PYGEOS = False


### PR DESCRIPTION
This should avoid issues like https://github.com/geopandas/geopandas/issues/1778 where having an older version of pygeos installed causes geopandas to stop working (if you explicitly set the option to use pygeos, it will still give an error that the version if too old).

I didn't check what version we actually require, but 0.6 is certainly too old, since `query_bulk` was only added in 0.7. And 0.8 is already a few months old, so that seems fine. 