### PR TITLE
DOC: override kernelspec when executing notebooks

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,6 +65,7 @@ autosummary_generate = True
 
 nbsphinx_execute = "always"
 nbsphinx_allow_errors = True
+nbsphinx_kernel_name = 'python3'
 
 # connect docs in other projects
 intersphinx_mapping = {"pyproj": ("http://pyproj4.github.io/pyproj/stable/", None)}

--- a/doc/source/gallery/create_geopandas_from_pandas.ipynb
+++ b/doc/source/gallery/create_geopandas_from_pandas.ipynb
@@ -206,9 +206,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "geopandas_docs",
    "language": "python",
-   "name": "python3"
+   "name": "geopandas_docs"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/source/gallery/create_geopandas_from_pandas.ipynb
+++ b/doc/source/gallery/create_geopandas_from_pandas.ipynb
@@ -206,9 +206,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "geopandas_docs",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "geopandas_docs"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This should ensure that no matter the kernel specified in kernelspec, RTD always uses default one and doesn't fail.

I have temporarily allowed RTD for PRs to test this.