### PR TITLE
DOC: only include common spatial index interface in the docs

### DIFF
--- a/doc/source/docs/reference/sindex.rst
+++ b/doc/source/docs/reference/sindex.rst
@@ -18,9 +18,13 @@ Constructor
 
     GeoSeries.sindex
 
-PyGEOS STRtree
---------------
-.. currentmodule:: geopandas.sindex.PyGEOSSTRTreeIndex
+Spatial Index object
+--------------------
+
+The spatial index object returned from :attr:`GeoSeries.sindex` has the following
+methods:
+
+.. currentmodule:: geopandas.sindex.SpatialIndex
 .. autosummary::
    :toctree: api/
 
@@ -31,20 +35,11 @@ PyGEOS STRtree
     size
     valid_query_predicates
 
-rtree Rtree
------------
-.. currentmodule:: geopandas.sindex.RTreeIndex
-.. autosummary::
-   :toctree: api/
+The concrete implementations currently available are
+``geopandas.sindex.PyGEOSSTRTreeIndex`` and ``geopandas.sindex.RTreeIndex``.
 
-    intersection
-    is_empty
-    query
-    query_bulk
-    size
-    valid_query_predicates
-
-Furthermore, the ``rtree``-based spatial index offers full capability of
+In addition to the methods listed above, the ``rtree``-based spatial index
+(``geopandas.sindex.RTreeIndex``) offers the full capability of
 ``rtree.index.Index`` - see the full API in the `rtree documentation`_.
 
 .. _rtree documentation: https://rtree.readthedocs.io/en/stable/class.html

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -50,10 +50,8 @@ class SpatialIndex(metaclass=abc.ABCMeta):
         """Return the index of all geometries in the tree with extents that
         intersect the envelope of the input geometry.
 
-        Compatibility layer for pygeos-based ``sindex.query``.
-
-        This is not a vectorized function, if speed is important,
-        please use PyGEOS.
+        When using the ``rtree`` package, this is not a vectorized function.
+        If speed is important, please use PyGEOS.
 
         Parameters
         ----------
@@ -108,11 +106,15 @@ class SpatialIndex(metaclass=abc.ABCMeta):
         the tree where the envelope of each input geometry intersects with
         the envelope of a tree geometry.
 
-        Compatibility layer for pygeos-based ``sindex.query_bulk``.
+        In the context of a spatial join, input geometries are the “left”
+        geometries that determine the order of the results, and tree geometries
+        are “right” geometries that are joined against the left geometries.
+        This effectively performs an inner join, where only those combinations
+        of geometries that can be joined based on envelope overlap or optional
+        predicate are returned.
 
-        Iterates over ``geometry`` and queries index.
-        This operation is not vectorized and may be slow.
-        Use PyGEOS with ``query_bulk`` for speed.
+        When using the ``rtree`` package, this is not a vectorized function
+        and may be slow. If speed is important, please use PyGEOS.
 
         Parameters
         ----------
@@ -171,7 +173,8 @@ class SpatialIndex(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def intersection(self, coordinates):
-        """Wrapper for rtree.index.Index.intersection.
+        """Compatibility wrapper for rtree.index.Index.intersection,
+        use ``query`` intead.
 
         Parameters
         ----------

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -516,61 +516,8 @@ if compat.HAS_PYGEOS:
             """
             return pygeos.strtree.VALID_PREDICATES | set([None])
 
+        @doc(SpatialIndex.query)
         def query(self, geometry, predicate=None, sort=False):
-            """
-            Return the index of all geometries in the tree with extents
-            that intersect the envelope of the input geometry.
-
-            Wrapper for pygeos.STRtree.query.
-
-            This also ensures a deterministic (sorted) order for the results.
-
-            Parameters
-            ----------
-            geometry : single PyGEOS or shapely geometry
-            predicate : {None, 'intersects', 'within', 'contains', \
-'overlaps', 'crosses', 'touches'}, optional
-                If predicate is provided, the input geometry is tested
-                using the predicate function against each item in the
-                tree whose extent intersects the envelope of the input
-                geometry: predicate(input_geometry, tree_geometry).
-            sort : bool, default False
-                If True, the results will be sorted in ascending order.
-                If False, results are often sorted but there is no guarantee.
-
-            Returns
-            -------
-            matches : ndarray of shape (n_results, )
-                Integer indices for matching geometries from the spatial index.
-
-            Notes
-            -----
-            See PyGEOS.strtree documentation for more information.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.query(box(1, 1, 3, 3))
-            array([1, 2, 3])
-
-            >>> s.sindex.query(box(1, 1, 3, 3), predicate="contains")
-            array([2])
-            """
-
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
                     "Got `predicate` = `{}`; ".format(predicate)
