### PR TITLE
DOC: pyarrow intersphinx mapping

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -334,69 +334,74 @@ nbsphinx_prolog = r"""
 
 # connect docs in other projects
 intersphinx_mapping = {
-    "pyproj": (
-        "https://pyproj4.github.io/pyproj/stable/",
-        "https://pyproj4.github.io/pyproj/stable/objects.inv",
-    ),
-    "pandas": (
-        "https://pandas.pydata.org/pandas-docs/stable/",
-        "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
-    ),
-    "shapely": (
-        "https://shapely.readthedocs.io/en/stable/",
-        "https://shapely.readthedocs.io/en/stable/objects.inv",
-    ),
-    "fiona": (
-        "https://fiona.readthedocs.io/en/stable/",
-        "https://fiona.readthedocs.io/en/stable/objects.inv",
-    ),
-    "pygeos": (
-        "https://pygeos.readthedocs.io/en/latest/",
-        "https://pygeos.readthedocs.io/en/latest/objects.inv",
-    ),
-    "rtree": (
-        "https://rtree.readthedocs.io/en/stable/",
-        "https://rtree.readthedocs.io/en/stable/objects.inv",
-    ),
-    "mapclassify": (
-        "https://pysal.org/mapclassify/",
-        "https://pysal.org/mapclassify/objects.inv",
-    ),
-    "libpysal": (
-        "https://pysal.org/libpysal/",
-        "https://pysal.org/libpysal/objects.inv",
-    ),
-    "matplotlib": (
-        "https://matplotlib.org/stable/",
-        "https://matplotlib.org/stable/objects.inv",
-    ),
-    "geopy": (
-        "https://geopy.readthedocs.io/en/stable/",
-        "https://geopy.readthedocs.io/en/stable/objects.inv",
-    ),
     "cartopy": (
         "https://scitools.org.uk/cartopy/docs/latest/",
         "https://scitools.org.uk/cartopy/docs/latest/objects.inv",
-    ),
-    "pyepsg": (
-        "https://pyepsg.readthedocs.io/en/stable/",
-        "https://pyepsg.readthedocs.io/en/stable/objects.inv",
     ),
     "contextily": (
         "https://contextily.readthedocs.io/en/stable/",
         "https://contextily.readthedocs.io/en/stable/objects.inv",
     ),
-    "rasterio": (
-        "https://rasterio.readthedocs.io/en/stable/",
-        "https://rasterio.readthedocs.io/en/stable/objects.inv",
-    ),
-    "geoplot": (
-        "https://residentmario.github.io/geoplot/index.html",
-        "https://residentmario.github.io/geoplot/objects.inv",
+    "fiona": (
+        "https://fiona.readthedocs.io/en/stable/",
+        "https://fiona.readthedocs.io/en/stable/objects.inv",
     ),
     "folium": (
         "https://python-visualization.github.io/folium/",
         "https://python-visualization.github.io/folium/objects.inv",
     ),
+    "geoplot": (
+        "https://residentmario.github.io/geoplot/index.html",
+        "https://residentmario.github.io/geoplot/objects.inv",
+    ),
+    "geopy": (
+        "https://geopy.readthedocs.io/en/stable/",
+        "https://geopy.readthedocs.io/en/stable/objects.inv",
+    ),
+    "libpysal": (
+        "https://pysal.org/libpysal/",
+        "https://pysal.org/libpysal/objects.inv",
+    ),
+    "mapclassify": (
+        "https://pysal.org/mapclassify/",
+        "https://pysal.org/mapclassify/objects.inv",
+    ),
+    "matplotlib": (
+        "https://matplotlib.org/stable/",
+        "https://matplotlib.org/stable/objects.inv",
+    ),
+    "pandas": (
+        "https://pandas.pydata.org/pandas-docs/stable/",
+        "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
+    ),
+    "pyarrow": ("https://arrow.apache.org/docs/", None),
+    "pyepsg": (
+        "https://pyepsg.readthedocs.io/en/stable/",
+        "https://pyepsg.readthedocs.io/en/stable/objects.inv",
+    ),   
+    "pyepsg": (
+        "https://pyepsg.readthedocs.io/en/stable/",
+        "https://pyepsg.readthedocs.io/en/stable/objects.inv",
+    ),
+    "pygeos": (
+        "https://pygeos.readthedocs.io/en/latest/",
+        "https://pygeos.readthedocs.io/en/latest/objects.inv",
+    ),
+    "pyproj": (
+        "https://pyproj4.github.io/pyproj/stable/",
+        "https://pyproj4.github.io/pyproj/stable/objects.inv",
+    ),
     "python": ("https://docs.python.org/3", "https://docs.python.org/3/objects.inv"),
+    "rtree": (
+        "https://rtree.readthedocs.io/en/stable/",
+        "https://rtree.readthedocs.io/en/stable/objects.inv",
+    ),
+    "rasterio": (
+        "https://rasterio.readthedocs.io/en/stable/",
+        "https://rasterio.readthedocs.io/en/stable/objects.inv",
+    ),
+    "shapely": (
+        "https://shapely.readthedocs.io/en/stable/",
+        "https://shapely.readthedocs.io/en/stable/objects.inv",
+    ),
 }

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -962,7 +962,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
         kwargs
-            Additional keyword arguments passed to ``pyarrow.parquet.write_table``.
+            Additional keyword arguments passed to :func:`pyarrow.parquet.write_table`.
 
         Examples
         --------
@@ -1010,7 +1010,8 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             Name of the compression to use. Use ``"uncompressed"`` for no
             compression. By default uses LZ4 if available, otherwise uncompressed.
         kwargs
-            Additional keyword arguments passed to to pyarrow.feather.write_feather().
+            Additional keyword arguments passed to to
+            :func:`pyarrow.feather.write_feather`.
 
         Examples
         --------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -962,7 +962,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
         kwargs
-            Additional keyword arguments passed to to pyarrow.parquet.write_table().
+            Additional keyword arguments passed to ``pyarrow.parquet.write_table``.
 
         Examples
         --------


### PR DESCRIPTION
This PR attempts to link `pyarrow.parquet.write_table` mentioned in the doc string of `to_parquet` to the relevant pyarrow docs page.

I couldn't get the doc build to show the update locally. It was building the old doc string and I can't work out why.

This PR also sorts the packages in intersphinx_mapping to make it easier to add new packages and remove the typo (to to) the the `to_parquet` doc string.