### PR TITLE
DOC: set up binder environment

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,32 @@
+name: geopandas-dev
+channels:
+    - conda-forge
+dependencies:
+    # required
+    - fiona>=1.8
+    - pandas>=0.24
+    - pyproj>=2.2.0
+    - shapely>=1.6
+
+    # geodatabase access
+    - psycopg2>=2.5.1
+    - SQLAlchemy>=0.8.3
+
+    # geocoding
+    - geopy
+
+    # plotting
+    - matplotlib>=2.2
+    - mapclassify
+
+    # testing
+    - pytest>=3.1.0
+    - pytest-cov
+    - codecov
+
+    # spatial access methods
+    - rtree>=0.8
+
+    # styling
+    - black
+    - pre-commit

--- a/environment.yml
+++ b/environment.yml
@@ -1,32 +1,20 @@
-name: geopandas-dev
+name: geopandas
 channels:
-    - conda-forge
+  - conda-forge
 dependencies:
-    # required
-    - fiona>=1.8
-    - pandas>=0.24
-    - pyproj>=2.2.0
-    - shapely>=1.6
-
-    # geodatabase access
-    - psycopg2>=2.5.1
-    - SQLAlchemy>=0.8.3
-
-    # geocoding
-    - geopy
-
-    # plotting
-    - matplotlib>=2.2
-    - mapclassify
-
-    # testing
-    - pytest>=3.1.0
-    - pytest-cov
-    - codecov
-
-    # spatial access methods
-    - rtree>=0.8
-
-    # styling
-    - black
-    - pre-commit
+  - geopandas
+  - shapely
+  - fiona
+  - pyproj
+  - pygeos
+  - rtree
+  - mapclassify
+  - libpysal
+  - matplotlib
+  - geopy
+  - cartopy
+  - pyepsg
+  - contextily
+  - rasterio
+  - geoplot
+  - folium


### PR DESCRIPTION
The binder button in docs creates an incorrect environment at the moment since it uses `environment.yml`, which is meant to be for development and as such does not include geopandas.

I have renamed the existing `environment.yml` to `environment-dev.yml` and created a new `environment.yml` with all dependencies required to run all examples in docs.