@@ -589,81 +536,8 @@ if compat.HAS_PYGEOS:
 
             return matches
 
+        @doc(SpatialIndex.query_bulk)
         def query_bulk(self, geometry, predicate=None, sort=False):
-            """
-            Returns all combinations of each input geometry and geometries in
-            the tree where the envelope of each input geometry intersects with
-            the envelope of a tree geometry.
-
-            Wrapper to expose underlaying pygeos objects to pygeos.query_bulk.
-
-            In the context of a spatial join, input geometries are the “left”
-            geometries that determine the order of the results, and tree geometries
-            are “right” geometries that are joined against the left geometries.
-            This effectively performs an inner join, where only those combinations
-            of geometries that can be joined based on envelope overlap or optional
-            predicate are returned.
-
-            This also allows a deterministic (sorted) order for the results.
-
-
-            Parameters
-            ----------
-            geometry : {GeoSeries, GeometryArray, numpy.array of PyGEOS geometries}
-                Accepts GeoPandas geometry iterables (GeoSeries, GeometryArray)
-                or a numpy array of PyGEOS geometries.
-            predicate : {None, 'intersects', 'within', 'contains', \
-'overlaps', 'crosses', 'touches'}, optional
-                If predicate is provided, the input geometry is tested
-                using the predicate function against each item in the
-                index whose extent intersects the envelope of the input geometry:
-                predicate(input_geometry, tree_geometry).
-            sort : bool, default False
-                If True, results sorted lexicographically using
-                geometry's indexes as the primary key and the sindex's indexes as the
-                secondary key. If False, no additional sorting is applied.
-
-            Returns
-            -------
-            ndarray with shape (2, n)
-                The first subarray contains input geometry integer indexes.
-                The second subarray contains tree geometry integer indexes.
-
-            Notes
-            -----
-            See PyGEOS.strtree documentation for more information.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-            >>> s2 = geopandas.GeoSeries([box(2, 2, 4, 4), box(5, 5, 6, 6)])
-            >>> s2
-            0    POLYGON ((4.00000 2.00000, 4.00000 4.00000, 2....
-            1    POLYGON ((6.00000 5.00000, 6.00000 6.00000, 5....
-            dtype: geometry
-
-            >>> s.sindex.query_bulk(s2)
-            array([[0, 0, 0, 1, 1],
-                   [2, 3, 4, 5, 6]])
-
-            >>> s.sindex.query_bulk(s2, predicate="contains")
-            array([[0],
-                   [3]])
-            """
-
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
                     "Got `predicate` = `{}`, `predicate` must be one of {}".format(
@@ -687,41 +561,8 @@ if compat.HAS_PYGEOS:
 
             return res
 
+        @doc(SpatialIndex.intersection)
         def intersection(self, coordinates):
-            """Wrapper for pygeos.query that uses the RTree API.
-
-            Compatibility wrapper, use ``query`` instead.
-
-            Parameters
-            ----------
-            coordinates : sequence or array
-                Sequence of the form (min_x, min_y, max_x, max_y)
-                to query a rectangle or (x, y) to query a point.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.query(box(1, 1, 3, 3))
-            array([1, 2, 3])
-
-            >>> s.sindex.intersection(box(1, 1, 3, 3).bounds)
-            array([1, 2, 3])
-
-            """
             # convert bounds to geometry
             # the old API uses tuples of bound, but pygeos uses geometries
             try:
@@ -750,60 +591,12 @@ if compat.HAS_PYGEOS:
 
             return indexes
 
+        @doc(SpatialIndex.size)
         @property
         def size(self):
-            """Size of the spatial index
-
-            Number of leaves (input geometries) in the index.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.size
-            10
-            """
             return len(self)
 
+        @doc(SpatialIndex.is_empty)
         @property
         def is_empty(self):
-            """Check if the spatial index is empty
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.is_empty
-            False
-
-            >>> s2 = geopandas.GeoSeries()
-            >>> s2.sindex.is_empty
-            True
-            """
             return len(self) == 0

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -1,3 +1,6 @@
+import abc
+from textwrap import dedent
+
 from shapely.geometry.base import BaseGeometry
 import pandas as pd
 import numpy as np
@@ -21,13 +24,269 @@ def _get_sindex_class():
     )
 
 
