### PR TITLE
Fix GeoDataFrame.pivot failing

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -126,16 +126,23 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                     "GeoDataFrame does not support multiple columns "
                     "using the geometry column name 'geometry'."
                 )
-            elif (
-                isinstance(self.columns, MultiIndex)
-                and (self.columns.get_level_values(0) == "geometry").sum() > 1
-            ):
-                raise ValueError(
-                    "GeoDataFrame does not support inferring geometry column name "
-                    "with MultiIndex columns containing more than one level 0 "
-                    "entry using the geometry column name 'geometry'. Please "
-                    "provide the geometry column name explicitly."
+            elif isinstance(self.columns, MultiIndex):
+                # TODO Perhaps this shouldn't even warn.
+                #  Behaviour should be the same as if "geometry" not in self.columns
+                # Note this introduces warnings into e.g. df.pivot
+
+                # MultiIndex case is prevented to stop recursion errors / crashes
+                # arising from self["geometry"] returning GeoDataFrames/ not returning
+                # a GeoSeries
+                warnings.warn(
+                    "GeoDataFrame does not support inferring geometry column "
+                    "name with MultiIndex columns, and must now be set explicitly "
+                    "with 'set_geometry'.\nTo solve this directly, provide the "
+                    "geometry column name explicitly in GeoDataFrame constructor.",
+                    UserWarning,
+                    stacklevel=2,
                 )
+                return
 
             # only if we have actual geometry values -> call set_geometry
             index = self.index

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, MultiIndex
 from pandas.core.accessor import CachedAccessor
 
 from shapely.geometry import mapping, shape
@@ -125,6 +125,16 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 raise ValueError(
                     "GeoDataFrame does not support multiple columns "
                     "using the geometry column name 'geometry'."
+                )
+            elif (
+                isinstance(self.columns, MultiIndex)
+                and (self.columns.get_level_values(0) == "geometry").sum() > 1
+            ):
+                raise ValueError(
+                    "GeoDataFrame does not support inferring geometry column name "
+                    "with MultiIndex columns containing more than one level 0 "
+                    "entry using the geometry column name 'geometry'. Please "
+                    "provide the geometry column name explicitly."
                 )
 
             # only if we have actual geometry values -> call set_geometry

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1034,14 +1034,20 @@ class TestConstructor:
         with pytest.raises(ValueError):
             GeoDataFrame(df3, geometry="geom")
 
-    # TODO what if the fuzzy match is unique (e.g. (geometry, ""))?
+    # TODO what if the MultiIndex.get_loc match is unique e.g.
+    #   [("geometry", "foo"), ("spam", "bar")]) or
+    #   [("geometry", ""), ("spam", "bar")])
     @pytest.mark.parametrize(
         "columns",
         [
             [("geometry", "foo"), ("geometry", "bar")],
             [("foo", "geometry"), ("geometry", "bar")],
             [("geometry", "foo"), ("bar", "geometry")],
-            [("foo", "geometry"), ("bar", "geometry")],
+            # case where geometry not in first level means
+            # "geometry" in gdf.columns is False, so there is no ambiguity,
+            # behaviour is the same as if no geometry supplied and
+            # "geometry" not in gdf.columns for list like columns
+            # [("foo", "geometry"), ("bar", "geometry")],
         ],
     )
     def test_repeat_geo_col_multiindex(self, columns):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1036,10 +1036,7 @@ class TestConstructor:
 
     def test_repeat_geo_col_multiindex(self):
         df = pd.DataFrame(
-            [
-                {"geometry": Point(x, y), "geom": Point(x, y)}
-                for x, y in zip(range(3), range(3))
-            ],
+            [{"geometry": Point(x, y), "col1": x} for x, y in zip(range(3), range(3))],
         )
         # cannot have two level zero columns containing geometry
         df.columns = pd.MultiIndex.from_tuples(
@@ -1065,7 +1062,15 @@ class TestConstructor:
         # result is an invalid geodataframe because geometry can't be inferred
         assert gdf._geometry_column_name == "geometry"
 
-        # duplicate geometry in a mix of levels is fine
+        # duplicate geometry in a mix of levels is fine - with geom
+        df.columns = pd.MultiIndex.from_tuples(
+            [("geometry", "foo"), ("bar", "geometry")]
+        )
+        gdf = GeoDataFrame(df)
+        # result is an invalid geodataframe because geometry can't be inferred
+        assert gdf._geometry_column_name == "geometry"
+
+        # duplicate geometry in a mix of levels is fine - with non geom
         df.columns = pd.MultiIndex.from_tuples(
             [("geometry", "foo"), ("bar", "geometry")]
         )

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1056,12 +1056,13 @@ class TestConstructor:
         )
 
         df.columns = pd.MultiIndex.from_tuples(columns)
-        exception_msg = (
-            "GeoDataFrame does not support inferring geometry column name "
-            "with MultiIndex columns, and must be set with 'set_geometry'.\n"
-            "Please provide the geometry column name explicitly in constructor."
+        warning_msg = (
+            "GeoDataFrame does not support inferring geometry column "
+            "name with MultiIndex columns, and must now be set explicitly "
+            "with 'set_geometry'.\nTo solve this directly, provide the "
+            "geometry column name explicitly in GeoDataFrame constructor."
         )
-        with pytest.warns(UserWarning, match=exception_msg):
+        with pytest.warns(UserWarning, match=warning_msg):
             gdf = GeoDataFrame(df)
         # default value is used, which is most likely broken
         assert gdf._geometry_column_name == "geometry"

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1052,11 +1052,14 @@ class TestConstructor:
         df.columns = pd.MultiIndex.from_tuples(columns)
         exception_msg = (
             "GeoDataFrame does not support inferring geometry column name "
-            "with MultiIndex columns, so geometry column name has been set to None. "
+            "with MultiIndex columns, and must be set with 'set_geometry'.\n"
             "Please provide the geometry column name explicitly in constructor."
         )
         with pytest.warns(UserWarning, match=exception_msg):
-            GeoDataFrame(df)
+            gdf = GeoDataFrame(df)
+        # default value is used, which is most likely broken
+        assert gdf._geometry_column_name == "geometry"
+
         geo_col_name = df.columns[0]  # always the first col, regardless of name
 
         # If geometry is supplied explicitly there should be no issue

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -602,6 +602,10 @@ def test_preserve_flags(df):
         pd.concat([df, df])
 
 
+@pytest.mark.filterwarnings(
+    "ignore:GeoDataFrame does not support inferring "
+    "geometry column name with MultiIndex columns"
+)
 def test_pivot(df):
     # https://github.com/geopandas/geopandas/issues/2057
     # pivot failing due to creating a MultiIndex

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -600,3 +600,14 @@ def test_preserve_flags(df):
 
     with pytest.raises(ValueError):
         pd.concat([df, df])
+
+
+def test_pivot(df):
+    # https://github.com/geopandas/geopandas/issues/2057
+    # pivot failing due to creating a MultiIndex
+    expected = GeoDataFrame(pd.DataFrame(df.pivot(columns="value1")))
+    actual = df.pivot(columns="value1")
+    assert_geodataframe_equal(expected, actual)
+    # Note this not a useful gdf, ideally would return a DataFrame
+    # along the lines of GH2060 when implemented
+    assert actual._geometry_column_name == "geometry"


### PR DESCRIPTION
Edit: Marked draft because solution fixes the crash, but spams warnings, and that's not satisfactory really. I need to have another look at this. Also, this is related to #722 and #748.

Fixes #2057.

Could probably use some input on what the desired fix behaviour is. Currently this avoids the issues of multiple geometry columns by not setting the geometry column and warning, rather than raising. 

Originally I thought it should raise to be consistent with 
https://github.com/geopandas/geopandas/blob/4536b9203b0b2ff577d1368e4677ff93a4c82164/geopandas/geodataframe.py#L124-L128
for the non-multiindex case. But this would break `DataFrame.pivot` and perhaps other methods (although in a nicer, but still confusing way). 

I think the long term solution is for #2060 (or a follow up to it) to it to be done so that stuff like `pivot` will downcast and sidestep this issue (and not have a warning), and then the case of directly using the constructor should actually be an error?


