### PR TITLE
ENH: Add id_as_index argument to GeoDataFrame.from_features

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -615,7 +615,20 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         gdf = GeoDataFrame(rows, columns=columns, crs=crs)
         if id_as_index:
+            if "id" not in gdf:
+                warnings.warn(
+                    "id_as_index=True is ignored since there is"
+                    " no `id` field in the given features."
+                )
+                return gdf
+            if gdf.id.isna().any():
+                warnings.warn(
+                    "id_as_index=True is ignored since "
+                    "the `id` field of the given features contains missing data."
+                )
+                return gdf
             gdf.set_index("id", inplace=True)
+
         return gdf
 
     @classmethod

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -583,9 +583,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         ... }
         >>> df = geopandas.GeoDataFrame.from_features(feature_coll)
         >>> df
-                          geometry   col1
-        0  POINT (1.00000 2.00000)  name1
-        1  POINT (2.00000 1.00000)  name2
+                          geometry   col1  id
+        0  POINT (1.00000 2.00000)  name1   0
+        1  POINT (2.00000 1.00000)  name2   1
 
         """
         # Handle feature collections

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -630,7 +630,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 )
                 return _maybe_use_feature_id(gdf)
 
-            gdf.set_index("feature_id", inplace=True, verify_integrity=True)
+            gdf.set_index("feature_id", inplace=True)
             gdf.index.name = None
         else:  # "feature_id" column still present in GeoDataFrame
             gdf = _maybe_use_feature_id(gdf)
@@ -2229,7 +2229,7 @@ def _maybe_use_feature_id(gdf):
     if "id" not in gdf.columns:  # use it
         gdf.rename(columns={"feature_id": "id"}, inplace=True)
     else:  # ignore it
-        gdf.drop(["feature_id"], axis=1, inplace=True)
+        gdf.drop(["feature_id"], axis=1, errors="ignore", inplace=True)
     return gdf
 
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -526,7 +526,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         return geopandas.io.file._read_file(filename, **kwargs)
 
     @classmethod
-    def from_features(cls, features, crs=None, columns=None):
+    def from_features(cls, features, crs=None, columns=None, id_as_index=False):
         """
         Alternate constructor to create GeoDataFrame from an iterable of
         features or a feature collection.
@@ -546,6 +546,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             Optionally specify the column names to include in the output frame.
             This does not overwrite the property names of the input, but can
             ensure a consistent output format.
+        id_as_index: bool (optional)
+            Controls whether the 'id' column is used as index of the
+            GeoDataFrame
 
         Returns
         -------
@@ -606,8 +609,14 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             }
             # load properties
             row.update(feature["properties"])
+            if "id" in feature:
+                row.update({"id": feature["id"]})
             rows.append(row)
-        return GeoDataFrame(rows, columns=columns, crs=crs)
+
+        gdf = GeoDataFrame(rows, columns=columns, crs=crs)
+        if id_as_index:
+            gdf.set_index("id", inplace=True)
+        return gdf
 
     @classmethod
     def from_postgis(

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -624,26 +624,26 @@ class TestDataFrame:
         assert df.geometry.tolist() == [p1, p2]
 
     def test_from_feature_collection(self):
-        data = {
-            "name": ["a", "b", "c"],
-            "lat": [45, 46, 47.5],
-            "lon": [-120, -121.2, -122.9],
-            "id": ["0", "1", "2"],
-        }
 
-        df = pd.DataFrame(data)
-        geometry = [Point(xy) for xy in zip(df["lon"], df["lat"])]
-        gdf = GeoDataFrame(df, geometry=geometry)
+        gdf = GeoDataFrame(
+            {"data": [0.1, 0.2], "id": [1, 2], "geometry": [Point(1, 1), Point(2, 2)]}
+        )
         # from_features returns sorted columns
-        expected = gdf[["geometry", "id", "lat", "lon", "name"]]
+        expected = gdf[["geometry", "data", "id"]]
 
         # test FeatureCollection
         res = GeoDataFrame.from_features(gdf.__geo_interface__)
         assert_frame_equal(res, expected)
 
-        # test id as index
+        # test feature id as index
+        feature_id = []
+        for feat in gdf.__geo_interface__["features"]:
+            feature_id.append(feat["id"])
         res = GeoDataFrame.from_features(gdf.__geo_interface__, id_as_index=True)
-        assert_frame_equal(res, expected.set_index("id"))
+        expected1 = expected.copy()
+        #  expected1.index = pd.Index(feature_id, name="id")
+        expected1.index = feature_id
+        assert_frame_equal(res, expected1)
 
         # test id field not present in FeatureCollection
         feature_coll1 = gdf.__geo_interface__.copy()

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -625,6 +625,13 @@ class TestDataFrame:
 
     def test_from_feature_collection(self):
 
+        gdf_no_id = GeoDataFrame(
+            {
+                "geometry": [Point(1, 1), Point(2, 2)],
+                "data": [0.1, 0.2],
+            }
+        )
+
         # Create a GeoDataFrame which contains an "id" column which does not
         # represent the feature ids, but some other data
         gdf = GeoDataFrame(
@@ -635,9 +642,35 @@ class TestDataFrame:
             }
         )
 
