### PR TITLE
TST: use public API to fix several issues with sqlalchemy

### DIFF
--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -64,7 +64,7 @@ def engine_postgis():
 
     try:
         con = sqlalchemy.create_engine(
-            URL(
+            URL.create(
                 drivername="postgresql+psycopg2",
                 username=user,
                 database=dbname,
@@ -114,7 +114,7 @@ def connection_spatialite():
 def drop_table_if_exists(conn_or_engine, table):
     sqlalchemy = pytest.importorskip("sqlalchemy")
 
-    if conn_or_engine.dialect.has_table(conn_or_engine, table):
+    if sqlalchemy.inspect(conn_or_engine).has_table(table):
         metadata = sqlalchemy.MetaData(conn_or_engine)
         metadata.reflect()
         table = metadata.tables.get(table)


### PR DESCRIPTION
The main fix here is to pass CI tests, which seem to have been broken for a few weeks. Reading the error message:

> sqlalchemy.exc.ArgumentError: The argument passed to Dialect.has_table() should be a <class 'sqlalchemy.engine.base.Connection'>, got <class 'sqlalchemy.engine.base.Engine'>. Additionally, the Dialect.has_table() method is for internal dialect use only; please use ``inspect(some_engine).has_table(<tablename>>)`` for public API use

A second fix is from a warning message:

> test_sql.py:67: SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.

Closes #1910 