### PR TITLE
DOC: document contextily layers functionality

### DIFF
--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -10,7 +10,10 @@
     "This example shows how you can add a background basemap to plots created\n",
     "with the geopandas ``.plot()`` method. This makes use of the\n",
     "[contextily](https://github.com/geopandas/contextily) package to retrieve\n",
-    "web map tiles from several sources (OpenStreetMap, Stamen).\n"
+    "web map tiles from several sources (OpenStreetMap, Stamen). Also have a\n",
+    "look at this package's \n",
+    "[introduction guide](https://contextily.readthedocs.io/en/latest/intro_guide.html#Using-transparent-layers)\n",
+    "for some potentially new features not covered here.\n"
    ]
   },
   {
@@ -37,8 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = geopandas.read_file(geopandas.datasets.get_path('nybb'))\n",
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')"
+    "raw_df = geopandas.read_file(geopandas.datasets.get_path('nybb'))\n",
+    "ax = raw_df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')"
    ]
   },
   {
@@ -62,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df.to_crs(epsg=3857)"
+    "df = raw_df.to_crs(epsg=3857)"
    ]
   },
   {
@@ -71,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import contextily as ctx"
+    "import contextily as cx"
    ]
   },
   {
@@ -97,7 +100,25 @@
    "outputs": [],
    "source": [
     "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
-    "ctx.add_basemap(ax)"
+    "cx.add_basemap(ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When possible for a given set of map tiles, one can keep the GeoDataFrame in its original CRS, \n",
+    "and use the kwarg `crs` of  `add_basemap` to plot using the original projection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = raw_df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "cx.add_basemap(ax, crs=raw_df.crs)"
    ]
   },
   {
@@ -117,7 +138,7 @@
    "outputs": [],
    "source": [
     "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
-    "ctx.add_basemap(ax, zoom=12)"
+    "cx.add_basemap(ax, zoom=12)"
    ]
   },
   {
@@ -125,7 +146,7 @@
    "metadata": {},
    "source": [
     "By default, contextily uses the Stamen Terrain style. We can specify a\n",
-    "different style using ``ctx.providers``:\n",
+    "different style using ``cx.providers``:\n",
     "\n"
    ]
   },
@@ -136,8 +157,48 @@
    "outputs": [],
    "source": [
     "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
-    "ctx.add_basemap(ax, url=ctx.providers.Stamen.TonerLite)\n",
+    "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLite)\n",
     "ax.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes, when you plot data on a basemap, the data will obscure some important map elements, such as labels,\n",
+    "that you would otherwise want to see unobscured. Some map tile providers offer multiple sets of partially\n",
+    "transparent tiles to solve this, and `contextily` will do its best to auto-detect these transparent layers\n",
+    "and put them on top."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLite)\n",
+    "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLabels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By splitting the layers like this, you can also independently manipulate the level of zoom on each layer,\n",
+    "for example to make labels larger while still showing a lot of detail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "cx.add_basemap(ax, source=cx.providers.Stamen.Watercolor, zoom=12)\n",
+    "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLabels, zoom=10)"
    ]
   },
   {
@@ -150,9 +211,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "geopandas_docs",
    "language": "python",
-   "name": "python3"
+   "name": "geopandas_docs"
   },
   "language_info": {
    "codemirror_mode": {
@@ -164,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -11,9 +11,9 @@
     "with the geopandas ``.plot()`` method. This makes use of the\n",
     "[contextily](https://github.com/geopandas/contextily) package to retrieve\n",
     "web map tiles from several sources (OpenStreetMap, Stamen). Also have a\n",
-    "look at this package's \n",
+    "look at contextily's \n",
     "[introduction guide](https://contextily.readthedocs.io/en/latest/intro_guide.html#Using-transparent-layers)\n",
-    "for some potentially new features not covered here.\n"
+    "for possible new features not covered here.\n"
    ]
   },
   {
@@ -22,7 +22,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import geopandas"
+    "import geopandas\n",
+    "import contextily as cx"
    ]
   },
   {
@@ -40,23 +41,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_df = geopandas.read_file(geopandas.datasets.get_path('nybb'))\n",
-    "ax = raw_df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')"
+    "df = geopandas.read_file(geopandas.datasets.get_path('nybb'))\n",
+    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Convert the data to Web Mercator\n",
-    "================================\n",
+    "## Matching coordinate systems \n",
     "\n",
-    "Web map tiles are typically provided in\n",
+    "\n",
+    "Before adding web map tiles to this plot, we first need to ensure the coordinate reference systems (CRS) of the tiles and the data match. Web map tiles are typically provided in\n",
     "[Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator>)\n",
-    "([EPSG 3857](https://epsg.io/3857)), so we need to make sure to convert\n",
-    "our data first to the same CRS to combine our polygons and background tiles\n",
-    "in the same map:\n",
-    "\n"
+    "([EPSG 3857](https://epsg.io/3857)), so let us first check what CRS our NYC boroughs are in:"
    ]
   },
   {
@@ -65,28 +63,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = raw_df.to_crs(epsg=3857)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import contextily as cx"
+    "df.crs"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add background tiles to plot\n",
-    "============================\n",
+    "Now we know the CRS do not match, so we need to choose in which CRS we wish to visualize the data: either the CRS of the tiles, the one of the data, or even a different one.\n",
     "\n",
-    "We can use `add_basemap` function of contextily to easily add a background\n",
-    "map to our plot. :\n",
-    "\n"
+    "The first option to match CRS is to leverage the `to_crs` method of GeoDataFrames to convert the CRS of our data, here to Web Mercator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_wm = df.to_crs(epsg=3857)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then use `add_basemap` function of contextily to easily add a background\n",
+    "map to our plot:"
    ]
   },
   {
@@ -99,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
     "cx.add_basemap(ax)"
    ]
   },
