### PR TITLE
Compatibility with Shapely 1.8 deprecation warnings (__len__)

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -137,7 +137,7 @@ if shapely_warning is not None and not SHAPELY_GE_20:
     def ignore_shapely2_warnings():
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore", "Iteration|The array interface", shapely_warning
+                "ignore", "Iteration|The array interface|__len__", shapely_warning
             )
             yield
 


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/geopandas/pull/1659 and https://github.com/geopandas/geopandas/pull/1662, also catching the deprecation warning for `len(..)`