### PR TITLE
CI: use numpy main instead of master branch

### DIFF
--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -23,7 +23,7 @@ dependencies:
     - geopy
     - mapclassify>=2.2.0
     # dev versions of packages
-    - git+https://github.com/numpy/numpy.git@master
+    - git+https://github.com/numpy/numpy.git@main
     - git+https://github.com/pydata/pandas.git@master
     - git+https://github.com/matplotlib/matplotlib.git@master
     - git+https://github.com/Toblerity/Shapely.git@master


### PR DESCRIPTION
Numpy renamed their `master` branch to `main`, which broke our dev CI environment. 