### PR TITLE
Adding Geography support to to_postgis function

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -396,10 +396,8 @@ def _write_postgis(
     gdf = _convert_to_ewkb(gdf, geom_name, srid)
 
     # Infer schema
-    if schema is not None:
-        schema_name = schema
-    else:
-        schema_name = "public"
+    if schema is None:
+        schema = "public"
 
     # Infer dtype for the `geom_name` column
     if dtype is None:
@@ -469,7 +467,7 @@ def _write_postgis(
         gdf.to_sql(
             name,
             connection,
-            schema=schema_name,
+            schema=schema,
             if_exists=if_exists,
             index=index,
             index_label=index_label,

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -144,7 +144,7 @@ def _get_srid_and_geom_from_postgis(name, con, schema=None, geom_name=None):
             )
             if geom_name is None:
                 result = connection.execute(query).all()
-                if result is not None:
+                if result is not None and len(result) > 0:
                     if len(result) > 1:
                         raise ValueError(
                             f"found multiple {gtype} columns in {name} table, "

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -407,7 +407,7 @@ def _write_postgis(
         dtype = {}
     with _get_conn(con) as connection:
         # Check if table exists and infer Geography/Geometry dtype
-        (target_srid,) = connection.execute(
+        target_srid = connection.execute(
             f"SELECT SRID FROM GEOMETRY_COLUMNS WHERE F_TABLE_SCHEMA = '{schema}' "
             f"AND F_TABLE_NAME = '{name}'"
         ).first()
@@ -415,7 +415,7 @@ def _write_postgis(
             if geom_name not in dtype:
                 dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
         else:
-            (target_srid,) = connection.execute(
+            target_srid = connection.execute(
                 f"SELECT SRID FROM GEOGRAPHY_COLUMNS WHERE F_TABLE_SCHEMA = '{schema}' "
                 f"AND F_TABLE_NAME = '{name}'"
             ).first()
@@ -427,11 +427,11 @@ def _write_postgis(
             dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
         else:
             # Table exists - check if GeoDataFrame's SRID is compatible with it
-            if target_srid != srid:
+            if target_srid[0] != srid:
                 msg = (
                     "The CRS of the target table (EPSG:{epsg_t}) differs from the "
                     "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
-                        epsg_t=target_srid, epsg_src=srid
+                        epsg_t=target_srid[0], epsg_src=srid
                     )
                 )
                 raise ValueError(msg)

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -172,7 +172,7 @@ def _get_srid_and_geom_from_postgis(name, con, schema=None, geom_name=None):
     ]
     if geom_name is not None:
         msg[0] += f"{geom_name} "
-    raise ValueError(msg)
+    raise ValueError("".join(msg))
 
 
 def _read_postgis(

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -449,7 +449,7 @@ def _write_postgis(
     >>> gdf.to_postgis("my_table", engine)  # doctest: +SKIP
     """
     try:
-        from geoalchemy2 import Geography, Geometry
+        from geoalchemy2 import Geometry
     except ImportError:
         raise ImportError("'to_postgis()' requires geoalchemy2 package. ")
 

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -408,7 +408,7 @@ def _write_postgis(
         # Check if table exists and infer Geography/Geometry dtype
         target_srid = connection.execute(
             f"SELECT SRID FROM GEOMETRY_COLUMNS WHERE F_TABLE_SCHEMA = '{schema}' "
-            f"AND F_TABLE_NAME = '{name}'"
+            f"AND F_TABLE_NAME = '{name}' AND F_GEOMETRY_COLUMN = '{geom_name}'"
         ).first()
         if target_srid is not None:
             if geom_name not in dtype:
@@ -416,7 +416,7 @@ def _write_postgis(
         else:
             target_srid = connection.execute(
                 f"SELECT SRID FROM GEOGRAPHY_COLUMNS WHERE F_TABLE_SCHEMA = '{schema}' "
-                f"AND F_TABLE_NAME = '{name}'"
+                f"AND F_TABLE_NAME = '{name}' AND F_GEOMETRY_COLUMN = '{geom_name}'"
             ).first()
             if geom_name not in dtype:
                 dtype[geom_name] = Geography(geometry_type=geometry_type, srid=srid)

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -157,7 +157,7 @@ def _get_srid_and_geom_from_postgis(name, con, schema=None, geom_name=None):
                         gclass(geometry_type=geom_type, srid=int(srid)),
                     )
             else:
-                query += f" AND F_GEOMETRY_COLUMN = '{geom_name}'"
+                query += f" AND F_{gtype.upper()}_COLUMN = '{geom_name}'"
                 result = connection.execute(query).first()
                 if result is not None:
                     geom_name, srid, geom_type = result

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -388,7 +388,6 @@ def _write_postgis(
     # Get geometry type and info whether data contains LinearRing.
     geometry_type, has_curve = _get_geometry_type(gdf)
 
-
     # Convert LinearRing geometries to LineString
     if has_curve:
         gdf = _convert_linearring_to_linestring(gdf, geom_name)

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -167,7 +167,7 @@ def _get_srid_and_geom_from_postgis(name, con, schema=None, geom_name=None):
                     )
 
     msg = [
-        f"Cannot find Geometry or Geography column ",
+        "Cannot find Geometry or Geography column ",
         f"in table {name} in schema {schema}",
     ]
     if geom_name is not None:

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -124,7 +124,7 @@ def _get_srid_and_geom_from_postgis(name, con, schema=None, geom_name=None):
         from sqlalchemy.exc import NoSuchTableError
     except ImportError:
         raise ImportError(
-            "geopandas requires the geoalchemy2 package to interface with PostGIS."
+            "geopandas requires the geoalchemy2/sqlalchemy packages to interface with PostGIS."
         )
 
     if schema is None:

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -417,7 +417,7 @@ def _write_postgis(
             # `geom_name` column is not Geometry - check if it is Geography
             target_srid = connection.execute(
                 f"SELECT SRID FROM GEOGRAPHY_COLUMNS WHERE F_TABLE_SCHEMA = '{schema}' "
-                f"AND F_TABLE_NAME = '{name}' AND F_GEOMETRY_COLUMN = '{geom_name}'"
+                f"AND F_TABLE_NAME = '{name}' AND F_GEOGRAPHY_COLUMN = '{geom_name}'"
             ).first()
             if target_srid is not None and geom_name not in dtype:
                 dtype[geom_name] = Geography(geometry_type=geometry_type, srid=srid)

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -404,52 +404,64 @@ def _write_postgis(
     # Infer dtype for the `geom_name` column
     if dtype is None:
         dtype = {}
-    with _get_conn(con) as connection:
-        # Check if table exists
-        if connection.dialect.has_table(connection, name, schema):
-            # Table exists - check whether `geom_name` column is Geometry or Geography
-            target_srid = connection.execute(
-                f"SELECT SRID FROM GEOMETRY_COLUMNS WHERE "
-                f"F_TABLE_SCHEMA = '{schema}' AND "
-                f"F_TABLE_NAME = '{name}' AND "
-                f"F_GEOMETRY_COLUMN = '{geom_name}'"
-            ).first()
-            if target_srid is not None:
-                # `geom_name` is Geometry - set dtype for it if not provided by user
-                if geom_name not in dtype:
-                    dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
-            else:
-                # `geom_name` column is not Geometry - check if it is Geography
+    if if_exists == "append":
+        with _get_conn(con) as connection:
+            # Check if table exists
+            if connection.dialect.has_table(connection, name, schema):
+                # Table exists - check whether `geom_name` column is
+                # Geometry or Geography
                 target_srid = connection.execute(
-                    f"SELECT SRID FROM GEOGRAPHY_COLUMNS WHERE "
+                    f"SELECT SRID FROM GEOMETRY_COLUMNS WHERE "
                     f"F_TABLE_SCHEMA = '{schema}' AND "
                     f"F_TABLE_NAME = '{name}' AND "
-                    f"F_GEOGRAPHY_COLUMN = '{geom_name}'"
+                    f"F_GEOMETRY_COLUMN = '{geom_name}'"
                 ).first()
                 if target_srid is not None:
-                    # `geom_name` is Geography - set dtype for it
-                    # if not provided by user
+                    # `geom_name` is Geometry - set dtype for it if not provided by user
                     if geom_name not in dtype:
-                        dtype[geom_name] = Geography(
+                        dtype[geom_name] = Geometry(
                             geometry_type=geometry_type, srid=srid
                         )
-            if target_srid is None:
-                msg = (
-                    f"Cannot find Geometry or Geography column {geom_name} "
-                    f"in table {name} in schema {schema}"
-                )
-                raise ValueError(msg)
-            # Check if GeoDataFrame's SRID is compatible with it
-            if target_srid[0] != srid:
-                msg = (
-                    "The CRS of the target table (EPSG:{epsg_t}) differs from the "
-                    "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
-                        epsg_t=target_srid[0], epsg_src=srid
+                else:
+                    # `geom_name` column is not Geometry - check if it is Geography
+                    target_srid = connection.execute(
+                        f"SELECT SRID FROM GEOGRAPHY_COLUMNS WHERE "
+                        f"F_TABLE_SCHEMA = '{schema}' AND "
+                        f"F_TABLE_NAME = '{name}' AND "
+                        f"F_GEOGRAPHY_COLUMN = '{geom_name}'"
+                    ).first()
+                    if target_srid is not None:
+                        # `geom_name` is Geography - set dtype for it
+                        # if not provided by user
+                        if geom_name not in dtype:
+                            dtype[geom_name] = Geography(
+                                geometry_type=geometry_type, srid=srid
+                            )
+                # Make sure SRID of `geom_name` in the database was found
+                if target_srid is None:
+                    msg = (
+                        f"Cannot find Geometry or Geography column {geom_name} "
+                        f"in table {name} in schema {schema}"
                     )
-                )
-                raise ValueError(msg)
-        else:
-            # Table doesn't exist - use Geometry by default
+                    raise ValueError(msg)
+                # Check if GeoDataFrame's SRID is compatible with it
+                if target_srid[0] != srid:
+                    msg = (
+                        "The CRS of the target table (EPSG:{epsg_t}) differs from the "
+                        "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
+                            epsg_t=target_srid[0], epsg_src=srid
+                        )
+                    )
+                    raise ValueError(msg)
+            else:
+                # Table doesn't exist
+                if geom_name not in dtype:
+                    # Use Geometry by default
+                    dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
+    else:
+        # We don't care if table exists for "replace" or "fail" `if_exists` values
+        if geom_name not in dtype:
+            # Use Geometry by default
             dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
 
     with _get_conn(con) as connection:

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -758,6 +758,10 @@ class TestIO:
 
         for column in df_geog.columns:
             if column != df_geog.geometry.name:
-                assert all(df_geog.loc[:, column].values == df_geog_read.loc[:, column].values)
+                assert all(
+                    df_geog.loc[:, column].values == df_geog_read.loc[:, column].values
+                )
         for attr in ["x", "y"]:
-            assert all(getattr(df_geog.geometry, attr) == getattr(df_geog_read.geometry, attr))
+            assert all(
+                getattr(df_geog.geometry, attr) == getattr(df_geog_read.geometry, attr)
+            )

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -6,9 +6,10 @@ see geopandas.tests.util for more information.
 """
 import os
 
-import geopandas
 import pandas as pd
 import pytest
+
+import geopandas
 
 from geopandas import GeoDataFrame, read_file, read_postgis
 from geopandas.io.sql import _get_conn as get_conn

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -11,8 +11,8 @@ import pytest
 
 import geopandas
 from geopandas import GeoDataFrame, read_file, read_postgis
-from geopandas.io.sql import _get_conn as get_conn
 from geopandas.io.sql import (
+    _get_conn as get_conn,
     _get_srid_and_geom_from_postgis as get_srid_and_geom_from_postgis,
     _get_srid_from_crs as get_srid_from_crs,
     _write_postgis as write_postgis,

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -823,7 +823,7 @@ class TestIO:
                 f"id INTEGER PRIMARY KEY, "
                 f"name VARCHAR, "
                 f"size INTEGER, "
-                f"geog GEOMETRY(POINT,4326), "
+                f"geog GEOGRAPHY(POINT,4326), "
                 f")"
             ),
             table_name=table_name,

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -742,8 +742,6 @@ class TestIO:
         """
         Tests writing to an existing PostGIS table with Geography column.
         """
-        import numpy as np
-
         table_name = create_postgis_geography_table
         write_postgis(
             df_geog,

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -724,7 +724,7 @@ class TestIO:
         """
         with pytest.raises(
             ValueError,
-            match="Cannot find Geometry of Geography column",
+            match="Cannot find Geometry or Geography column",
         ):
             write_postgis(
                 df_nybb.rename_geometry("_wrong_column_name_"),
@@ -760,12 +760,6 @@ class TestIO:
 
         for column in df_geog.columns:
             if column != df_geog.geometry.name:
-                assert np.allclose(
-                    df_geog.loc[:, column].values,
-                    df_geog_read.loc[:, column].values,
-                )
+                assert all(df_geog.loc[:, column].values == df_geog_read.loc[:, column].values)
         for attr in ["x", "y"]:
-            assert np.allclose(
-                getattr(df_geog.geometry, attr),
-                getattr(df_geog_read.geometry, attr),
-            )
+            assert all(getattr(df_geog.geometry, attr) == getattr(df_geog_read.geometry, attr))

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -823,7 +823,7 @@ class TestIO:
                 f"id INTEGER PRIMARY KEY, "
                 f"name VARCHAR, "
                 f"size INTEGER, "
-                f"geog GEOGRAPHY(POINT,4326), "
+                f"geog GEOGRAPHY(POINT,4326)"
                 f")"
             ),
             table_name=table_name,

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -780,7 +780,7 @@ class TestIO:
                 f"id INTEGER PRIMARY KEY, "
                 f"name VARCHAR, "
                 f"size INTEGER, "
-                f"{column_name} {gtype.upper()}(POINT,{srid:d}), "
+                f"{column_name} {gtype.upper()}(POINT,{srid:d})"
                 f")"
             ),
             table_name=table_name,

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -759,8 +759,15 @@ class TestIO:
             sql=f"SELECT * FROM {table_name}",
             con=engine_postgis,
             geom_col=df_geog.geometry.name,
-        )
+        ).astype(df_geog.dtypes)
 
-        assert df_geog.equals(df_geog_read)
+        # Sort both dataframes by "id" prior to comparison
+        df_geog = df_geog.sort_values(by="id", ascending=True)
+        df_geog_read = df_geog_read.sort_values(by="id", ascending=True)
+
+        # Compare geometries
         assert df_geog.crs.equals(df_geog_read.crs)
-        assert df_geog.geom_equals(df_geog_read)
+        assert all(df_geog.geom_equals(df_geog_read))
+
+        # Compare values
+        assert df_geog.equals(df_geog_read)

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -196,6 +196,7 @@ def df_geog():
 
     return GeoDataFrame(
         data={
+            "id": [1, 2],
             "name": ["bar", "baz"],
             "size": [12, 7],
         },
@@ -215,7 +216,7 @@ def create_postgis_geography_table(engine_postgis):
         connection.execute(
             f"CREATE TABLE {table_name} "
             f"("
-            f"id SERIAL PRIMARY KEY, "
+            f"id INTEGER PRIMARY KEY, "
             f"name VARCHAR, "
             f"size INTEGER, "
             f"geog GEOGRAPHY(POINT,4326)"


### PR DESCRIPTION
The `to_postgis` function was changed to support Geography PostGIS column type as follows:

- It now respects dtype for geometry column provided by user
- It now infers column type (Geography/Geometry) from the PostGIS database and assigns appropriate dtype if dtype wasn't provided (default)