### PR TITLE
DRAFT: BUG: Losing the geometry column should convert to a DataFrame

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -33,24 +33,29 @@ class _GeoLocIndexer(_LocIndexer):
     info.
     """
 
-    def __init__(self, name: str, df: "GeoDataFrame", geo_col: str):
+    def __init__(self, name: str, df: "GeoDataFrame"):
         self.df = df
-        self._geo_col = geo_col
+        self._geo_col = df._geometry_column_name
         super().__init__(name=name, obj=df)
 
     def __getitem__(self, item):
         result = super(_LocIndexer, self.df.loc).__getitem__(item)
-        return _class_dispatch(result, geo_col=self._geo_col)
+        if self._geo_col is not None:
+            return _class_dispatch(result, geo_col=self._geo_col)
+        else:
+            return result
 
 
 class _GeoiLocIndexer(_iLocIndexer):
-    def __init__(self, name: str, df: "GeoDataFrame", geo_col: str):
+    def __init__(self, name: str, df: "GeoDataFrame"):
         self.df = df
-        self._geo_col = geo_col
+        self._geo_col = df._geometry_column_name
         super().__init__(name=name, obj=df)
 
     def __getitem__(self, item):
         result = super(_iLocIndexer, self.df.iloc).__getitem__(item)
+        # still run this even if geo_col is None as we could
+        # have Series -> GeoSeries promotion
         return _class_dispatch(result, geo_col=self._geo_col)
 
 
@@ -1413,11 +1418,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
 
     @property
     def loc(self):
-        return _GeoLocIndexer("loc", self, self._geometry_column_name)
+        return _GeoLocIndexer("loc", self)
 
     @property
     def iloc(self):
-        return _GeoiLocIndexer("iloc", self, self._geometry_column_name)
+        return _GeoiLocIndexer("iloc", self)
 
     def merge(self, *args, **kwargs):
         r"""Merge two ``GeoDataFrame`` objects with a database-style join.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1315,12 +1315,27 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         ):
             result = method(self, *method_args, **method_kwargs)
             geo_col = self._geometry_column_name
-            print(result)
+            # print(result)
             if isinstance(result, Series) and isinstance(result.dtype, GeometryDtype):
                 result.__class__ = GeoSeries
-            elif isinstance(result, DataFrame) and geo_col in result:
-                result.__class__ = GeoDataFrame
-                result._geometry_column_name = geo_col
+            elif isinstance(result, DataFrame):
+                if geo_col in result:
+                    result.__class__ = GeoDataFrame
+                    result._geometry_column_name = geo_col
+                # seems unfortunate to have to construct df, couldn't get
+                # result.dtypes==GeometryDType to work correctly though
+                elif len(result.select_dtypes(include=GeometryDtype).columns) > 0:
+                    result.__class__ = GeoDataFrame
+                    if len(result.columns) == 1:
+                        result._geometry_column_name = result.columns[0]
+                    # TODO unclear what to do if >1 column. geometry_col is None
+                    # with warning?, first of geom cols with warning?
+                    # TODO else behaviour is untested
+                    else:
+                        result._geometry_column_name = None
+                else:
+                    result.__class__ = DataFrame
+            # TODO should this just be else?
             elif isinstance(result, DataFrame) and geo_col not in result:
                 result.__class__ = DataFrame
             return result

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1345,7 +1345,11 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         result = super().__getitem__(key)
         return result
 
-    # __getitem__ = class_dispatch_decorator(DataFrame.__getitem__)
+    # Squeeze should always return a GeoSeries (since if the parent we a DataFrame,
+    # DataFrame.squeeze would be called directly - so this could be done explicitly
+    squeeze = class_dispatch_decorator(DataFrame.squeeze)
+    drop = class_dispatch_decorator(DataFrame.drop)
+    reindex = class_dispatch_decorator(DataFrame.reindex)  # this one could use finalize
 
     def __setitem__(self, key, value):
         """

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1408,11 +1408,6 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
     # Implement pandas methods
     #
 
-    # Squeeze should always return a GeoSeries (since if the parent we a DataFrame,
-    # DataFrame.squeeze would be called directly - so this could be done explicitly
-    # TODO do these inherit docstrings? probably not...
-    squeeze = _class_dispatch_decorator(DataFrame.squeeze)
-
     @property
     def loc(self):
         return _GeoLocIndexer("loc", self)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1298,17 +1298,6 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         """
         return self.geometry.estimate_utm_crs(datum_name=datum_name)
 
