### PR TITLE
TST: Fix sindex query predicates used in benchmarks

### DIFF
--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -1,8 +1,14 @@
-from geopandas import read_file, datasets
-from geopandas.sindex import VALID_QUERY_PREDICATES
+from shapely.geometry import Point
+
+from geopandas import read_file, datasets, GeoSeries
+from geopandas.sindex import _get_sindex_class
 
 
-predicates = sorted(VALID_QUERY_PREDICATES, key=lambda x: (x is None, x))
+# Derive list of valid query predicates based on underlying index backend;
+# we have to create a non-empty instance of the index to get these
+index = _get_sindex_class()(GeoSeries([Point(0, 0)]).values.data)
+predicates = sorted(p for p in index.valid_query_predicates if p is not None)
+
 geom_types = ("mixed", "points", "polygons")
 
 

--- a/benchmarks/sindex.py
+++ b/benchmarks/sindex.py
@@ -1,12 +1,11 @@
 from shapely.geometry import Point
 
 from geopandas import read_file, datasets, GeoSeries
-from geopandas.sindex import _get_sindex_class
 
 
 # Derive list of valid query predicates based on underlying index backend;
 # we have to create a non-empty instance of the index to get these
-index = _get_sindex_class()(GeoSeries([Point(0, 0)]).values.data)
+index = GeoSeries([Point(0, 0)]).sindex
 predicates = sorted(p for p in index.valid_query_predicates if p is not None)
 
 geom_types = ("mixed", "points", "polygons")


### PR DESCRIPTION
This corrects for removal of `VALID_QUERY_PREDICATES` in #1698, which breaks the sindex benchmarks.

Query predicates are now a property on the instance of a sindex backend class.  To get these up front, we have to first create a non-empty instance of the sindex.