### PR TITLE
add pyarrow sphinx objects.inv

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -375,7 +375,10 @@ intersphinx_mapping = {
         "https://pandas.pydata.org/pandas-docs/stable/",
         "https://pandas.pydata.org/pandas-docs/stable/objects.inv",
     ),
-    "pyarrow": ("https://arrow.apache.org/docs/", None),
+    "pyarrow": (
+        "https://arrow.apache.org/docs/",
+        "https://arrow.apache.org/docs/objects.inv",
+    ),
     "pyepsg": (
         "https://pyepsg.readthedocs.io/en/stable/",
         "https://pyepsg.readthedocs.io/en/stable/objects.inv",


### PR DESCRIPTION
The `objects.inv` of pyarrow package In `intersphinx_mapping` is None, but it is accessible.