### PR TITLE
TST: adapt colorbar tests to matplotlib 3.5 changes

### DIFF
--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1195,8 +1195,8 @@ class TestMapclassifyPlotting:
             ax2 = self.df.plot(
                 column="pop_est", cmap="OrRd", legend=True, cax=cax, ax=ax2
             )
-        plot_height = _get_ax(fig, "").get_position().height
-        legend_height = _get_ax(fig, "fixed_colorbar").get_position().height
+        plot_height = fig.axes[0].get_position().height
+        legend_height = fig.axes[1].get_position().height
         assert abs(plot_height - legend_height) < 1e-6
 
 
@@ -1683,4 +1683,10 @@ def _get_ax(fig, label):
 
 
 def _get_colorbar_ax(fig):
-    return _get_ax(fig, "<colorbar>")
+    cax = _get_ax(fig, "<colorbar>")
+    if matplotlib.__version__ < LooseVersion("3.5.0"):
+        return cax
+    else:
+        # Get the inset axis actually containing the colorbar elements, see GH
+        # matplotlib#20054.
+        return cax.child_axes[0]


### PR DESCRIPTION
fixes #1962 

I ran the tests in two environments, one with matplotlib versions 3.3.4 and the other with 3.5.0.dev1280+g92825fefb, which passed.