### PR TITLE
BUG: fix colorbar issue under matplotlib 3.4.3

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -906,7 +906,7 @@ GON (((-122.84000 49.00000, -120.0000...
             else:
                 legend_kwds.setdefault("ax", ax)
 
-            n_cmap.set_array([])
+            n_cmap.set_array(np.array([]))
             ax.get_figure().colorbar(n_cmap, **legend_kwds)
 
     plt.draw()


### PR DESCRIPTION
This should fix the failure we got after matplotlib 3.4.3 appeared on conda-forge (https://github.com/geopandas/geopandas/runs/3345624943?check_suite_focus=true#step:5:3000)