### PR TITLE
DOC: update RTD env

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib=3.4.2
   - mapclassify=2.4.2
   - sphinx>=4.0.2
-  - pydata-sphinx-theme-0.6.3
+  - pydata-sphinx-theme=0.6.3
   - numpydoc=1.1.0
   - ipython=7.25.0
   - pillow=8.2.0

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - geopy
   - matplotlib
   - mapclassify
-  - sphinx
+  - sphinx>=4
   - pydata-sphinx-theme
   - numpydoc
   - ipython

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,41 +2,41 @@ name: geopandas_docs
 channels:
   - conda-forge
 dependencies:
-  - python
-  - pandas
-  - shapely
-  - fiona
-  - pyproj
-  - rtree
-  - geopy
-  - matplotlib
-  - mapclassify
-  - sphinx>=4
-  - pydata-sphinx-theme
-  - numpydoc
-  - ipython
-  - pillow
-  - mock
-  - cartopy
-  - pyepsg
-  - contextily
-  - rasterio
-  - geoplot
-  - sphinx-gallery
-  - jinja2
-  - doc2dash
+  - python=3.9.5
+  - pandas=1.2.5
+  - shapely=1.7.1
+  - fiona=1.8.18
+  - pyproj=3.1.0
+  - rtree=0.9.7
+  - geopy=2.1.0
+  - matplotlib=3.4.2
+  - mapclassify=2.4.2
+  - sphinx>=4.0.2
+  - pydata-sphinx-theme-0.6.3
+  - numpydoc=1.1.0
+  - ipython=7.25.0
+  - pillow=8.2.0
+  - mock=4.0.3
+  - cartopy=0.19.0.post1
+  - pyepsg=0.4.0
+  - contextily=1.1.0
+  - rasterio=1.2.6
+  - geoplot=0.4.1
+  - sphinx-gallery=0.9.0
+  - jinja2=3.0.1
+  - doc2dash=2.3.0
   # specify additional dependencies to reduce solving for conda
-  - gdal
-  - libgdal
-  - proj
-  - geos
-  - nbsphinx
-  - jupyter_client
-  - ipykernel
-  - myst-parser
-  - folium
-  - libpysal
-  - pygeos
+  - gdal=3.2.1
+  - libgdal=3.2.1
+  - proj=7.2.0
+  - geos=3.9.1
+  - nbsphinx=0.8.6
+  - jupyter_client=6.1.12
+  - ipykernel=5.5.5
+  - myst-parser=0.15.1
+  - folium=0.12.0
+  - libpysal=4.4.0
+  - pygeos=0.10
   - pip
   - pip:
       - sphinx-toggleprompt

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,41 +2,41 @@ name: geopandas_docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.9.1
-  - pandas=1.2.2
-  - shapely=1.7.1
-  - fiona=1.8.18
-  - pyproj=3.0.0.post1
-  - rtree=0.9.7
-  - geopy=2.1.0
-  - matplotlib=3.3.4
-  - mapclassify=2.4.2
-  - sphinx=3.5.1
-  - pydata-sphinx-theme=0.5.0
-  - numpydoc=1.1.0
-  - ipython=7.20.0
-  - pillow=8.1.0
-  - mock=4.0.3
-  - cartopy=0.18.0
-  - pyepsg=0.4.0
-  - contextily=1.1.0
-  - rasterio=1.2.0
-  - geoplot=0.4.1
-  - sphinx-gallery=0.8.2
-  - jinja2=2.11.3
-  - doc2dash=2.3.0
+  - python
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  - rtree
+  - geopy
+  - matplotlib
+  - mapclassify
+  - sphinx
+  - pydata-sphinx-theme
+  - numpydoc
+  - ipython
+  - pillow
+  - mock
+  - cartopy
+  - pyepsg
+  - contextily
+  - rasterio
+  - geoplot
+  - sphinx-gallery
+  - jinja2
+  - doc2dash
   # specify additional dependencies to reduce solving for conda
