### PR TITLE
DOC: add cd doc in code block

### DIFF
--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -258,16 +258,21 @@ and examples are Jupyter notebooks converted to docs using `nbsphinx
 <https://nbsphinx.readthedocs.io/>`_. Jupyter notebooks should be stored without the output.
 
 Once you have made your changes, you may try if they render correctly by
-building the docs using sphinx. To do so, you can navigate to the `doc` folder
+building the docs using sphinx. To do so, you can navigate to the `doc` folder::
+
+    cd doc
+
 and type::
 
     make html
 
-The resulting html pages will be located in ``doc/build/html``. In case of any errors, you
-can try to use ``make html`` within a new environment based on environment.yml
-specification in the ``doc`` folder. You may need to register Jupyter kernel as
+The resulting html pages will be located in ``doc/build/html``.
+
+In case of any errors, you can try to use ``make html`` within a new environment based on
+environment.yml specification in the ``doc`` folder. You may need to register Jupyter kernel as
 ``geopandas_docs``. Using conda::
 
+    cd doc
     conda env create -f environment.yml
     conda activate geopandas_docs
     python -m ipykernel install --user --name geopandas_docs


### PR DESCRIPTION
I'll confess I was slow to read the text and my eyes tend to drift and follow instructions in the code blocks. The small doc PR adds cd doc in the instructions to make it easier to copy-paste instructions in the future.