### PR TITLE
CI: unpin python in 3.7 build

### DIFF
--- a/ci/envs/37-latest-defaults.yaml
+++ b/ci/envs/37-latest-defaults.yaml
@@ -2,7 +2,7 @@ name: test
 channels:
   - defaults
 dependencies:
-  - python=3.7.3
+  - python=3.7
   # required
   - pandas
   - shapely


### PR DESCRIPTION
This is basically a revert of https://github.com/geopandas/geopandas/pull/1092, and should no longer be needed.