### PR TITLE
BUG: fix GeoDataFrame.explode with MultiIndex (#1937)

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1582,9 +1582,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
         exploded_index = exploded_geom.columns[0]
 
-        df = pd.concat(
-            [df_copy.drop(df_copy._geometry_column_name, axis=1), exploded_geom], axis=1
-        ).__finalize__(self)
+        df = df_copy.drop(df_copy._geometry_column_name, axis=1).join(exploded_geom).__finalize__(self)
 
         # reset to MultiIndex, otherwise df index is only first level of
         # exploded GeoSeries index.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1582,7 +1582,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
         exploded_index = exploded_geom.columns[0]
 
-        df = df_copy.drop(df_copy._geometry_column_name, axis=1).join(exploded_geom).__finalize__(self)
+        df = (
+            df_copy.drop(df_copy._geometry_column_name, axis=1)
+            .join(exploded_geom)
+            .__finalize__(self)
+        )
 
         # reset to MultiIndex, otherwise df index is only first level of
         # exploded GeoSeries index.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from pandas import Series, MultiIndex
 from pandas.core.internals import SingleBlockManager
-from pandas.core.common import flatten
 
 from pyproj import CRS
 from shapely.geometry.base import BaseGeometry
@@ -835,7 +834,7 @@ class GeoSeries(GeoPandasBase, Series):
 
             # if self.index is a MultiIndex then index is a list of nested tuples
             if isinstance(self.index, MultiIndex):
-                index = [tuple(flatten(e)) for e in index]
+                index = [tuple(outer) + (inner,) for outer, inner in index]
 
             index = MultiIndex.from_tuples(index, names=self.index.names + [None])
             return GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
@@ -856,7 +855,7 @@ class GeoSeries(GeoPandasBase, Series):
 
         # if self.index is a MultiIndex then index is a list of nested tuples
         if isinstance(self.index, MultiIndex):
-            index = [tuple(flatten(e)) for e in index]
+            index = [tuple(outer) + (inner,) for outer, inner in index]
 
         index = MultiIndex.from_tuples(index, names=self.index.names + [None])
         return GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -941,9 +941,11 @@ class TestGeomMethods:
         exploded_df = gdf.explode(column="col1", ignore_index=True)
         assert_geodataframe_equal(exploded_df, expected_df)
 
-    def test_explode_pandas_multi_index(self):
+    @pytest.mark.parametrize("outer_index", [1, (1, 2), "1"])
+    def test_explode_pandas_multi_index(self, outer_index):
         index = MultiIndex.from_arrays(
-            [[1, 1, 1], [1, 2, 3]], names=("first", "second")
+            [[outer_index, outer_index, outer_index], [1, 2, 3]],
+            names=("first", "second"),
         )
         df = GeoDataFrame(
             {"vals": [1, 2, 3]},
@@ -965,7 +967,10 @@ class TestGeomMethods:
         )
         expected_df = GeoDataFrame({"vals": [1, 1, 2, 2, 3, 3], "geometry": expected_s})
         expected_index = MultiIndex.from_tuples(
-            [(1, 1, 0), (1, 1, 1), (1, 2, 0), (1, 2, 1), (1, 3, 0), (1, 3, 1)],
+            [
+                (outer_index, *pair)
+                for pair in [(1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
+            ],
             names=["first", "second", None],
         )
         expected_df = expected_df.set_index(expected_index)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -941,6 +941,36 @@ class TestGeomMethods:
         exploded_df = gdf.explode(column="col1", ignore_index=True)
         assert_geodataframe_equal(exploded_df, expected_df)
 
+    def test_explode_pandas_multi_index(self):
+        index = MultiIndex.from_arrays(
+            [[1, 1, 1], [1, 2, 3]], names=("first", "second")
+        )
+        df = GeoDataFrame(
+            {"vals": [1, 2, 3]},
+            geometry=[MultiPoint([(x, x), (x, 0)]) for x in range(3)],
+            index=index,
+        )
+
+        test_df = df.explode()
+
+        expected_s = GeoSeries(
+            [
+                Point(0, 0),
+                Point(0, 0),
+                Point(1, 1),
+                Point(1, 0),
+                Point(2, 2),
+                Point(2, 0),
+            ]
+        )
+        expected_df = GeoDataFrame({"vals": [1, 1, 2, 2, 3, 3], "geometry": expected_s})
+        expected_index = MultiIndex.from_tuples(
+            [(1, 1, 0), (1, 1, 1), (1, 2, 0), (1, 2, 1), (1, 3, 0), (1, 3, 1)],
+            names=["first", "second", None],
+        )
+        expected_df = expected_df.set_index(expected_index)
+        assert_frame_equal(test_df, expected_df)
+
     #
     # Test '&', '|', '^', and '-'
     #


### PR DESCRIPTION
Closes #1937 

Additionally ran into other issues when pygeos is not available, see traceback below, which this PR also solves. 

<details>
<summary>Details</summary>

  ```shell
Traceback (most recent call last):
  File "/home/daniel/PycharmProjects/geopandas/geopandas/tests/scripting.py", line 40, in <module>
    explode_pandas_multi_index()
  File "/home/daniel/PycharmProjects/geopandas/geopandas/tests/scripting.py", line 20, in explode_pandas_multi_index
    test_df = df.explode()
  File "/home/daniel/PycharmProjects/geopandas/geopandas/geodataframe.py", line 1582, in explode
    exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
  File "/home/daniel/PycharmProjects/geopandas/geopandas/geoseries.py", line 852, in explode
    index = MultiIndex.from_tuples(index, names=self.index.names + [None])
  File "/home/daniel/miniconda3/envs/geopandas_dev/lib/python3.9/site-packages/pandas/core/indexes/multi.py", line 175, in new_meth
    return meth(self_or_cls, *args, **kwargs)
  File "/home/daniel/miniconda3/envs/geopandas_dev/lib/python3.9/site-packages/pandas/core/indexes/multi.py", line 537, in from_tuples
    return cls.from_arrays(arrays, sortorder=sortorder, names=names)
  File "/home/daniel/miniconda3/envs/geopandas_dev/lib/python3.9/site-packages/pandas/core/indexes/multi.py", line 466, in from_arrays
    return cls(
  File "/home/daniel/miniconda3/envs/geopandas_dev/lib/python3.9/site-packages/pandas/core/indexes/multi.py", line 308, in __new__
    result._set_names(names)
  File "/home/daniel/miniconda3/envs/geopandas_dev/lib/python3.9/site-packages/pandas/core/indexes/multi.py", line 1433, in _set_names
    raise ValueError(
ValueError: Length of names must match number of levels in MultiIndex.
  ```
</details>

**Output of `geopandas.show_versions()`**
<details>
<summary>Details</summary>

```
SYSTEM INFO
-----------
python     : 3.9.2 (default, Mar  3 2021, 20:02:32)  [GCC 7.3.0]
executable : /home/daniel/miniconda3/envs/geopandas_dev/bin/python
machine    : Linux-5.4.0-73-generic-x86_64-with-glibc2.31

GEOS, GDAL, PROJ INFO
---------------------
GEOS       : 3.9.1
GEOS lib   : /home/daniel/miniconda3/envs/geopandas_dev/lib/libgeos_c.so
GDAL       : 3.2.2
GDAL data dir: /home/daniel/miniconda3/envs/geopandas_dev/share/gdal
PROJ       : 8.0.0
PROJ data dir: /home/daniel/miniconda3/envs/geopandas_dev/share/proj

PYTHON DEPENDENCIES
-------------------
geopandas  : 0.9.0+24.ga26bde2
pandas     : 1.2.3
fiona      : 1.8.18
numpy      : 1.20.1
shapely    : 1.7.1
rtree      : 0.9.7
pyproj     : 3.0.1
matplotlib : None
mapclassify: None
geopy      : None
psycopg2   : None
geoalchemy2: None
pyarrow    : None
pygeos     : None

```
</details>