-        # test FeatureCollection
+        # test the feature id has been retrieved
+        res_no_id = GeoDataFrame.from_features(gdf_no_id.__geo_interface__)
+        exp_no_id = gdf_no_id.copy()
+        exp_no_id["id"] = ["0", "1"]
+        assert_frame_equal(res_no_id, exp_no_id)
+
+        # test the feature id has NOT been retrieved
         res = GeoDataFrame.from_features(gdf.__geo_interface__)
         assert_frame_equal(res, gdf)
+
+        # test list of Features
+        res = GeoDataFrame.from_features(gdf.__geo_interface__["features"])
+        assert_frame_equal(res, gdf)
+
+        # test __geo_interface__ attribute (a GeoDataFrame has one)
+        res = GeoDataFrame.from_features(gdf)
+        assert_frame_equal(res, gdf)
+
+    def test_from_feature_collection_id_as_index(self):
+
+        # Create a GeoDataFrame which contains an "id" column which does not
+        # represent the feature ids, but some other data
+        gdf = GeoDataFrame(
+            {
+                "geometry": [Point(1, 1), Point(2, 2)],
+                "data": [0.1, 0.2],
+                "id": [1, 2],
+            }
+        )
 
         # test feature id as index
         feature_id = []
@@ -663,14 +696,6 @@ class TestDataFrame:
         del feat["properties"]["id"]
         with pytest.warns(UserWarning, match=r".* features contains missing data."):
             GeoDataFrame.from_features(feature_coll2, id_as_index=True)
-
-        # test list of Features
-        res = GeoDataFrame.from_features(gdf.__geo_interface__["features"])
-        assert_frame_equal(res, gdf)
-
-        # test __geo_interface__ attribute (a GeoDataFrame has one)
-        res = GeoDataFrame.from_features(gdf)
-        assert_frame_equal(res, gdf)
 
     def test_dataframe_to_geodataframe(self):
         df = pd.DataFrame(

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -645,6 +645,22 @@ class TestDataFrame:
         res = GeoDataFrame.from_features(gdf.__geo_interface__, id_as_index=True)
         assert_frame_equal(res, expected.set_index("id"))
 
+        # test id field not present in FeatureCollection
+        feature_coll1 = gdf.__geo_interface__.copy()
+        for feat in feature_coll1["features"]:
+            del feat["id"]
+            del feat["properties"]["id"]
+        with pytest.warns(UserWarning, match=r".* field in the given features."):
+            GeoDataFrame.from_features(feature_coll1, id_as_index=True)
+
+        # test id field with missing data in FeatureCollection
+        feature_coll2 = gdf.__geo_interface__.copy()
+        feat = feature_coll2["features"][0]
+        del feat["id"]
+        del feat["properties"]["id"]
+        with pytest.warns(UserWarning, match=r".* features contains missing data."):
+            GeoDataFrame.from_features(feature_coll2, id_as_index=True)
+
         # test list of Features
         res = GeoDataFrame.from_features(gdf.__geo_interface__["features"])
         assert_frame_equal(res, expected)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -641,6 +641,10 @@ class TestDataFrame:
         res = GeoDataFrame.from_features(gdf.__geo_interface__)
         assert_frame_equal(res, expected)
 
+        # test id as index
+        res = GeoDataFrame.from_features(gdf.__geo_interface__, id_as_index=True)
+        assert_frame_equal(res, expected.set_index("id"))
+
         # test list of Features
         res = GeoDataFrame.from_features(gdf.__geo_interface__["features"])
         assert_frame_equal(res, expected)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -628,13 +628,14 @@ class TestDataFrame:
             "name": ["a", "b", "c"],
             "lat": [45, 46, 47.5],
             "lon": [-120, -121.2, -122.9],
+            "id": ["0", "1", "2"],
         }
 
         df = pd.DataFrame(data)
         geometry = [Point(xy) for xy in zip(df["lon"], df["lat"])]
         gdf = GeoDataFrame(df, geometry=geometry)
         # from_features returns sorted columns
-        expected = gdf[["geometry", "lat", "lon", "name"]]
+        expected = gdf[["geometry", "id", "lat", "lon", "name"]]
 
         # test FeatureCollection
         res = GeoDataFrame.from_features(gdf.__geo_interface__)


### PR DESCRIPTION
Closes #1988, closes #1208.

I've set the default to `False` so this does not surprise anybody in the future.
Probably an error or at least a warning  should be raised if `id_as_index=True` but there is no id in the features ?