### PR TITLE
BUG: fix pd.concat(... axis=1) causing duplicate geometry column names

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -118,6 +118,15 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         # allowed in that case
         # TODO do we want to raise / return normal DataFrame in this case?
         if geometry is None and "geometry" in self.columns:
+            # Check for multiple columns with name "geometry". If there are,
+            # self["geometry"] is a gdf and constructor gets recursively recalled
+            # by pandas internals trying to access this
+            if len(self.columns[self.columns == "geometry"]) > 1:
+                raise ValueError(
+                    "GeoDataFrame does not support multiple columns "
+                    "using the geometry column name 'geometry'."
+                )
+
             # only if we have actual geometry values -> call set_geometry
             index = self.index
             try:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1404,6 +1404,13 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other.objs[0], name, None))
 
+            if len(self.columns[self.columns == self._geometry_column_name]) > 1:
+                raise ValueError(
+                    "Concat operation has resulted multiple columns using "
+                    f"the geometry column name "
+                    f"'{self._geometry_column_name}'.\nPlease ensure this "
+                    f"column from the first Frame is not repeated."
+                )
         return self
 
     def dissolve(

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -121,7 +121,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             # Check for multiple columns with name "geometry". If there are,
             # self["geometry"] is a gdf and constructor gets recursively recalled
             # by pandas internals trying to access this
-            if len(self.columns[self.columns == "geometry"]) > 1:
+            if (self.columns == "geometry").sum() > 1:
                 raise ValueError(
                     "GeoDataFrame does not support multiple columns "
                     "using the geometry column name 'geometry'."
@@ -280,15 +280,16 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             raise ValueError("Must pass array with one dimension only.")
         else:
             try:
-                level = frame[col].values
+                level = frame[col]
             except KeyError:
                 raise ValueError("Unknown column %s" % col)
             except Exception:
                 raise
-            # specially check shape of level for consistency (shapely raises a
-            # TypeError but pygeos raises a ValueError)
-            if hasattr(level, "ndim") and level.ndim != 1:
-                raise ValueError("Must pass array with one dimension only.")
+            if isinstance(level, DataFrame):
+                raise ValueError(
+                    "GeoDataFrame does not support setting the geometry column where "
+                    "the column name shared by multiple columns."
+                )
 
             if drop:
                 to_remove = col

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -288,7 +288,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             if isinstance(level, DataFrame):
                 raise ValueError(
                     "GeoDataFrame does not support setting the geometry column where "
-                    "the column name shared by multiple columns."
+                    "the column name is shared by multiple columns."
                 )
 
             if drop:
@@ -1410,12 +1410,12 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other.objs[0], name, None))
 
-            if len(self.columns[self.columns == self._geometry_column_name]) > 1:
+            if (self.columns == self._geometry_column_name).sum() > 1:
                 raise ValueError(
-                    "Concat operation has resulted multiple columns using "
-                    f"the geometry column name "
-                    f"'{self._geometry_column_name}'.\nPlease ensure this "
-                    f"column from the first Frame is not repeated."
+                    "Concat operation has resulted in multiple columns using "
+                    f"the geometry column name '{self._geometry_column_name}'.\n"
+                    f"Please ensure this column from the first DataFrame is not "
+                    f"repeated."
                 )
         return self
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -285,6 +285,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 raise ValueError("Unknown column %s" % col)
             except Exception:
                 raise
+            # specially check shape of level for consistency (shapely raises a
+            # TypeError but pygeos raises a ValueError)
+            if hasattr(level, "ndim") and level.ndim != 1:
+                raise ValueError("Must pass array with one dimension only.")
+
             if drop:
                 to_remove = col
                 geo_column_name = self._geometry_column_name

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -52,16 +52,18 @@ class TestDataFrame:
         assert self.df2.crs == self.crs
 
     def test_df_init_repeat_geo_col(self):
-        df3 = pd.DataFrame(self.df2)
-        df3["geom"] = df3["geometry"]
+        df = pd.DataFrame(self.df2)
+        df["geom"] = df["geometry"]
         # explicitly prevent construction of gdf with repeat geometry column names
         # two columns called "geometry", geom col inferred
+        df3 = df.rename(columns={"geom": "geometry"})
         with pytest.raises(ValueError):
-            GeoDataFrame(df3.rename(columns={"geom": "geometry"}))
+            GeoDataFrame(df3)
         # ensure case is caught when custom geom column name is used
         # two columns called "geom", geom col explicit
+        df4 = df.rename(columns={"geometry": "geom"})
         with pytest.raises(ValueError):
