### PR TITLE
CLN: gather all decorators into _decorator.py

### DIFF
--- a/geopandas/_decorator.py
+++ b/geopandas/_decorator.py
@@ -1,3 +1,4 @@
+import warnings
 from textwrap import dedent
 from typing import Callable, Union
 
@@ -49,3 +50,18 @@ def doc(*docstrings: Union[str, Callable], **params) -> Callable:
         return decorated
 
     return decorator
+
+
+def deprecated(new):
+    """Helper to provide deprecation warning."""
+
+    def old(*args, **kwargs):
+        warnings.warn(
+            "{} is intended for internal ".format(new.__name__[1:])
+            + "use only, and will be deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        new(*args, **kwargs)
+
+    return old

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -7,22 +7,7 @@ import geopandas
 
 from distutils.version import LooseVersion
 
-from ._decorator import doc
-
-
-def deprecated(new):
-    """Helper to provide deprecation warning."""
-
-    def old(*args, **kwargs):
-        warnings.warn(
-            "{} is intended for internal ".format(new.__name__[1:])
-            + "use only, and will be deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        new(*args, **kwargs)
-
-    return old
+from ._decorator import deprecated, doc
 
 
 def _flatten_multi_geoms(geoms, prefix="Multi"):


### PR DESCRIPTION
Since we have a script.py called `_decorator.py`, then we could move all decorators into this script.