-  - gdal=3.1.4
-  - libgdal=3.1.4
-  - proj=7.2.0
-  - geos=3.9.0
-  - nbsphinx=0.8.1
-  - jupyter_client=6.1.11
-  - ipykernel=5.4.3
-  - myst-parser=0.13.5
-  - folium=0.12.0
-  - libpysal=4.4.0
-  - pygeos=0.10
+  - gdal
+  - libgdal
+  - proj
+  - geos
+  - nbsphinx
+  - jupyter_client
+  - ipykernel
+  - myst-parser
+  - folium
+  - libpysal
+  - pygeos
   - pip
   - pip:
       - sphinx-toggleprompt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,8 +36,8 @@ extensions = [
     "myst_parser",
     "nbsphinx",
     "numpydoc",
-    'sphinx_toggleprompt',
-    "matplotlib.sphinxext.plot_directive"
+    "sphinx_toggleprompt",
+    "matplotlib.sphinxext.plot_directive",
 ]
 
 # continue doc build and only print warnings/errors in examples
@@ -54,7 +54,7 @@ numpydoc_show_class_members = False
 
 
 def setup(app):
-    app.add_stylesheet("custom.css")  # may also be an URL
+    app.add_css_file("custom.css")  # may also be an URL
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -355,16 +355,16 @@ intersphinx_mapping = {
         "https://pygeos.readthedocs.io/en/latest/objects.inv",
     ),
     "rtree": (
-      "https://rtree.readthedocs.io/en/stable/",
-      "https://rtree.readthedocs.io/en/stable/objects.inv",
+        "https://rtree.readthedocs.io/en/stable/",
+        "https://rtree.readthedocs.io/en/stable/objects.inv",
     ),
     "mapclassify": (
         "https://pysal.org/mapclassify/",
-        "https://pysal.org/mapclassify/objects.inv"
+        "https://pysal.org/mapclassify/objects.inv",
     ),
     "libpysal": (
         "https://pysal.org/libpysal/",
-        "https://pysal.org/libpysal/objects.inv"
+        "https://pysal.org/libpysal/objects.inv",
     ),
     "matplotlib": (
         "https://matplotlib.org/stable/",
@@ -376,30 +376,27 @@ intersphinx_mapping = {
     ),
     "cartopy": (
         "https://scitools.org.uk/cartopy/docs/latest/",
-        "https://scitools.org.uk/cartopy/docs/latest/objects.inv"
+        "https://scitools.org.uk/cartopy/docs/latest/objects.inv",
     ),
     "pyepsg": (
         "https://pyepsg.readthedocs.io/en/stable/",
-        "https://pyepsg.readthedocs.io/en/stable/objects.inv"
+        "https://pyepsg.readthedocs.io/en/stable/objects.inv",
     ),
     "contextily": (
         "https://contextily.readthedocs.io/en/stable/",
-        "https://contextily.readthedocs.io/en/stable/objects.inv"
+        "https://contextily.readthedocs.io/en/stable/objects.inv",
     ),
     "rasterio": (
         "https://rasterio.readthedocs.io/en/stable/",
-        "https://rasterio.readthedocs.io/en/stable/objects.inv"
+        "https://rasterio.readthedocs.io/en/stable/objects.inv",
     ),
     "geoplot": (
         "https://residentmario.github.io/geoplot/index.html",
-        "https://residentmario.github.io/geoplot/objects.inv"
+        "https://residentmario.github.io/geoplot/objects.inv",
     ),
     "folium": (
         "https://python-visualization.github.io/folium/",
-        "https://python-visualization.github.io/folium/objects.inv"
+        "https://python-visualization.github.io/folium/objects.inv",
     ),
-    "python": (
-        "https://docs.python.org/3",
-        "https://docs.python.org/3/objects.inv"
-    )
+    "python": ("https://docs.python.org/3", "https://docs.python.org/3/objects.inv"),
 }


### PR DESCRIPTION
RTD fails to create the environment now. Removing pins to check how it resolves and whether we really need them, since it may be wiser to use the latest versions of dependencies.

EDIT: pinned to new versions, it shaves off 5 minutes from the build time.