@@ -107,8 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When possible for a given set of map tiles, one can keep the GeoDataFrame in its original CRS, \n",
-    "and use the kwarg `crs` of  `add_basemap` to plot using the original projection."
+    "If we want to convert the CRS of the tiles instead, which might be advisable for large datasets, we can use the `crs` keyword argument of `add_basemap` as follows:"
    ]
   },
   {
@@ -117,8 +119,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = raw_df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
-    "cx.add_basemap(ax, crs=raw_df.crs)"
+    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "cx.add_basemap(ax, crs=df.crs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This reprojects map tiles to a target CRS which may in some cases cause a loss of sharpness. See [contextily's guide on warping tiles](https://contextily.readthedocs.io/en/latest/warping_guide.html) for more information on the subject."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlling the level of detail"
    ]
   },
   {
@@ -137,8 +153,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
     "cx.add_basemap(ax, zoom=12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Choosing a different style"
    ]
   },
   {
@@ -156,9 +179,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLite)\n",
     "ax.set_axis_off()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding labels as an overlay"
    ]
   },
   {
@@ -177,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLite)\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLabels)"
    ]
@@ -196,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = df.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
+    "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor='k')\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.Watercolor, zoom=12)\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLabels, zoom=10)"
    ]

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -241,13 +241,6 @@
     "cx.add_basemap(ax, source=cx.providers.Stamen.Watercolor, zoom=12)\n",
     "cx.add_basemap(ax, source=cx.providers.Stamen.TonerLabels, zoom=10)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -52,9 +52,12 @@
     "## Matching coordinate systems \n",
     "\n",
     "\n",
-    "Before adding web map tiles to this plot, we first need to ensure the coordinate reference systems (CRS) of the tiles and the data match. Web map tiles are typically provided in\n",
+    "Before adding web map tiles to this plot, we first need to ensure the\n",
+    "coordinate reference systems (CRS) of the tiles and the data match.\n",
+    "Web map tiles are typically provided in\n",
     "[Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator>)\n",
-    "([EPSG 3857](https://epsg.io/3857)), so let us first check what CRS our NYC boroughs are in:"
+    "([EPSG 3857](https://epsg.io/3857)), so let us first check what\n",
+    "CRS our NYC boroughs are in:"
    ]
   },
   {
@@ -70,9 +73,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we know the CRS do not match, so we need to choose in which CRS we wish to visualize the data: either the CRS of the tiles, the one of the data, or even a different one.\n",
+    "Now we know the CRS do not match, so we need to choose in which\n",
+    "CRS we wish to visualize the data: either the CRS of the tiles,\n",
+    "the one of the data, or even a different one.\n",
     "\n",
-    "The first option to match CRS is to leverage the `to_crs` method of GeoDataFrames to convert the CRS of our data, here to Web Mercator:"
+    "The first option to match CRS is to leverage the `to_crs` method\n",
+    "of GeoDataFrames to convert the CRS of our data, here to Web Mercator:"
    ]
   },
   {
@@ -88,8 +94,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then use `add_basemap` function of contextily to easily add a background\n",
-    "map to our plot:"
+    "We can then use `add_basemap` function of contextily to easily add a\n",
+    "background map to our plot:"
    ]
   },
   {
@@ -110,7 +116,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to convert the CRS of the tiles instead, which might be advisable for large datasets, we can use the `crs` keyword argument of `add_basemap` as follows:"
+    "If we want to convert the CRS of the tiles instead, which might be advisable\n",
+    "for large datasets, we can use the `crs` keyword argument of `add_basemap`\n",
+    "as follows:"
    ]
   },
   {
@@ -127,7 +135,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This reprojects map tiles to a target CRS which may in some cases cause a loss of sharpness. See [contextily's guide on warping tiles](https://contextily.readthedocs.io/en/latest/warping_guide.html) for more information on the subject."
+    "This reprojects map tiles to a target CRS which may in some cases cause a\n",
+    "loss of sharpness. See \n",
+    "[contextily's guide on warping tiles](https://contextily.readthedocs.io/en/latest/warping_guide.html)\n",
+    "for more information on the subject."
    ]
   },
   {


### PR DESCRIPTION
Complements [the example page about adding a background map to plots](https://geopandas.org/gallery/plotting_basemap_background.html) with the new layers functionality of `contextily`, shamefully copying from [its introduction guide](https://contextily.readthedocs.io/en/latest/intro_guide.html#Using-transparent-layers), with the changes introduced in geopandas/contextily#114. Not much but I thought that'd make a good first PR since I'd been following that PR in `contextily` and wanted to give visibility to this feature. 

In passing I changed the use of the deprecated `url` kwarg of `contextily.basemap` to `source`, adopted the same naming for `contextily` as in its docs(`cx`), and added a plot to show that projecting to Mercator wasn't always necessary.