+class SpatialIndex(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def valid_query_predicates(self):
+        """Returns valid predicates for this spatial index.
+
+        Returns
+        -------
+        set
+            Set of valid predicates for this spatial index.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> s = geopandas.GeoSeries([Point(0, 0), Point(1, 1)])
+        >>> s.sindex.valid_query_predicates  # doctest: +SKIP
+        {'contains', 'crosses', 'intersects', 'within', 'touches', \
+'overlaps', None, 'covers', 'contains_properly'}
+        """
+        pass
+
+    @abc.abstractmethod
+    def query(self, geometry, predicate=None, sort=False):
+        """Return the index of all geometries in the tree with extents that
+        intersect the envelope of the input geometry.
+
+        Compatibility layer for pygeos-based ``sindex.query``.
+
+        This is not a vectorized function, if speed is important,
+        please use PyGEOS.
+
+        Parameters
+        ----------
+        geometry : shapely geometry
+            A single shapely geometry to query against the spatial index.
+        predicate : {None, 'intersects', 'within', 'contains', \
+'overlaps', 'crosses', 'touches'}, optional
+            If predicate is provided, the input geometry is
+            tested using the predicate function against each item
+            in the tree whose extent intersects the envelope of the
+            input geometry: predicate(input_geometry, tree_geometry).
+            If possible, prepared geometries are used to help
+            speed up the predicate operation.
+        sort : bool, default False
+            If True, the results will be sorted in ascending order.
+            If False, results are often sorted but there is no guarantee.
+
+        Returns
+        -------
+        matches : ndarray of shape (n_results, )
+            Integer indices for matching geometries from the spatial index.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, box
+        >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
+        >>> s
+        0    POINT (0.00000 0.00000)
+        1    POINT (1.00000 1.00000)
+        2    POINT (2.00000 2.00000)
+        3    POINT (3.00000 3.00000)
+        4    POINT (4.00000 4.00000)
+        5    POINT (5.00000 5.00000)
+        6    POINT (6.00000 6.00000)
+        7    POINT (7.00000 7.00000)
+        8    POINT (8.00000 8.00000)
+        9    POINT (9.00000 9.00000)
+        dtype: geometry
+
+        >>> s.sindex.query(box(1, 1, 3, 3))
+        array([1, 2, 3])
+
+        >>> s.sindex.query(box(1, 1, 3, 3), predicate="contains")
+        array([2])
+        """
+        pass
+
+    @abc.abstractmethod
+    def query_bulk(self, geometry, predicate=None, sort=False):
+        """
+        Returns all combinations of each input geometry and geometries in
+        the tree where the envelope of each input geometry intersects with
+        the envelope of a tree geometry.
+
+        Compatibility layer for pygeos-based ``sindex.query_bulk``.
+
+        Iterates over ``geometry`` and queries index.
+        This operation is not vectorized and may be slow.
+        Use PyGEOS with ``query_bulk`` for speed.
+
+        Parameters
+        ----------
+        geometry : {GeoSeries, GeometryArray, numpy.array of PyGEOS geometries}
+            Accepts GeoPandas geometry iterables (GeoSeries, GeometryArray)
+            or a numpy array of PyGEOS geometries.
+        predicate : {None, 'intersects', 'within', 'contains', 'overlaps', \
+'crosses', 'touches'}, optional
+            If predicate is provided, the input geometries are tested using
+            the predicate function against each item in the tree whose extent
+            intersects the envelope of the each input geometry:
+            predicate(input_geometry, tree_geometry).  If possible, prepared
+            geometries are used to help speed up the predicate operation.
+        sort : bool, default False
+            If True, results sorted lexicographically using
+            geometry's indexes as the primary key and the sindex's indexes as the
+            secondary key. If False, no additional sorting is applied.
+
+        Returns
+        -------
+        ndarray with shape (2, n)
+            The first subarray contains input geometry integer indexes.
+            The second subarray contains tree geometry integer indexes.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, box
+        >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
+        >>> s
+        0    POINT (0.00000 0.00000)
+        1    POINT (1.00000 1.00000)
+        2    POINT (2.00000 2.00000)
+        3    POINT (3.00000 3.00000)
+        4    POINT (4.00000 4.00000)
+        5    POINT (5.00000 5.00000)
+        6    POINT (6.00000 6.00000)
+        7    POINT (7.00000 7.00000)
+        8    POINT (8.00000 8.00000)
+        9    POINT (9.00000 9.00000)
+        dtype: geometry
+        >>> s2 = geopandas.GeoSeries([box(2, 2, 4, 4), box(5, 5, 6, 6)])
+        >>> s2
+        0    POLYGON ((4.00000 2.00000, 4.00000 4.00000, 2....
+        1    POLYGON ((6.00000 5.00000, 6.00000 6.00000, 5....
+        dtype: geometry
+
+        >>> s.sindex.query_bulk(s2)
+        array([[0, 0, 0, 1, 1],
+                [2, 3, 4, 5, 6]])
+
+        >>> s.sindex.query_bulk(s2, predicate="contains")
+        array([[0],
+                [3]])
+        """
+        pass
+
+    @abc.abstractmethod
+    def intersection(self, coordinates):
+        """Wrapper for rtree.index.Index.intersection.
+
+        Parameters
+        ----------
+        coordinates : sequence or array
+            Sequence of the form (min_x, min_y, max_x, max_y)
+            to query a rectangle or (x, y) to query a point.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point, box
+        >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
+        >>> s
+        0    POINT (0.00000 0.00000)
+        1    POINT (1.00000 1.00000)
+        2    POINT (2.00000 2.00000)
+        3    POINT (3.00000 3.00000)
+        4    POINT (4.00000 4.00000)
+        5    POINT (5.00000 5.00000)
+        6    POINT (6.00000 6.00000)
+        7    POINT (7.00000 7.00000)
+        8    POINT (8.00000 8.00000)
+        9    POINT (9.00000 9.00000)
+        dtype: geometry
+
+        >>> s.sindex.intersection(box(1, 1, 3, 3).bounds)
+        array([1, 2, 3])
+
+        Alternatively, you can use ``query``:
+
+        >>> s.sindex.query(box(1, 1, 3, 3))
+        array([1, 2, 3])
+
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def size(self):
+        """Size of the spatial index
+
+        Number of leaves (input geometries) in the index.
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
+        >>> s
+        0    POINT (0.00000 0.00000)
+        1    POINT (1.00000 1.00000)
+        2    POINT (2.00000 2.00000)
+        3    POINT (3.00000 3.00000)
+        4    POINT (4.00000 4.00000)
+        5    POINT (5.00000 5.00000)
+        6    POINT (6.00000 6.00000)
+        7    POINT (7.00000 7.00000)
+        8    POINT (8.00000 8.00000)
+        9    POINT (9.00000 9.00000)
+        dtype: geometry
+
+        >>> s.sindex.size
+        10
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def is_empty(self):
+        """Check if the spatial index is empty
+
+        Examples
+        --------
+        >>> from shapely.geometry import Point
+        >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
+        >>> s
+        0    POINT (0.00000 0.00000)
+        1    POINT (1.00000 1.00000)
+        2    POINT (2.00000 2.00000)
+        3    POINT (3.00000 3.00000)
+        4    POINT (4.00000 4.00000)
+        5    POINT (5.00000 5.00000)
+        6    POINT (6.00000 6.00000)
+        7    POINT (7.00000 7.00000)
+        8    POINT (8.00000 8.00000)
+        9    POINT (9.00000 9.00000)
+        dtype: geometry
+
+        >>> s.sindex.is_empty
+        False
+
+        >>> s2 = geopandas.GeoSeries()
+        >>> s2.sindex.is_empty
+        True
+        """
+        pass
+
+
+def doc(docstring):
+    """
+    A decorator take docstring from passed object and it to decorated one.
+    """
+
+    def decorator(decorated):
+        decorated.__doc__ = dedent(docstring.__doc__ or "")
+        return decorated
+
+    return decorator
+
+
 if compat.HAS_RTREE:
 
     import rtree.index  # noqa
     from rtree.core import RTreeError  # noqa
     from shapely.prepared import prep  # noqa
 
-    class SpatialIndex(rtree.index.Index):
+    class SpatialIndex2(rtree.index.Index):
         """Original rtree wrapper, kept for backwards compatibility."""
 
         def __init__(self, *args):
@@ -74,23 +333,9 @@ if compat.HAS_RTREE:
                 [None] * self.geometries.size, dtype=object
             )
 
