### PR TITLE
ENH: Add chunksize to read_file

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -196,7 +196,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, chunksize=None, **kwar
                 if rows is None:
                     chunk_filters = (
                         features.filter(
-                            n * chunksize, ((n + 1) * chunksize), None, bbox=bbox, mask=mask
+                            n * chunksize, ((n + 1) * chunksize), bbox=bbox, mask=mask
                         )
                         for n in range(0, math.ceil(len(features) / chunksize))
                     )


### PR DESCRIPTION
This makes `read_file` more similar to the API provided by Pandas in `read_csv` et al, and allows for processing large files under limited memory. Notably, I have found that significantly more memory is required to load a large shapefile in one go than to load it in several chunks and concatenate them.

To-do:

- [ ] Test
- [ ] Update documentation