### PR TITLE
BUG: GeoSeries constructor should return Series for empty array with dtype when possible (fix GeoSeries.isna for empty Series)

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -190,7 +190,8 @@ class GeoSeries(GeoPandasBase, Series):
                 s = pd.Series(data, index=index, name=name, **kwargs)
             # prevent trying to convert non-geometry objects
             if s.dtype != object:
-                if s.empty or data is None:
+                if (s.empty and s.dtype == "float64") or data is None:
+                    # pd.Series with empty data gives float64 for older pandas versions
                     s = s.astype(object)
                 else:
                     warnings.warn(_SERIES_WARNING_MSG, FutureWarning, stacklevel=2)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -460,7 +460,7 @@ class TestConstructor:
             assert type(s) == pd.Series
 
         # dtypes that can potentially hold geometry-like data (object) or
-        # can come from emtpy data (float64)
+        # can come from empty data (float64)
         for arr in [
             np.array([], dtype="object"),
             np.array([], dtype="float64"),

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -466,8 +466,9 @@ class TestConstructor:
             np.array([], dtype="float64"),
             np.array([], dtype="str"),
         ]:
-            with pytest.warns(None):
+            with pytest.warns(None) as record:
                 s = GeoSeries(arr)
+            assert not record
             assert isinstance(s, GeoSeries)
 
     def test_from_series(self):


### PR DESCRIPTION
While looking into some more of the warnings from our tests, I noticed that `GeoSeries([]).isna()` didn't properly return a boolean Series:

```
>>> geopandas.GeoSeries([]).isna()
GeoSeries([], dtype: geometry)
```

while the result of `isna` should always be boolean.