### PR TITLE
DOC: modify `read_file` `bbox` example so that `bbox` is shaped like a box

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -112,7 +112,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, **kwargs):
 
     Reading only geometries intersecting ``bbox``:
 
-    >>> df = geopandas.read_file("nybb.shp", bbox=(0, 10, 0, 20))  # doctest: +SKIP
+    >>> df = geopandas.read_file("nybb.shp", bbox=(0, 0, 10, 20))  # doctest: +SKIP
 
     Returns
     -------


### PR DESCRIPTION
The coordinate order of the `bbox` parameter to `read_file()` is (minx, miny, maxx, maxy), and is documented as such in the docstring.  One of the examples in `read_file()` passes a tuple where minx == maxx == 0, which isn't invalid as an intersecting geometry but seems a bit misleading (or at least it confused me :) ) since the resulting Polygon is shaped like a line rather than a box.

This just flips `miny` and `maxx` so that the resulting geometry is rectangular with positive area.