### PR TITLE
BUG: Refactor geopandas.testing._check_equality (GH1863)

### DIFF
--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -20,7 +20,7 @@ def _isna(this):
         return pd.isnull(this)
 
 
-def geom_equals_mask(this, that):
+def _geom_equals_mask(this, that):
     """
     Test for geometric equality. Empty or missing geometries are considered
     equal.
@@ -59,10 +59,10 @@ def geom_equals(this, that):
         True if all geometries in left equal geometries in right
     """
 
-    return geom_equals_mask(this, that).all()
+    return _geom_equals_mask(this, that).all()
 
 
-def geom_almost_equals_mask(this, that):
+def _geom_almost_equals_mask(this, that):
     """
     Test for 'almost' geometric equality. Empty or missing geometries
     considered equal.
@@ -107,7 +107,7 @@ def geom_almost_equals(this, that):
         True if all geometries in left almost equal geometries in right
     """
 
-    return geom_almost_equals_mask(this, that).all()
+    return _geom_almost_equals_mask(this, that).all()
 
 
 def assert_geoseries_equal(
@@ -208,10 +208,10 @@ def _check_equality(left, right, check_less_precise):
     )
     if check_less_precise:
         precise = "almost "
-        equal = geom_almost_equals_mask(left, right)
+        equal = _geom_almost_equals_mask(left, right)
     else:
         precise = ""
-        equal = geom_equals_mask(left, right)
+        equal = _geom_equals_mask(left, right)
 
     if not equal.all():
         unequal_left_geoms = left[~equal]

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -129,3 +129,11 @@ def test_ignore_crs_mismatch():
         assert_geodataframe_equal(df1, df2, check_crs=False)
 
     assert len(record) == 0
+
+
+def test_almost_equal_but_not_equal():
+    s_origin = GeoSeries([Point(0, 0)])
+    s_almost_origin = GeoSeries([Point(0.0000001, 0)])
+    assert_geoseries_equal(s_origin, s_almost_origin, check_less_precise=True)
+    with pytest.raises(AssertionError):
+        assert_geoseries_equal(s_origin, s_almost_origin)


### PR DESCRIPTION
* Use geom_equals or geom_almost_equals consistently
* Reuse repeated code to generate AssertionError by taking it outside if/else block
* Only check equality once instead of three times by generating a boolean series and reusing it

Closes #1863