### PR TITLE
REF: line_interpolate_point and line_locate_point now use normalized

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -797,7 +797,10 @@ def buffer(data, distance, resolution=16, **kwargs):
 
 def interpolate(data, distance, normalized=False):
     if compat.USE_PYGEOS:
-        return pygeos.line_interpolate_point(data, distance, normalize=normalized)
+        try:
+            return pygeos.line_interpolate_point(data, distance, normalized=normalized)
+        except TypeError:  # support for pygeos<0.9
+            return pygeos.line_interpolate_point(data, distance, normalize=normalized)
     else:
         out = np.empty(len(data), dtype=object)
         if isinstance(distance, np.ndarray):
@@ -861,7 +864,10 @@ def normalize(data):
 
 def project(data, other, normalized=False):
     if compat.USE_PYGEOS:
-        return pygeos.line_locate_point(data, other, normalize=normalized)
+        try:
+            return pygeos.line_locate_point(data, other, normalized=normalized)
+        except TypeError:  # support for pygeos<0.9
+            return pygeos.line_locate_point(data, other, normalize=normalized)
     else:
         return _binary_op("project", data, other, normalized=normalized)
 


### PR DESCRIPTION
Since PyGEOS 0.9, the "normalize" parameter was renamed to "normalized" for line_interpolate_point and line_locate_point.

There are a few [pytest CI warnings](https://github.com/geopandas/geopandas/runs/3074661832#step:6:3101):
>   /usr/share/miniconda/envs/test/lib/python3.8/site-packages/pygeos/linear.py:90: DeprecationWarning: argument 'normalize' is deprecated; use 'normalized'

This PR should clear these warnings up, and work with older PyGEOS versions.

xref https://github.com/pygeos/pygeos/pull/209