### PR TITLE
DOC: fix API reference page for GeoDataFrame.plot accessor

### DIFF
--- a/doc/source/_templates/accessor_callable.rst
+++ b/doc/source/_templates/accessor_callable.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module.split('.')[0] }}
+
+.. automethod:: {{ (module.split('.')[1:] + [objname]) | join('.') }}

--- a/doc/source/docs/reference/geodataframe.rst
+++ b/doc/source/docs/reference/geodataframe.rst
@@ -62,6 +62,7 @@ Plotting
 
 .. autosummary::
    :toctree: api/
+   :template: accessor_callable.rst
 
    GeoDataFrame.plot
 


### PR DESCRIPTION
xref https://github.com/geopandas/geopandas/issues/1776#issuecomment-787486170

This copies the template from pandas to ensure the API docstring page gets built properly. 
The reason for the custom template is (IIRC) because sphinx otherwise splits the `geopandas.GeoDataFrame` and `plot` parts incorrectly.

It doesn't yet fully show up like a function (eg in the overview page it is listed as `GeoDataFrame.plot` and not ``GeoDataFrame.plot(..)``), but the rest of the generated page looks good (uses the correct docstring. 
The full fix entails a bit more sphinx hackery, like pandas does here: https://github.com/pandas-dev/pandas/blob/f4b67b5eafca7310235cb4b037978739d0e3e52e/doc/source/conf.py#L551-L564

But this fix should be sufficient for now I think.
