### PR TITLE
BUG: fixup GeoDataFrame.apply in case there is no geometry column

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1364,7 +1364,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         if (
             isinstance(result, GeoDataFrame)
             and self._geometry_column_name in result.columns
-            and any(t == "geometry" for t in result.dtypes)
+            and any(isinstance(t, GeometryDtype) for t in result.dtypes)
         ):
             if self.crs is not None and result.crs is None:
                 result.set_crs(self.crs, inplace=True)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1361,7 +1361,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         result = super().apply(
             func, axis=axis, raw=raw, result_type=result_type, args=args, **kwargs
         )
-        if isinstance(result, GeoDataFrame):
+        if (
+            isinstance(result, GeoDataFrame)
+            and self._geometry_column_name in result.columns
+            and any(t == "geometry" for t in result.dtypes)
+        ):
             if self.crs is not None and result.crs is None:
                 result.set_crs(self.crs, inplace=True)
         return result

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -520,6 +520,21 @@ def test_apply_convert_dtypes_keyword(s):
     assert_geoseries_equal(res, s)
 
 
+@pytest.mark.parametrize("crs", [None, "EPSG:4326"])
+def test_apply_no_geometry_result(df, crs):
+    if crs:
+        df = df.set_crs(crs)
+    result = df.apply(lambda col: col.astype(str), axis=0)
+    # TODO this should actually not return a GeoDataFrame
+    assert isinstance(result, GeoDataFrame)
+    expected = df.astype(str)
+    assert_frame_equal(result, expected)
+
+    result = df.apply(lambda col: col.astype(str), axis=1)
+    assert isinstance(result, GeoDataFrame)
+    assert_frame_equal(result, expected)
+
+
 @pytest.mark.skipif(not compat.PANDAS_GE_10, reason="attrs introduced in pandas 1.0")
 def test_preserve_attrs(df):
     # https://github.com/geopandas/geopandas/issues/1654

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1481,7 +1481,9 @@ class TestGeoplotAccessor:
         geometries = [Polygon([(0, 0), (1, 0), (1, 1)]), Point(1, 3)]
         x = [1, 2]
         y = [10, 20]
-        self.gdf = GeoDataFrame({"geometry": geometries, "x": x, "y": y})
+        self.gdf = GeoDataFrame(
+            {"geometry": geometries, "x": x, "y": y}, crs="EPSG:4326"
+        )
         self.df = pd.DataFrame({"x": x, "y": y})
 
     def compare_figures(self, kind, fig_test, fig_ref, kwargs):


### PR DESCRIPTION
Still need to add tests, but this should fix the pandas plotting issue (https://github.com/geopandas/geopandas/issues/1776#issuecomment-787487017).

The underlying cause is in the first place that the subset of columns that gets selected by pandas when preparing to plot (without a geometry column) still is a GeoDataFrame (-> opened https://github.com/geopandas/geopandas/issues/1856). And then on my fix for apply fails for such a GeoDataFrame without geometry column.