### PR TITLE
BUG: Create unintialized GeoSeries

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -201,7 +201,7 @@ class GeoSeries(GeoPandasBase, Series):
                 s = pd.Series(data, index=index, name=name, **kwargs)
             # prevent trying to convert non-geometry objects
             if s.dtype != object:
-                if s.empty:
+                if s.empty or data is None:
                     s = s.astype(object)
                 else:
                     warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -376,6 +376,10 @@ class TestConstructor:
         s = GeoSeries()
         check_geoseries(s)
 
+    def test_data_is_none(self):
+        s = GeoSeries(index=range(3))
+        check_geoseries(s)
+
     def test_from_series(self):
         shapes = [
             Polygon([(random.random(), random.random()) for _ in range(3)])


### PR DESCRIPTION
Fixes #1704 (probably not completely)

I went for the easy fix (which still addresses the initial message of the issue), so that I could ask some clarifying questions.

The message below seems to suggest that when not passing the data argument (or passing `None`) to the GeoSeries constructor:

1.  there should be no warning raised
2.  a GeoSeries should still be returned.

Is this correct ?

> Thanks for the notice! This is indeed something worth fixing. Not only because of this, but also to avoid that warning we raise during (and potential deprecation in the future).
```
FutureWarning:     You are passing non-geometry data to the GeoSeries constructor. Currently,
    it falls back to returning a pandas Series. But in the future, we will start
    to raise a TypeError instead.
```
> Our constructor should check for this case and return proper GeoSeries in this case:
>https://github.com/geopandas/geopandas/blob/cdb42821ababcf29b6f7f94dd66fa9cb5a8f6071/geopandas/geoseries.py#L103

_Originally posted by @martinfleis in https://github.com/geopandas/geopandas/issues/1704#issuecomment-729994155_