+        @doc(SpatialIndex.valid_query_predicates)
         @property
         def valid_query_predicates(self):
-            """Returns valid predicates for this spatial index.
-
-            Returns
-            -------
-            set
-                Set of valid predicates for this spatial index.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point
-            >>> s = geopandas.GeoSeries([Point(0, 0), Point(1, 1)])
-            >>> s.sindex.valid_query_predicates  # doctest: +SKIP
-            {'contains', 'crosses', 'intersects', 'within', 'touches', \
-'overlaps', None, 'covers', 'contains_properly'}
-            """
             return {
                 None,
                 "intersects",
@@ -103,60 +348,8 @@ if compat.HAS_RTREE:
                 "contains_properly",
             }
 
+        @doc(SpatialIndex.query)
         def query(self, geometry, predicate=None, sort=False):
-            """Return the index of all geometries in the tree with extents that
-            intersect the envelope of the input geometry.
-
-            Compatibility layer for pygeos-based ``sindex.query``.
-
-            This is not a vectorized function, if speed is important,
-            please use PyGEOS.
-
-            Parameters
-            ----------
-            geometry : shapely geometry
-                A single shapely geometry to query against the spatial index.
-            predicate : {None, 'intersects', 'within', 'contains', \
-'overlaps', 'crosses', 'touches'}, optional
-                If predicate is provided, the input geometry is
-                tested using the predicate function against each item
-                in the tree whose extent intersects the envelope of the
-                input geometry: predicate(input_geometry, tree_geometry).
-                If possible, prepared geometries are used to help
-                speed up the predicate operation.
-            sort : bool, default False
-                If True, the results will be sorted in ascending order.
-                If False, results are often sorted but there is no guarantee.
-
-            Returns
-            -------
-            matches : ndarray of shape (n_results, )
-                Integer indices for matching geometries from the spatial index.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.query(box(1, 1, 3, 3))
-            array([1, 2, 3])
-
-            >>> s.sindex.query(box(1, 1, 3, 3), predicate="contains")
-            array([2])
-            """
-
             # handle invalid predicates
             if predicate not in self.valid_query_predicates:
                 raise ValueError(
@@ -235,71 +428,8 @@ if compat.HAS_RTREE:
             # unsorted
             return np.array(tree_idx, dtype=np.intp)
 
+        @doc(SpatialIndex.query_bulk)
         def query_bulk(self, geometry, predicate=None, sort=False):
-            """
-            Returns all combinations of each input geometry and geometries in
-            the tree where the envelope of each input geometry intersects with
-            the envelope of a tree geometry.
-
-            Compatibility layer for pygeos-based ``sindex.query_bulk``.
-
-            Iterates over ``geometry`` and queries index.
-            This operation is not vectorized and may be slow.
-            Use PyGEOS with ``query_bulk`` for speed.
-
-            Parameters
-            ----------
-            geometry : {GeoSeries, GeometryArray, numpy.array of PyGEOS geometries}
-                Accepts GeoPandas geometry iterables (GeoSeries, GeometryArray)
-                or a numpy array of PyGEOS geometries.
-            predicate : {None, 'intersects', 'within', 'contains', 'overlaps', \
-'crosses', 'touches'}, optional
-                If predicate is provided, the input geometries are tested using
-                the predicate function against each item in the tree whose extent
-                intersects the envelope of the each input geometry:
-                predicate(input_geometry, tree_geometry).  If possible, prepared
-                geometries are used to help speed up the predicate operation.
-            sort : bool, default False
-                If True, results sorted lexicographically using
-                geometry's indexes as the primary key and the sindex's indexes as the
-                secondary key. If False, no additional sorting is applied.
-
-            Returns
-            -------
-            ndarray with shape (2, n)
-                The first subarray contains input geometry integer indexes.
-                The second subarray contains tree geometry integer indexes.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-            >>> s2 = geopandas.GeoSeries([box(2, 2, 4, 4), box(5, 5, 6, 6)])
-            >>> s2
-            0    POLYGON ((4.00000 2.00000, 4.00000 4.00000, 2....
-            1    POLYGON ((6.00000 5.00000, 6.00000 6.00000, 5....
-            dtype: geometry
-
-            >>> s.sindex.query_bulk(s2)
-            array([[0, 0, 0, 1, 1],
-                   [2, 3, 4, 5, 6]])
-
-            >>> s.sindex.query_bulk(s2, predicate="contains")
-            array([[0],
-                   [3]])
-            """
             # Iterates over geometry, applying func.
             tree_index = []
             input_geometry_index = []
@@ -310,69 +440,13 @@ if compat.HAS_RTREE:
                 input_geometry_index.extend([i] * len(res))
             return np.vstack([input_geometry_index, tree_index])
 
+        @doc(SpatialIndex.intersection)
         def intersection(self, coordinates):
-            """Wrapper for rtree.index.Index.intersection.
-
-            Parameters
-            ----------
-            coordinates : sequence or array
-                Sequence of the form (min_x, min_y, max_x, max_y)
-                to query a rectangle or (x, y) to query a point.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point, box
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.intersection(box(1, 1, 3, 3).bounds)
-            array([1, 2, 3])
-
-            Alternatively, you can use ``query``:
-
-            >>> s.sindex.query(box(1, 1, 3, 3))
-            array([1, 2, 3])
-
-            """
             return super().intersection(coordinates, objects=False)
 
+        @doc(SpatialIndex.size)
         @property
         def size(self):
-            """Size of the spatial index
-
-            Number of leaves (input geometries) in the index.
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.size
-            10
-            """
             if hasattr(self, "_size"):
                 size = self._size
             else:
@@ -383,34 +457,9 @@ if compat.HAS_RTREE:
                 self._size = size
             return size
 
+        @doc(SpatialIndex.is_empty)
         @property
         def is_empty(self):
-            """Check if the spatial index is empty
-
-            Examples
-            --------
-            >>> from shapely.geometry import Point
-            >>> s = geopandas.GeoSeries(geopandas.points_from_xy(range(10), range(10)))
-            >>> s
-            0    POINT (0.00000 0.00000)
-            1    POINT (1.00000 1.00000)
-            2    POINT (2.00000 2.00000)
-            3    POINT (3.00000 3.00000)
-            4    POINT (4.00000 4.00000)
-            5    POINT (5.00000 5.00000)
-            6    POINT (6.00000 6.00000)
-            7    POINT (7.00000 7.00000)
-            8    POINT (8.00000 8.00000)
-            9    POINT (9.00000 9.00000)
-            dtype: geometry
-
-            >>> s.sindex.is_empty
-            False
-
-            >>> s2 = geopandas.GeoSeries()
-            >>> s2.sindex.is_empty
-            True
-            """
             return self.geometries.size == 0 or self.size == 0
 
         def __len__(self):

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -720,7 +720,7 @@ class TestPygeosInterface:
         assert res.shape == expected_shape
 
 
-@pytest.mark.skip_no_sindex
+@pytest.mark.skipif(not compat.HAS_RTREE, reason="no rtree installed")
 def test_old_spatial_index_deprecated():
     t1 = Polygon([(0, 0), (1, 0), (1, 1)])
     t2 = Polygon([(0, 0), (1, 1), (0, 1)])

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -718,3 +718,15 @@ class TestPygeosInterface:
 
         res = world.sindex.query_bulk(capitals.geometry, predicate)
         assert res.shape == expected_shape
+
+
+def test_old_spatial_index_deprecated():
+    t1 = Polygon([(0, 0), (1, 0), (1, 1)])
+    t2 = Polygon([(0, 0), (1, 1), (0, 1)])
+
+    stream = ((i, item.bounds, None) for i, item in enumerate([t1, t2]))
+
+    with pytest.warns(FutureWarning):
+        idx = geopandas.sindex.SpatialIndex(stream)
+
+    assert list(idx.intersection((0, 0, 1, 1))) == [0, 1]

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -720,6 +720,7 @@ class TestPygeosInterface:
         assert res.shape == expected_shape
 
 
+@pytest.mark.skip_no_sindex
 def test_old_spatial_index_deprecated():
     t1 = Polygon([(0, 0), (1, 0), (1, 1)])
     t2 = Polygon([(0, 0), (1, 1), (0, 1)])


### PR DESCRIPTION
@martinfleis as a test, I copied the docstrings out of the RTreeIndex into a base class, and added those back to the RTreeIndex class with a decorator. And then only included this base class in the sindex.rst API docs.

Of course, if we want this, we need to generalize the docstrings a bit to suite both implementations. The question is if we want to keep the actual docstrings of the 2 concrete implementations more specific, which is possible, but then it doesn't really lead to a deduplication of docstrings in the code (and only in the online documentation)