### PR TITLE
DOC: hyperlink to API in merging section

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -331,3 +331,12 @@ nbsphinx_prolog = r"""
 
         __ https://github.com/geopandas/geopandas/blob/master/doc/source/{{ docname }}
 """
+
+#  --Options for sphinx extensions -----------------------------------------------
+
+intersphinx_mapping = {
+    "pandas": (
+        "https://pandas.pydata.org/pandas-docs/stable/",
+        "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
+    ),
+}

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -11,9 +11,12 @@ Merging Data
 
 There are two ways to combine datasets in *geopandas* -- attribute joins and spatial joins.
 
-In an attribute join, a ``GeoSeries`` or ``GeoDataFrame`` is combined with a regular *pandas* ``Series`` or ``DataFrame`` based on a common variable. This is analogous to normal merging or joining in *pandas*.
+In an attribute join, a :py:class:`GeoSeries` or :py:class:`GeoDataFrame` is
+combined with a regular :py:class:`pandas.Series` or :py:class:`pandas.DataFrame` based on a
+common variable. This is analogous to normal merging or joining in *pandas*.
 
-In a Spatial Join, observations from two ``GeoSeries`` or ``GeoDataFrames`` are combined based on their spatial relationship to one another.
+In a Spatial Join, observations from two :py:class:`GeoSeries` or :py:class:`GeoDataFrame`
+are combined based on their spatial relationship to one another.
 
 In the following examples, we use these datasets:
 
@@ -34,7 +37,8 @@ In the following examples, we use these datasets:
 Appending
 ---------
 
-Appending GeoDataFrames and GeoSeries uses pandas ``append`` methods. Keep in mind, that appended geometry columns needs to have the same CRS.
+Appending :py:class:`GeoDataFrame` and :py:class:`GeoSeries` uses pandas ``append`` methods.
+Keep in mind, that appended geometry columns needs to have the same CRS.
 
 .. ipython:: python
 
@@ -50,10 +54,14 @@ Appending GeoDataFrames and GeoSeries uses pandas ``append`` methods. Keep in mi
 Attribute Joins
 ----------------
 
-Attribute joins are accomplished using the ``merge`` method. In general, it is recommended to use the ``merge`` method called from the spatial dataset. With that said, the stand-alone ``merge`` function will work if the GeoDataFrame is in the ``left`` argument; if a DataFrame is in the ``left`` argument and a GeoDataFrame is in the ``right`` position, the result will no longer be a GeoDataFrame.
+Attribute joins are accomplished using the ``merge`` method. In general, it is recommended
+to use the ``merge`` method called from the spatial dataset. With that said, the stand-alone
+``merge`` function will work if the :py:class:`GeoDataFrame` is in the ``left`` argument;
+if a :py:class:`pandas.DataFrame` is in the ``left`` argument and a :py:class:`GeoDataFrame`
+is in the ``right`` position, the result will no longer be a :py:class:`GeoDataFrame`.
 
-
-For example, consider the following merge that adds full names to a ``GeoDataFrame`` that initially has only ISO codes for each country by merging it with a *pandas* ``DataFrame``.
+For example, consider the following merge that adds full names to a :py:class:`GeoDataFrame`
+that initially has only ISO codes for each country by merging it with a :py:class:`pandas.DataFrame`.
 
 .. ipython:: python
 
@@ -66,7 +74,6 @@ For example, consider the following merge that adds full names to a ``GeoDataFra
    # Merge with `merge` method on shared variable (iso codes):
    country_shapes = country_shapes.merge(country_names, on='iso_a3')
    country_shapes.head()
-
 
 
 Spatial Joins
@@ -91,15 +98,19 @@ In a Spatial Join, two geometry objects are merged based on their spatial relati
 Sjoin Arguments
 ~~~~~~~~~~~~~~~~
 
-``sjoin()`` has two core arguments: ``how`` and ``op``.
+:py:class:`sjoin` has two core arguments: ``how`` and ``op``.
 
 **op**
 
-The ``op`` argument specifies how ``geopandas`` decides whether or not to join the attributes of one object to another, based on their geometric relationship.
+The ``op`` argument specifies how ``geopandas`` decides whether or not to join the attributes of one
+object to another, based on their geometric relationship.
 
-The values for ``op`` correspond to the names of geometric binary predicates and depend on the spatial index implementation.
+The values for ``op`` correspond to the names of geometric binary predicates and depend on the spatial
+index implementation.
 
-The default spatial index in GeoPandas currently supports the following values for ``op``:
+The default spatial index in ``geopandas`` currently supports the following values for ``op`` which are
+defined in the
+`Shapely documentation <http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates>`__:
 
 * `intersects`
 * `contains`
@@ -108,14 +119,16 @@ The default spatial index in GeoPandas currently supports the following values f
 * `crosses`
 * `overlaps`
 
-You can read more about each join type in the `Shapely documentation <http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates>`__.
-
 **how**
 
-The `how` argument specifies the type of join that will occur and which geometry is retained in the resultant geodataframe. It accepts the following options:
+The `how` argument specifies the type of join that will occur and which geometry is retained in the resultant
+:py:class:`GeoDataFrame`. It accepts the following options:
 
-* ``left``: use the index from the first (or `left_df`) geodataframe that you provide to ``sjoin``; retain only the `left_df` geometry column
+* ``left``: use the index from the first (or `left_df`) :py:class:`GeoDataFrame` that you provide
+  to ``sjoin``; retain only the `left_df` geometry column
 * ``right``: use index from second (or `right_df`); retain only the `right_df` geometry column
-* ``inner``: use intersection of index values from both geodataframes; retain only the `left_df` geometry column
+* ``inner``: use intersection of index values from both :py:class:`GeoDataFrame`; retain only the `left_df` geometry column
 
-Note more complicated spatial relationships can be studied by combining geometric operations with spatial join. To find all polygons within a given distance of a point, for example, one can first use the ``buffer`` method to expand each point into a circle of appropriate radius, then intersect those buffered circles with the polygons in question.
+Note more complicated spatial relationships can be studied by combining geometric operations with spatial join.
+To find all polygons within a given distance of a point, for example, one can first use the ``buffer`` method to expand each
+point into a circle of appropriate radius, then intersect those buffered circles with the polygons in question.


### PR DESCRIPTION
This doc PR add hyperlinks from the user-guide to the API. It also adds hyperlinks to the pandas docs.

Before: https://geopandas.org/docs/user_guide/mergingdata.html

![Screenshot from 2021-04-30 14-26-32](https://user-images.githubusercontent.com/17162724/116738155-166d2a00-a9c0-11eb-91fa-83b96f2408a7.png)

after with the Blue sections being clickable:

![Screenshot from 2021-04-30 14-27-11](https://user-images.githubusercontent.com/17162724/116738295-41577e00-a9c0-11eb-92e6-7f18712f8d15.png)

