### PR TITLE
DOC: Update copyright year

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -97,7 +97,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"GeoPandas"
-copyright = u"2013–2019, GeoPandas developers"
+copyright = u"2013–2021, GeoPandas developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
The copyright states 2013-2019, but the project looks like it's still being updated as of 2021. This PR changes the end copyright date to 2021.