### PR TITLE
DOC: Clarify bbox input to read_file

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -78,7 +78,8 @@ def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
     bbox : tuple | GeoDataFrame or GeoSeries | shapely Geometry, default None
         Filter features by given bounding box, GeoSeries, GeoDataFrame or a
         shapely geometry. CRS mis-matches are resolved if given a GeoSeries
-        or GeoDataFrame. Cannot be used with mask.
+        or GeoDataFrame. Tuple is (minx, miny, maxx, maxy) to match the
+        bounds property of shapely geometry objects. Cannot be used with mask.
     mask : dict | GeoDataFrame or GeoSeries | shapely Geometry, default None
         Filter for features that intersect with the given dict-like geojson
         geometry, GeoSeries, GeoDataFrame or shapely geometry.


### PR DESCRIPTION
I think this is right, based on how a Shapely input is handled, and the bounds doc: (https://shapely.readthedocs.io/en/stable/manual.html#object.bounds).

https://github.com/geopandas/geopandas/blob/a445f979e29ec5180d5fa08660af08305a1a6932/geopandas/io/file.py#L176-L177