### PR TITLE
TST: check exact warning

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -672,7 +672,8 @@ class TestGeomMethods:
             # do not warn for 0
             self.g4.buffer(0)
 
-        assert len(record) == 0
+        for r in record:
+            assert "Geometry is in a geographic CRS." not in str(r.message)
 
     def test_envelope(self):
         e = self.g3.envelope


### PR DESCRIPTION
Check for a specific warning instead of generic number in buffer CRS warning. It currently fails since pygeog 0.8 and numpy 1.20 raise the following warning (fixed in pygeos 0.9)

```
  /opt/miniconda3/envs/test/lib/python3.7/site-packages/pygeos/constructive.py:165: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    np.bool(single_sided),
```

https://github.com/geopandas/geopandas/runs/1803069757?check_suite_focus=true#step:7:2826