### PR TITLE
TST: Enable tests for windows that work on windows

### DIFF
--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -1,5 +1,3 @@
-import sys
-
 from shapely.geometry import (
     Point,
     Polygon,
@@ -18,7 +16,6 @@ import pytest
 import numpy as np
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="fails on AppVeyor")
 @pytest.mark.skip_no_sindex
 class TestSeriesSindex:
     def test_has_sindex(self):
@@ -107,7 +104,6 @@ class TestSeriesSindex:
         assert sliced.sindex is not original_index
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="fails on AppVeyor")
 @pytest.mark.skip_no_sindex
 class TestFrameSindex:
     def setup_method(self):


### PR DESCRIPTION
These sindex tests were disabled for windows due to appveyor, but we don't actually use appveyor [any more?]. In any case, they pass on windows locally and on CI: https://github.com/m-richards/geopandas/pull/5