### PR TITLE
DOC: remove faulty geoplot Voronoi example

### DIFF
--- a/doc/source/gallery/plotting_with_geoplot.ipynb
+++ b/doc/source/gallery/plotting_with_geoplot.ipynb
@@ -164,32 +164,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, we may partition the space into neighborhoods automatically,\n",
-    "using Voronoi tessellation. This is a good way of visually verifying whether\n",
-    "or not a certain data column is spatially correlated.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ax = geoplot.voronoi(\n",
-    "    collisions.head(1000), projection=geoplot.crs.AlbersEqualArea(),\n",
-    "    clip=boroughs.simplify(0.001),\n",
-    "    hue='NUMBER OF PERSONS INJURED', cmap='Reds',\n",
-    "    legend=True,\n",
-    "    edgecolor='white'\n",
-    ")\n",
-    "geoplot.polyplot(boroughs, edgecolor='black', zorder=1, ax=ax)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "These are just some of the plots you can make with Geoplot. There are\n",
     "many other possibilities not covered in this brief introduction. For more\n",
     "examples, refer to the\n",


### PR DESCRIPTION
Removing an example using geoplot which fails (both locally and on RTD).