### PR TITLE
TST: adapt GPKG tests with undefined CRS

### DIFF
--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -86,7 +86,7 @@ Re-projecting is the process of changing the representation of locations from on
     world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
 
     # Check original projection
-    # (it's Platte Carre! x-y are long and lat)
+    # (it's Plate Carrée! x-y are long and lat)
     world.crs
 
     # Visualize

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -273,10 +273,12 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert_geodataframe_equal(df, expected, check_less_precise=True)
 
 
-@pytest.mark.xfail(strict=False)
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_gpkg_empty_crs(tmpdir, driver, ext):
     """Test handling of undefined CRS with GPKG driver (GH #1975)."""
+    if driver == "GPKG":
+        pytest.xfail("GPKG is read with Undefined geographic SRS.")
+
     tempfilename = os.path.join(str(tmpdir), "boros." + ext)
     df = GeoDataFrame(
         {

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -66,7 +66,7 @@ driver_ext_pairs = [("ESRI Shapefile", "shp"), ("GeoJSON", "geojson"), ("GPKG", 
 
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_to_file(tmpdir, df_nybb, df_null, driver, ext):
-    """ Test to_file and from_file """
+    """Test to_file and from_file"""
     tempfilename = os.path.join(str(tmpdir), "boros." + ext)
     df_nybb.to_file(tempfilename, driver=driver)
     # Read layer back in
@@ -87,7 +87,7 @@ def test_to_file(tmpdir, df_nybb, df_null, driver, ext):
 
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_to_file_pathlib(tmpdir, df_nybb, df_null, driver, ext):
-    """ Test to_file and from_file """
+    """Test to_file and from_file"""
     temppath = pathlib.Path(os.path.join(str(tmpdir), "boros." + ext))
     df_nybb.to_file(temppath, driver=driver)
     # Read layer back in
@@ -106,7 +106,8 @@ def test_to_file_bool(tmpdir, driver, ext):
             "a": [1, 2, 3],
             "b": [True, False, True],
             "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
-        }
+        },
+        crs=4326,
     )
 
     df.to_file(tempfilename, driver=driver)
@@ -125,7 +126,7 @@ def test_to_file_datetime(tmpdir):
     tempfilename = os.path.join(str(tmpdir), "test_datetime.gpkg")
     point = Point(0, 0)
     now = datetime.datetime.now()
-    df = GeoDataFrame({"a": [1, 2], "b": [now, now]}, geometry=[point, point], crs={})
+    df = GeoDataFrame({"a": [1, 2], "b": [now, now]}, geometry=[point, point], crs=4326)
     df.to_file(tempfilename, driver="GPKG")
     df_read = read_file(tempfilename)
     assert_geoseries_equal(df.geometry, df_read.geometry)
@@ -158,7 +159,7 @@ def test_to_file_with_poly_z(tmpdir, ext, driver):
 
 
 def test_to_file_types(tmpdir, df_points):
-    """ Test various integer type columns (GH#93) """
+    """Test various integer type columns (GH#93)"""
     tempfilename = os.path.join(str(tmpdir), "int.shp")
     int_types = [
         np.int8,
@@ -247,7 +248,7 @@ def test_to_file_column_len(tmpdir, df_points):
 
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
-    """ Test to_file with append mode and from_file """
+    """Test to_file with append mode and from_file"""
     from fiona import supported_drivers
 
     if "a" not in supported_drivers[driver]:
@@ -273,6 +274,22 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert len(df) == (2 * 2)
     expected = pd.concat([df_null] * 2, ignore_index=True)
     assert_geodataframe_equal(df, expected, check_less_precise=True)
+
+
+@pytest.mark.xfail
+def test_gpkg_empty_crs(tmpdir):
+    """Test handling of undefined CRS with GPKG driver (GH #1975)."""
+    tempfilename = os.path.join(str(tmpdir), "temp.gpkg")
+    df = GeoDataFrame(
+        {
+            "a": [1, 2, 3],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+    )
+
+    df.to_file(tempfilename, driver="GPKG")
+    result = read_file(tempfilename)
+    assert_geodataframe_equal(result, df)
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -273,10 +273,11 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext):
     assert_geodataframe_equal(df, expected, check_less_precise=True)
 
 
-@pytest.mark.xfail
-def test_gpkg_empty_crs(tmpdir):
+@pytest.mark.xfail(strict=False)
+@pytest.mark.parametrize("driver,ext", driver_ext_pairs)
+def test_gpkg_empty_crs(tmpdir, driver, ext):
     """Test handling of undefined CRS with GPKG driver (GH #1975)."""
-    tempfilename = os.path.join(str(tmpdir), "temp.gpkg")
+    tempfilename = os.path.join(str(tmpdir), "boros." + ext)
     df = GeoDataFrame(
         {
             "a": [1, 2, 3],
@@ -284,8 +285,13 @@ def test_gpkg_empty_crs(tmpdir):
         },
     )
 
-    df.to_file(tempfilename, driver="GPKG")
+    df.to_file(tempfilename, driver=driver)
     result = read_file(tempfilename)
+
+    if driver == "GeoJSON":
+        # geojson by default assumes epsg:4326
+        result.crs = None
+
     assert_geodataframe_equal(result, df)
 
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -112,9 +112,6 @@ def test_to_file_bool(tmpdir, driver, ext):
 
     df.to_file(tempfilename, driver=driver)
     result = read_file(tempfilename)
-    if driver == "GeoJSON":
-        # geojson by default assumes epsg:4326
-        result.crs = None
     if driver == "ESRI Shapefile":
         # Shapefile does not support boolean, so is read back as int
         df["b"] = df["b"].astype("int64")


### PR DESCRIPTION
xref #1975

This should make CI green (with the exception of dev) again. I would keep the #1975 open because we need to resolve it properly I think.