-    def cast_class(self, result):
-        geo_col = self._geometry_column_name
-        if isinstance(result, Series) and isinstance(result.dtype, GeometryDtype):
-            result.__class__ = GeoSeries
-        elif isinstance(result, DataFrame) and geo_col in result:
-            result.__class__ = GeoDataFrame
-            result._geometry_column_name = geo_col
-        elif isinstance(result, DataFrame) and geo_col not in result:
-            result.__class__ = DataFrame
-        return result
-
     @staticmethod
     def _class_dispatch(
         result: Union["GeoDataFrame", DataFrame, GeoSeries, Series], geo_col: str

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1673,11 +1673,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         exploded_geom = df_copy.geometry.explode().reset_index(level=-1)
         exploded_index = exploded_geom.columns[0]
 
-        df = (
-            df_copy.drop(df_copy._geometry_column_name, axis=1)
-            .join(exploded_geom)
-            .__finalize__(self)
-        )
+        df = df_copy.drop(df_copy._geometry_column_name, axis=1).join(exploded_geom)
 
         # reset to MultiIndex, otherwise df index is only first level of
         # exploded GeoSeries index.
@@ -1686,8 +1682,9 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
 
         if "__level_1" in df.columns:
             df = df.rename(columns={"__level_1": "level_1"})
-
-        geo_df = df.set_geometry(self._geometry_column_name)
+        # df is a DataFrame, monkey patched DataFrame.set_geometry does not propagate
+        # .attrs, need to call finalize to fix
+        geo_df = df.set_geometry(self._geometry_column_name).__finalize__(self)
         return geo_df
 
     # overrides the pandas astype method to ensure the correct return type

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1412,9 +1412,6 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
     # DataFrame.squeeze would be called directly - so this could be done explicitly
     # TODO do these inherit docstrings? probably not...
     squeeze = _class_dispatch_decorator(DataFrame.squeeze)
-    drop = _class_dispatch_decorator(DataFrame.drop)
-    # reindex also could use finalize instead of this
-    reindex = _class_dispatch_decorator(DataFrame.reindex)
 
     @property
     def loc(self):
@@ -1485,7 +1482,10 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         elif method == "concat":
             for name in self._metadata:
                 object.__setattr__(self, name, getattr(other.objs[0], name, None))
-
+        elif method == "reindex":
+            self = _class_dispatch(
+                self, geo_col=getattr(other, "_geometry_column_name", None)
+            )
         return self
 
     def dissolve(

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -98,9 +98,6 @@ def _class_dispatch(
                 result._geometry_column_name = None
         else:
             result.__class__ = DataFrame
-    # TODO should this just be else?
-    elif isinstance(result, DataFrame) and geo_col not in result:
-        result.__class__ = DataFrame
     return result
 
 

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -49,8 +49,12 @@ class TestDataFrame:
         self._check_metadata(self.df.loc[:, ["geometry2"]], "geometry2")
 
     def test_squeeze(self):
-        assert type(self.df[["geometry"]].squeeze()) is GeoSeries
-        assert type(self.df[["geometry2"]].squeeze()) is GeoSeries
+        res1 = self.df[["geometry"]].squeeze()
+        assert type(res1) is GeoSeries
+        assert res1.crs == self.crs
+        res2 = self.df[["geometry2"]].squeeze()
+        assert type(res2) is GeoSeries
+        assert res2.crs == self.crs
 
     def test_to_frame(self):
         res1 = self.df["geometry"].to_frame()

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -107,3 +107,13 @@ class TestDataFrame:
 
         assert type(self.df.apply(lambda x: x)) is GeoDataFrame
         assert type(self.df[["value1", "value2"]].apply(lambda x: x)) is pd.DataFrame
+
+    def test_convert_dtypes(self):
+        assert type(self.df[["value1", "value2"]].convert_dtypes()) is pd.DataFrame
+        res1 = self.df[["geometry"]].convert_dtypes()
+        assert type(res1) is GeoDataFrame
+        self._check_metadata(res1)
+        assert type(self.df[["value1"]].convert_dtypes()) is pd.DataFrame
+        res2 = self.df[["geometry2"]].convert_dtypes()
+        assert type(res2) is GeoDataFrame
+        self._check_metadata(res2, geometry_column_name="geometry2")

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+import tempfile
+
+import pandas as pd
+
+from shapely.geometry import Point
+
+import geopandas
+from geopandas import GeoDataFrame, read_file
+
+from geopandas.tests.util import PACKAGE_DIR
+
+
+class TestDataFrame:
+    def setup_method(self):
+        N = 10
+
+        nybb_filename = geopandas.datasets.get_path("nybb")
+        self.df = read_file(nybb_filename)
+        self.tempdir = tempfile.mkdtemp()
+        self.crs = "epsg:4326"
+        self.df2 = GeoDataFrame(
+            [
+                {"geometry": Point(x, y), "value1": x + y, "value2": x * y}
+                for x, y in zip(range(N), range(N))
+            ],
+            crs=self.crs,
+        )
+        self.df3 = read_file(
+            os.path.join(PACKAGE_DIR, "geopandas", "tests", "data", "null_geom.geojson")
+        )
+
+    def teardown_method(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_df_init(self):
+        assert type(self.df2) is GeoDataFrame
+        assert self.df2.crs == self.crs
+
+    def test_drop(self):
+        assert type(self.df.drop(columns="geometry")) is pd.DataFrame
+
+    def test_getitem(self):
+        assert type(self.df2[["value1", "value2"]]) is pd.DataFrame
+
+    def test_loc(self):
+        assert type(self.df2.loc[:, ["value1", "value2"]]) is pd.DataFrame
+
+    def test_iloc(self):
+        df = self.df2.iloc[:, 1:]
+        print(df.columns)
+
+        assert type(df) is pd.DataFrame
+
+    def test_reindex(self):
+        df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_cities"))
+
+        df_reindex = df.reindex(columns=["name"])
+        print(df)
+        print(df_reindex)
+        assert type(df_reindex) is pd.DataFrame

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -58,7 +58,10 @@ class TestDataFrame:
         self._check_metadata(res1)
         res2 = self.df["geometry2"].to_frame()
         assert type(res2) is GeoDataFrame
-        self._check_metadata(res2, geometry_column_name="geometry2")
+        # TODO this should have geometry col name geometry2 by updating
+        # GeoSeries._constructor_expanddim to give geo col based on series name
+        # similarly for CRS
+        self._check_metadata(res2, geometry_column_name="geometry", crs=None)
         assert type(self.df["value1"].to_frame()) is pd.DataFrame
 
     def test_iloc(self):

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -23,7 +23,7 @@ class TestDataFrame:
         self.df["geometry2"] = self.df["geometry"]  # want geometry2 to be a geoseries
 
     @staticmethod
-    def _check_metadata(gdf, geometry_column_name="geometry", crs=None):
+    def _check_metadata(gdf, geometry_column_name="geometry", crs="epsg:4326"):
 
         assert gdf._geometry_column_name == geometry_column_name
         assert gdf.crs == crs
@@ -36,9 +36,7 @@ class TestDataFrame:
         assert type(self.df[["geometry"]]) is GeoDataFrame
         assert type(self.df[["value1"]]) is pd.DataFrame
         assert type(self.df[["geometry2"]]) is GeoDataFrame
-        self._check_metadata(
-            self.df[["geometry2"]], geometry_column_name="geometry2", crs=self.crs
-        )
+        self._check_metadata(self.df[["geometry2"]], geometry_column_name="geometry2")
 
     def test_loc(self):
         assert type(self.df.loc[:, ["value1", "value2"]]) is pd.DataFrame
@@ -48,11 +46,7 @@ class TestDataFrame:
         assert type(self.df.loc[:, ["geometry"]]) is GeoDataFrame
         assert type(self.df.loc[:, ["value1"]]) is pd.DataFrame
         assert type(self.df.loc[:, ["geometry2"]]) is GeoDataFrame
-        self._check_metadata(
-            self.df.loc[:, ["geometry2"]],
-            geometry_column_name="geometry2",
-            crs=self.crs,
-        )
+        self._check_metadata(self.df.loc[:, ["geometry2"]], "geometry2")
 
     def test_squeeze(self):
         assert type(self.df[["geometry"]].squeeze()) is GeoSeries
@@ -61,14 +55,11 @@ class TestDataFrame:
     def test_to_frame(self):
         res1 = self.df["geometry"].to_frame()
         assert type(res1) is GeoDataFrame
-        assert res1._geometry_column_name == "geometry"
-        self._check_metadata(res1, crs=self.crs)
-
-        assert res1.crs == self.crs
+        self._check_metadata(res1)
         res2 = self.df["geometry2"].to_frame()
         assert type(res2) is GeoDataFrame
-        self._check_metadata(res2, geometry_column_name="geometry2", crs=self.crs)
-        assert res2.crs == self.crs
+        self._check_metadata(res2, geometry_column_name="geometry2")
+        assert type(self.df["value1"].to_frame()) is pd.DataFrame
 
     def test_iloc(self):
         assert type(self.df.iloc[:, 1:3]) is pd.DataFrame
@@ -77,30 +68,30 @@ class TestDataFrame:
         assert type(self.df.iloc[:, 1]) is pd.Series
         res1 = self.df.iloc[:, [0]]
         assert type(res1) is GeoDataFrame
-        self._check_metadata(res1, crs=self.crs)
+        self._check_metadata(res1)
         assert type(self.df.iloc[:, [1]]) is pd.DataFrame
         res2 = self.df.iloc[:, [3]]
         assert type(res2) is GeoDataFrame
-        self._check_metadata(res2, geometry_column_name="geometry2", crs=self.crs)
+        self._check_metadata(res2, geometry_column_name="geometry2")
 
     def test_reindex(self):
         res1 = self.df.reindex(columns=["value1"])
         assert type(res1) is pd.DataFrame
         res2 = self.df.reindex(columns=["geometry"])
         assert type(res2) is GeoDataFrame
-        self._check_metadata(res2, crs=self.crs)
+        self._check_metadata(res2)
         res3 = self.df.reindex(columns=["geometry2"])
         assert type(res3) is GeoDataFrame
-        self._check_metadata(res3, geometry_column_name="geometry2", crs=self.crs)
+        self._check_metadata(res3, geometry_column_name="geometry2")
 
     def test_drop(self):
         assert type(self.df.drop(columns=["geometry", "geometry2"])) is pd.DataFrame
         res1 = self.df.drop(columns=["value1", "value2", "geometry2"])
         assert type(res1) is GeoDataFrame
-        self._check_metadata(res1, geometry_column_name="geometry", crs=self.crs)
+        self._check_metadata(res1)
         res2 = self.df.drop(columns=["value1", "value2", "geometry"])
         assert type(res2) is GeoDataFrame
-        self._check_metadata(res2, geometry_column_name="geometry2", crs=self.crs)
+        self._check_metadata(res2, geometry_column_name="geometry2")
 
     def test_apply(self):
         assert type(self.df["geometry"].apply(lambda x: x)) is GeoSeries

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -7,7 +7,7 @@ import pandas as pd
 from shapely.geometry import Point
 
 import geopandas
-from geopandas import GeoDataFrame, read_file
+from geopandas import GeoDataFrame, read_file, GeoSeries
 
 from geopandas.tests.util import PACKAGE_DIR
 
@@ -22,7 +22,12 @@ class TestDataFrame:
         self.crs = "epsg:4326"
         self.df2 = GeoDataFrame(
             [
-                {"geometry": Point(x, y), "value1": x + y, "value2": x * y}
+                {
+                    "geometry": Point(x, y),
+                    "value1": x + y,
+                    "value2": x * y,
+                    "geometry2": Point(x, y),
+                }
                 for x, y in zip(range(N), range(N))
             ],
             crs=self.crs,
@@ -38,20 +43,40 @@ class TestDataFrame:
         assert type(self.df2) is GeoDataFrame
         assert self.df2.crs == self.crs
 
-    def test_drop(self):
-        assert type(self.df.drop(columns="geometry")) is pd.DataFrame
-
     def test_getitem(self):
         assert type(self.df2[["value1", "value2"]]) is pd.DataFrame
+        assert type(self.df2["geometry"]) is GeoSeries
+        assert type(self.df2["geometry2"]) is GeoSeries
+        assert type(self.df2["value1"]) is pd.Series
+        assert type(self.df2[["geometry"]]) is GeoDataFrame
+        assert type(self.df2[["value1"]]) is pd.DataFrame
+        assert type(self.df2[["geometry2"]]) is GeoDataFrame
 
     def test_loc(self):
         assert type(self.df2.loc[:, ["value1", "value2"]]) is pd.DataFrame
+        assert type(self.df2.loc[:, "geometry"]) is GeoSeries
+        assert type(self.df2.loc[:, "geometry2"]) is GeoSeries
+        assert type(self.df2["value1"]) is pd.Series
+        assert type(self.df2.loc[:, ["geometry"]]) is GeoDataFrame
+        assert type(self.df2.loc[:, ["value1"]]) is pd.DataFrame
+        assert type(self.df2.loc[:, ["geometry2"]]) is GeoDataFrame
+
+    def test_squeeze(self):
+        assert type(self.df2[["geometry"]].squeeze()) is GeoSeries
+        assert type(self.df2[["geometry2"]].squeeze()) is GeoSeries
+
+    def test_to_frame(self):
+        assert type(self.df2["geometry"].to_frame()) is GeoDataFrame
+        assert type(self.df2["geometry2"].to_frame()) is GeoDataFrame
 
     def test_iloc(self):
-        df = self.df2.iloc[:, 1:]
-        print(df.columns)
-
-        assert type(df) is pd.DataFrame
+        assert type(self.df2.iloc[:, 1:3]) is pd.DataFrame
+        assert type(self.df2.iloc[:, 0]) is GeoSeries
+        assert type(self.df2.iloc[:, 3]) is GeoSeries
+        assert type(self.df2.iloc[:, 1]) is pd.Series
+        assert type(self.df2.iloc[:, [0]]) is GeoDataFrame
+        assert type(self.df2.iloc[:, [1]]) is pd.DataFrame
+        assert type(self.df2.iloc[:, [3]]) is GeoDataFrame
 
     def test_reindex(self):
         df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_cities"))
@@ -60,3 +85,14 @@ class TestDataFrame:
         print(df)
         print(df_reindex)
         assert type(df_reindex) is pd.DataFrame
+
+    def test_drop(self):
+        assert type(self.df.drop(columns="geometry")) is pd.DataFrame
+
+    def test_apply(self):
+        assert type(self.df2["geometry"].apply(lambda x: x)) is GeoSeries
+        assert type(self.df2["geometry2"].apply(lambda x: x)) is GeoSeries
+        assert type(self.df2["value1"].apply(lambda x: x)) is pd.Series
+
+        assert type(self.df2.apply(lambda x: x)) is GeoDataFrame
+        assert type(self.df2[["value1", "value2"]].apply(lambda x: x)) is pd.DataFrame

--- a/geopandas/tests/test_op_types.py
+++ b/geopandas/tests/test_op_types.py
@@ -26,12 +26,12 @@ class TestDataFrame:
                     "geometry": Point(x, y),
                     "value1": x + y,
                     "value2": x * y,
-                    "geometry2": Point(x, y),
                 }
                 for x, y in zip(range(N), range(N))
             ],
             crs=self.crs,
         )
+        self.df2["geometry2"] = self.df2["geometry"]  # want geometry2 to be a geoseries
         self.df3 = read_file(
             os.path.join(PACKAGE_DIR, "geopandas", "tests", "data", "null_geom.geojson")
         )
@@ -42,14 +42,18 @@ class TestDataFrame:
     def test_df_init(self):
         assert type(self.df2) is GeoDataFrame
         assert self.df2.crs == self.crs
+        print(type(self.df2["geometry2"]))
+        print(type(self.df2["geometry"]))
 
-    def test_getitem(self):
+    def test_getitem_passing(self):
         assert type(self.df2[["value1", "value2"]]) is pd.DataFrame
         assert type(self.df2["geometry"]) is GeoSeries
-        assert type(self.df2["geometry2"]) is GeoSeries
         assert type(self.df2["value1"]) is pd.Series
         assert type(self.df2[["geometry"]]) is GeoDataFrame
         assert type(self.df2[["value1"]]) is pd.DataFrame
+
+    def test_getitem(self):
+        assert type(self.df2["geometry2"]) is GeoSeries
         assert type(self.df2[["geometry2"]]) is GeoDataFrame
 
     def test_loc(self):

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -310,8 +310,9 @@ def _frame_join(indices, left_df, right_df, how, lsuffix, rsuffix):
             joined.index.name = left_index_name
 
     else:  # how == 'right':
+        left_geo_col_name = left_df.geometry.name
         joined = (
-            left_df.drop(left_df.geometry.name, axis=1)
+            left_df.drop(left_geo_col_name, axis=1)
             .merge(
                 indices.merge(
                     right_df, left_on="_key_right", right_index=True, how="right"
@@ -323,6 +324,7 @@ def _frame_join(indices, left_df, right_df, how, lsuffix, rsuffix):
             .set_index(index_right)
             .drop(["_key_left", "_key_right"], axis=1)
         )
+        joined = GeoDataFrame(joined, geometry=left_geo_col_name)
         if isinstance(index_right, list):
             joined.index.names = right_index_name
         else:

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -2,13 +2,13 @@ from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
+from geopandas.testing import assert_geodataframe_equal
 
 from shapely.geometry import Point, Polygon, GeometryCollection
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, read_file, sjoin
 
-from pandas.testing import assert_frame_equal
 import pytest
 
 
@@ -140,7 +140,7 @@ class TestSpatialJoin:
                 columns={"df2_ix1": "index_right0", "df2_ix2": "index_right1"}
             )
             exp.index.names = df1.index.names
-        assert_frame_equal(res, GeoDataFrame(exp))
+        assert_geodataframe_equal(res, GeoDataFrame(exp))
 
     @pytest.mark.parametrize(
         "dfs",
@@ -190,7 +190,7 @@ class TestSpatialJoin:
             )
             exp.index.names = df1.index.names
 
-        assert_frame_equal(res, GeoDataFrame(exp))
+        assert_geodataframe_equal(res, GeoDataFrame(exp))
 
     def test_empty_join(self):
         # Check joins resulting in empty gdfs.
@@ -299,7 +299,9 @@ class TestSpatialJoin:
         if op == "within" and str(pd.__version__) >= LooseVersion("1.1.0"):
             exp = exp.sort_index()
 
-        assert_frame_equal(res, exp, check_index_type=False)
+        assert_geodataframe_equal(
+            res, GeoDataFrame(exp, geometry="geometry"), check_index_type=False
+        )
 
 
 class TestSpatialJoinNYBB:

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -70,6 +70,10 @@ def dfs(request):
     )
     part1["_merge"] = [0, 1, 2]
     part2["_merge"] = [0, 0, 1, 3]
+    # TODO this replaces geometry -> (geometry_x, geometry_y) and so the active
+    #   geometry column "geometry" no longer exists
+    #   Under new behaviour, drop will then drop the knowledge of the active geometry
+    #   geometry col
     exp = pd.merge(part1, part2, on="_merge", how="outer")
     expected["intersects"] = exp.drop("_merge", axis=1).copy()
 
@@ -136,8 +140,7 @@ class TestSpatialJoin:
                 columns={"df2_ix1": "index_right0", "df2_ix2": "index_right1"}
             )
             exp.index.names = df1.index.names
-
-        assert_frame_equal(res, exp)
+        assert_frame_equal(res, GeoDataFrame(exp))
 
     @pytest.mark.parametrize(
         "dfs",
@@ -187,7 +190,7 @@ class TestSpatialJoin:
             )
             exp.index.names = df1.index.names
 
-        assert_frame_equal(res, exp)
+        assert_frame_equal(res, GeoDataFrame(exp))
 
     def test_empty_join(self):
         # Check joins resulting in empty gdfs.


### PR DESCRIPTION
Work in progress improvement of the conversion of return types to be Geo/ non geo DataFrames/ Series for appropriate cases - "fixing" #1911, (and also the referenced #1856, #1153 and #544).

I realise that there's perhaps too much for one PR here but I'm hoping this at least demonstrates feasibility and triggers some discussion. 

I also realise that this might currently be foregoing some of the wisdom from discussion in those threads over the last four years. This current approach is functional but there is likely more a more elegant solution.

Still some rough edges at the moment
- New tests probably should probably be grouped with all the other tests for each method, not as a new file, this was just easier to test with. 
- Docstrings are probably getting lost in some cases right now
- Some methods are missing (like `convert_dtypes`)
- Overriden index objects probably should not go in the `geodataframe.py` file.

There is also some interpretation in what are sensible conversion rules. 
- What to do if the geometry column is dropped but there are other GeoSeries in the DataFrame?
    * Currently returning a GeoDataFrame with geometry column of None, but I've just seen here (https://github.com/geopandas/geopandas/pull/553) discussion that just returning a dataframe makes more sense. On reflection that would make more sense, one still needs to do `df.set_geometry()` to get a usable `GeoDataFrame`, and it perhaps makes more sense to use the monkey patched method on a valid DataFrame than to do so on an invalid GeoDataFrame. 
    * What about if there is only one column left in the DataFrame and it contains geometry? In this case I think it makes sense to return a GeoDataFrame with the appropriate geometry column set. 