-            GeoDataFrame(df3.rename(columns={"geometry": "geom"}), geometry="geom")
+            GeoDataFrame(df4, geometry="geom")
 
     def test_different_geo_colname(self):
         data = {

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -51,20 +51,6 @@ class TestDataFrame:
         assert type(self.df2) is GeoDataFrame
         assert self.df2.crs == self.crs
 
-    def test_df_init_repeat_geo_col(self):
-        df = pd.DataFrame(self.df2)
-        df["geom"] = df["geometry"]
-        # explicitly prevent construction of gdf with repeat geometry column names
-        # two columns called "geometry", geom col inferred
-        df3 = df.rename(columns={"geom": "geometry"})
-        with pytest.raises(ValueError):
-            GeoDataFrame(df3)
-        # ensure case is caught when custom geom column name is used
-        # two columns called "geom", geom col explicit
-        df4 = df.rename(columns={"geometry": "geom"})
-        with pytest.raises(ValueError):
-            GeoDataFrame(df4, geometry="geom")
-
     def test_different_geo_colname(self):
         data = {
             "A": range(5),
@@ -1021,6 +1007,24 @@ class TestConstructor:
         # passed geometry kwarg should overwrite geometry column in data
         res = GeoDataFrame(data, geometry=geoms)
         assert_geoseries_equal(res.geometry, GeoSeries(geoms))
+
+    def test_repeat_geo_col(self):
+        df = pd.DataFrame(
+            [
+                {"geometry": Point(x, y), "geom": Point(x, y)}
+                for x, y in zip(range(3), range(3))
+            ],
+        )
+        # explicitly prevent construction of gdf with repeat geometry column names
+        # two columns called "geometry", geom col inferred
+        df2 = df.rename(columns={"geom": "geometry"})
+        with pytest.raises(ValueError):
+            GeoDataFrame(df2)
+        # ensure case is caught when custom geom column name is used
+        # two columns called "geom", geom col explicit
+        df3 = df.rename(columns={"geometry": "geom"})
+        with pytest.raises(ValueError):
+            GeoDataFrame(df3, geometry="geom")
 
 
 def test_geodataframe_crs():

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -51,6 +51,17 @@ class TestDataFrame:
         assert type(self.df2) is GeoDataFrame
         assert self.df2.crs == self.crs
 
+    def test_df_init_repeat_geo_col(self):
+        df3 = pd.DataFrame(self.df2)
+        df3["geom"] = df3["geometry"]
+        df3 = df3.rename(columns={"geom": "geometry"})
+        # explicitly prevent construction of gdf with repeat geometry column names
+        with pytest.raises(ValueError):
+            GeoDataFrame(df3)
+        # ensure case is caught when custom geom column name is used
+        with pytest.raises(ValueError):
+            GeoDataFrame(df3.rename(columns={"geometry": "geom"}), geometry="geom")
+
     def test_different_geo_colname(self):
         data = {
             "A": range(5),

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -54,11 +54,12 @@ class TestDataFrame:
     def test_df_init_repeat_geo_col(self):
         df3 = pd.DataFrame(self.df2)
         df3["geom"] = df3["geometry"]
-        df3 = df3.rename(columns={"geom": "geometry"})
         # explicitly prevent construction of gdf with repeat geometry column names
+        # two columns called "geometry", geom col inferred
         with pytest.raises(ValueError):
-            GeoDataFrame(df3)
+            GeoDataFrame(df3.rename(columns={"geom": "geometry"}))
         # ensure case is caught when custom geom column name is used
+        # two columns called "geom", geom col explicit
         with pytest.raises(ValueError):
             GeoDataFrame(df3.rename(columns={"geometry": "geom"}), geometry="geom")
 

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import pytest
+from geopandas.testing import assert_geodataframe_equal
 
 from shapely.geometry import Point
 
@@ -48,6 +50,13 @@ class TestMerging:
         assert isinstance(res, GeoDataFrame)
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res)
+        exp = GeoDataFrame(pd.concat([pd.DataFrame(self.gdf), pd.DataFrame(self.gdf)]))
+        assert_geodataframe_equal(exp, res)
+        # check metadata comes from first gdf
+        res4 = pd.concat([self.gdf.set_crs("epsg:4326"), self.gdf], axis=0)
+        # Note: this behaviour does not make sense - geom cols combined into one
+        # but they have different CRS and that is lost. We should raise instead.
+        self._check_metadata(res4, crs="epsg:4326")
 
         # series
         res = pd.concat([self.gdf.geometry, self.gdf.geometry])
@@ -63,3 +72,23 @@ class TestMerging:
         assert isinstance(res, GeoDataFrame)
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res)
+
+        # https://github.com/geopandas/geopandas/issues/1230
+        # Expect that concat should fail gracefully if duplicate column names belonging
+        # to geometry columns are introduced.
+        expected_err = (
+            "GeoDataFrame does not support multiple columns using the geometry"
+            " column name 'geometry'"
+        )
+        with pytest.raises(ValueError, match=expected_err):
+            pd.concat([self.gdf, self.gdf], axis=1)
+
+        # Check case is handled if custom geometry column name is used
+        df2 = self.gdf.rename_geometry("geom")
+        with pytest.raises(ValueError):
+            pd.concat([df2, df2], axis=1)
+
+        # Check that two geometry columns is fine, if they have different names
+        res3 = pd.concat([df2.set_crs("epsg:4326"), self.gdf], axis=1)
+        # check metadata comes from first df
+        self._check_metadata(res3, geometry_column_name="geom", crs="epsg:4326")

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -582,3 +582,23 @@ def test_preserve_flags(df):
 
     with pytest.raises(ValueError):
         pd.concat([df, df])
+
+
+def test_concat(df):
+    df_rows = pd.concat([pd.DataFrame(df), pd.DataFrame(df)], axis=0)
+    assert_frame_equal(pd.concat([df, df], axis=0), df_rows)
+
+    # https://github.com/geopandas/geopandas/issues/1230
+    # Expect that concat should fail gracefully if duplicate column names belonging to
+    # geometry columns are introduced.
+    with pytest.raises(ValueError):
+        pd.concat([df, df], axis=1)
+
+    df2 = df.rename_geometry("geom")
+
+    # Check case is handled if custom geometry column name is used
+    with pytest.raises(ValueError):
+        pd.concat([df2, df2], axis=1)
+
+    # Check that legal case without repeated geometry column is fine
+    pd.concat([df, df2], axis=1)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pyproj
 from numpy.testing import assert_array_equal
 import pandas as pd
 
@@ -583,38 +582,3 @@ def test_preserve_flags(df):
 
     with pytest.raises(ValueError):
         pd.concat([df, df])
-
-
-def test_concat(df):
-    df_rows = GeoDataFrame(pd.concat([pd.DataFrame(df), pd.DataFrame(df)], axis=0))
-    res1 = pd.concat([df, df], axis=0)
-    assert_geodataframe_equal(res1, df_rows)
-
-    # https://github.com/geopandas/geopandas/issues/1230
-    # Expect that concat should fail gracefully if duplicate column names belonging to
-    # geometry columns are introduced.
-    expected_err = (
-        "GeoDataFrame does not support multiple columns using the geometry"
-        " column name 'geometry'"
-    )
-    with pytest.raises(ValueError, match=expected_err):
-        pd.concat([df, df], axis=1)
-
-    df2 = df.rename_geometry("geom")
-
-    # Check case is handled if custom geometry column name is used
-    with pytest.raises(ValueError):
-        pd.concat([df2, df2], axis=1)
-
-    # Check that legal case without repeated geometry column is fine
-    res3 = pd.concat([df.set_crs("EPSG:4326"), df2], axis=1)
-
-    # check that metadata is propagated from the first gdf by __finalise__
-    assert df.crs is None
-    assert res3.geometry.name == df.geometry.name
-    assert res3.crs == pyproj.CRS(4326)
-
-    res4 = pd.concat([df.set_crs("EPSG:4326"), df], axis=0)
-    assert res4.geometry.name == df.geometry.name
-    # TODO expect this to fail (at the very least warn), not desirable
-    assert res4.crs == pyproj.CRS(4326)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -593,7 +593,11 @@ def test_concat(df):
     # https://github.com/geopandas/geopandas/issues/1230
     # Expect that concat should fail gracefully if duplicate column names belonging to
     # geometry columns are introduced.
-    with pytest.raises(ValueError):
+    expected_err = (
+        "GeoDataFrame does not support multiple columns using the geometry"
+        " column name 'geometry'"
+    )
+    with pytest.raises(ValueError, match=expected_err):
         pd.concat([df, df], axis=1)
 
     df2 = df.rename_geometry("geom")


### PR DESCRIPTION
Fixes #1230. 
Adds tests for pd.concat().

Wording of exceptions could probably use a little work. 
Currently I've added a new test demonstrating undesirable behaviour of pd.concat(... axis=0), which should probably be addressed separately.
