### PR TITLE
TST: add normalize option to assert methods + fix tests for GEOS 3.9

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -6,6 +6,8 @@ import warnings
 
 import pandas as pd
 import shapely
+import shapely.geos
+
 
 # -----------------------------------------------------------------------------
 # pandas compat
@@ -25,6 +27,8 @@ PANDAS_GE_12 = str(pd.__version__) >= LooseVersion("1.2.0")
 SHAPELY_GE_17 = str(shapely.__version__) >= LooseVersion("1.7.0")
 SHAPELY_GE_18 = str(shapely.__version__) >= LooseVersion("1.8")
 SHAPELY_GE_20 = str(shapely.__version__) >= LooseVersion("2.0")
+
+GEOS_GE_390 = shapely.geos.geos_version >= (3, 9, 0)
 
 
 HAS_PYGEOS = None

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import GeometryDtype
+from geopandas import _vectorized
 
 
 def _isna(this):
@@ -67,6 +68,7 @@ def assert_geoseries_equal(
     check_less_precise=False,
     check_geom_type=False,
     check_crs=True,
+    normalize=False,
 ):
     """
     Test util for checking that two GeoSeries are equal.
@@ -89,6 +91,10 @@ def assert_geoseries_equal(
     check_crs: bool, default True
         If `check_series_type` is True, then also check that the
         crs matches.
+    normalize: bool, default False
+        If True, normalize the geometries before comparing equality.
+        Typically useful with ``check_less_precise=True``, which uses
+        ``geom_almost_equals`` and requires exact coordinate order.
     """
     assert len(left) == len(right), "%d != %d" % (len(left), len(right))
 
@@ -120,6 +126,10 @@ def assert_geoseries_equal(
             right.type,
         )
 
+    if normalize:
+        left = GeoSeries(_vectorized.normalize(left.array.data))
+        right = GeoSeries(_vectorized.normalize(right.array.data))
+
     if not check_crs:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "CRS mismatch", UserWarning)
@@ -145,6 +155,7 @@ def assert_geodataframe_equal(
     check_less_precise=False,
     check_geom_type=False,
     check_crs=True,
+    normalize=False,
 ):
     """
     Check that two GeoDataFrames are equal/
@@ -168,6 +179,10 @@ def assert_geodataframe_equal(
     check_crs: bool, default True
         If `check_frame_type` is True, then also check that the
         crs matches.
+    normalize: bool, default False
+        If True, normalize the geometries before comparing equality.
+        Typically useful with ``check_less_precise=True``, which uses
+        ``geom_almost_equals`` and requires exact coordinate order.
     """
     try:
         # added from pandas 0.20
@@ -217,6 +232,7 @@ def assert_geodataframe_equal(
             assert_geoseries_equal(
                 left[col],
                 right[col],
+                normalize=normalize,
                 check_dtype=check_dtype,
                 check_less_precise=check_less_precise,
                 check_geom_type=check_geom_type,

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -191,7 +191,12 @@ def test_overlay_nybb(how):
     expected.geometry[expected.geometry.geom_type == "MultiPolygon"] = None
 
     assert_geodataframe_equal(
-        result, expected, check_crs=False, check_column_type=False
+        result,
+        expected,
+        normalize=True,
+        check_crs=False,
+        check_column_type=False,
+        check_less_precise=True,
     )
 
 
@@ -244,7 +249,11 @@ def test_overlay_overlap(how):
         result = result.sort_values(["col1", "col2"]).reset_index(drop=True)
 
     assert_geodataframe_equal(
-        result, expected, check_column_type=False, check_less_precise=True
+        result,
+        expected,
+        normalize=True,
+        check_column_type=False,
+        check_less_precise=True,
     )
 
 
@@ -469,6 +478,7 @@ def test_overlay_strict(how, keep_geom_type, geom_types):
         assert_geodataframe_equal(
             result,
             expected,
+            normalize=True,
             check_column_type=False,
             check_less_precise=True,
             check_crs=False,

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1490,7 +1490,10 @@ def test_polygon_patch():
     patch = _PolygonPatch(polygon)
     assert isinstance(patch, PathPatch)
     path = patch.get_path()
-    assert len(path.vertices) == len(path.codes) == 198
+    if compat.GEOS_GE_390:
+        assert len(path.vertices) == len(path.codes) == 195
+    else:
+        assert len(path.vertices) == len(path.codes) == 198
 
 
 def _check_colors(N, actual_colors, expected_colors, alpha=None):

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -412,10 +412,14 @@ class TestPygeosInterface:
 
         test_geo = test_df.geometry.values.data[0]
         res = tree_df.sindex.query(test_geo, sort=sort)
+
+        # asserting the same elements
+        assert set(res) == set(expected)
+        # asserting the exact array can fail if sort=False
         try:
             assert_array_equal(res, expected)
         except AssertionError as e:
-            if not compat.USE_PYGEOS and sort is False:
+            if sort is False:
                 pytest.xfail(
                     "rtree results are known to be unordered, see "
                     "https://github.com/geopandas/geopandas/issues/1337\n"
@@ -649,10 +653,15 @@ class TestPygeosInterface:
         test_df = geopandas.GeoDataFrame(geometry=test_polys)
 
         res = tree_df.sindex.query_bulk(test_df.geometry, sort=sort)
+
+        # asserting the same elements
+        assert set(res[0]) == set(expected[0])
+        assert set(res[1]) == set(expected[1])
+        # asserting the exact array can fail if sort=False
         try:
             assert_array_equal(res, expected)
         except AssertionError as e:
-            if not compat.USE_PYGEOS and sort is False:
+            if sort is False:
                 pytest.xfail(
                     "rtree results are known to be unordered, see "
                     "https://github.com/geopandas/geopandas/issues/1337\n"

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -414,7 +414,7 @@ class TestPygeosInterface:
         res = tree_df.sindex.query(test_geo, sort=sort)
 
         # asserting the same elements
-        assert set(res) == set(expected)
+        assert sorted(res) == sorted(expected)
         # asserting the exact array can fail if sort=False
         try:
             assert_array_equal(res, expected)
@@ -655,8 +655,8 @@ class TestPygeosInterface:
         res = tree_df.sindex.query_bulk(test_df.geometry, sort=sort)
 
         # asserting the same elements
-        assert set(res[0]) == set(expected[0])
-        assert set(res[1]) == set(expected[1])
+        assert sorted(res[0]) == sorted(expected[0])
+        assert sorted(res[1]) == sorted(expected[1])
         # asserting the exact array can fail if sort=False
         try:
             assert_array_equal(res, expected)


### PR DESCRIPTION
Closes #1818

This adds `normalize` capabilities. For now I only added it to our assert_.. functions. Eventually we might also want to add it to the GeometryArray/GeoSeries, but for that I would like to wait on Shapely including it (https://github.com/Toblerity/Shapely/pull/1090/)

Normalizing the geometries fixes most of the overlay tests, only the NYBB tests are still failing (here the differences with GEOS 3.9 are bigger than just some coordinate order). Not sure what the best way to solve this is. We can skip the geometry equality check for now with GEOS 3.9 (we already check area and bounds, and that passes), and later re-produce the expected files with GEOS 3.9