### PR TITLE
TST: skip tests of in overlay symmetric_difference under pandas 1.3.3

### DIFF
--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   # required
-  - pandas
+  - pandas=1.3.2  # temporary pin because 1.3.3 has regression for overlay (GH2101)
   - shapely
   - fiona
   - pyproj

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -361,6 +361,11 @@ def test_preserve_crs(dfs, how):
     result = overlay(df1, df2, how=how)
     assert result.crs == crs
 
+
+def test_crs_mismatch(dfs, how):
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     df1, df2 = dfs
     df1.crs = 4326
     df2.crs = 3857

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -53,6 +53,8 @@ def dfs_index(request, dfs):
     params=["union", "intersection", "difference", "symmetric_difference", "identity"]
 )
 def how(request):
+    if pandas_133 and request.param in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
     return request.param
 
 
@@ -67,9 +69,6 @@ def test_overlay(dfs_index, how):
     Results obtained using QGIS 2.16 (Vector -> Geoprocessing Tools ->
     Intersection / Union / ...), saved to GeoJSON
     """
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     df1, df2 = dfs_index
     result = overlay(df1, df2, how=how)
 
@@ -110,9 +109,6 @@ def test_overlay(dfs_index, how):
 
 @pytest.mark.filterwarnings("ignore:GeoSeries crs mismatch:UserWarning")
 def test_overlay_nybb(how):
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     polydf = read_file(geopandas.datasets.get_path("nybb"))
 
     # The circles have been constructed and saved at the time the expected
@@ -245,9 +241,6 @@ def test_overlay_overlap(how):
     (Vector -> Geoprocessing Tools -> Intersection / Union / ...),
     saved to GeoJSON.
     """
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     df1 = read_file(os.path.join(DATA, "overlap", "df1_overlap.geojson"))
     df2 = read_file(os.path.join(DATA, "overlap", "df2_overlap.geojson"))
 
@@ -280,9 +273,6 @@ def test_overlay_overlap(how):
 
 @pytest.mark.parametrize("other_geometry", [False, True])
 def test_geometry_not_named_geometry(dfs, how, other_geometry):
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     # Issue #306
     # Add points and flip names
     df1, df2 = dfs
@@ -334,9 +324,6 @@ def test_bad_how(dfs):
 
 
 def test_duplicate_column_name(dfs, how):
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     if how == "difference":
         pytest.skip("Difference uses columns from one df only.")
     df1, df2 = dfs
@@ -353,9 +340,6 @@ def test_geoseries_warning(dfs):
 
 
 def test_preserve_crs(dfs, how):
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     df1, df2 = dfs
     result = overlay(df1, df2, how=how)
     assert result.crs is None
@@ -367,9 +351,6 @@ def test_preserve_crs(dfs, how):
 
 
 def test_crs_mismatch(dfs, how):
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     df1, df2 = dfs
     df1.crs = 4326
     df2.crs = 3857
@@ -475,9 +456,6 @@ def test_overlay_strict(how, keep_geom_type, geom_types):
                     exp.to_file('poly_point_{p}_{s}.geojson'.format(p=p, s=s),
                                 driver='GeoJSON')
     """
-    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
-        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
-
     polys1 = GeoSeries(
         [
             Polygon([(1, 1), (3, 1), (3, 3), (1, 3)]),

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -334,10 +334,10 @@ def test_bad_how(dfs):
 
 
 @pytest.mark.xfail(pandas_133, reason="Regression in pandas 1.3.3 (GH #2101)")
-def test_duplicate_column_name(dfs):
+def test_duplicate_column_name(dfs, how):
     df1, df2 = dfs
     df2r = df2.rename(columns={"col2": "col1"})
-    res = overlay(df1, df2r, how="union")
+    res = overlay(df1, df2r, how=how)
     assert ("col1_1" in res.columns) and ("col1_2" in res.columns)
 
 

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -1,4 +1,5 @@
 import os
+from distutils.version import LooseVersion
 
 import pandas as pd
 
@@ -15,6 +16,7 @@ DATA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data", "overlay
 
 
 pytestmark = pytest.mark.skip_no_sindex
+pandas_133 = pd.__version__ == LooseVersion("1.3.3")
 
 
 @pytest.fixture
@@ -65,6 +67,9 @@ def test_overlay(dfs_index, how):
     Results obtained using QGIS 2.16 (Vector -> Geoprocessing Tools ->
     Intersection / Union / ...), saved to GeoJSON
     """
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     df1, df2 = dfs_index
     result = overlay(df1, df2, how=how)
 
@@ -105,6 +110,9 @@ def test_overlay(dfs_index, how):
 
 @pytest.mark.filterwarnings("ignore:GeoSeries crs mismatch:UserWarning")
 def test_overlay_nybb(how):
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     polydf = read_file(geopandas.datasets.get_path("nybb"))
 
     # The circles have been constructed and saved at the time the expected
@@ -237,6 +245,9 @@ def test_overlay_overlap(how):
     (Vector -> Geoprocessing Tools -> Intersection / Union / ...),
     saved to GeoJSON.
     """
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     df1 = read_file(os.path.join(DATA, "overlap", "df1_overlap.geojson"))
     df2 = read_file(os.path.join(DATA, "overlap", "df2_overlap.geojson"))
 
@@ -269,6 +280,9 @@ def test_overlay_overlap(how):
 
 @pytest.mark.parametrize("other_geometry", [False, True])
 def test_geometry_not_named_geometry(dfs, how, other_geometry):
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     # Issue #306
     # Add points and flip names
     df1, df2 = dfs
@@ -319,6 +333,7 @@ def test_bad_how(dfs):
         overlay(df1, df2, how="spandex")
 
 
+@pytest.mark.xfail(pandas_133, reason="Regression in pandas 1.3.3 (GH #2101)")
 def test_duplicate_column_name(dfs):
     df1, df2 = dfs
     df2r = df2.rename(columns={"col2": "col1"})
@@ -334,6 +349,9 @@ def test_geoseries_warning(dfs):
 
 
 def test_preserve_crs(dfs, how):
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     df1, df2 = dfs
     result = overlay(df1, df2, how=how)
     assert result.crs is None
@@ -343,8 +361,6 @@ def test_preserve_crs(dfs, how):
     result = overlay(df1, df2, how=how)
     assert result.crs == crs
 
-
-def test_crs_mismatch(dfs, how):
     df1, df2 = dfs
     df1.crs = 4326
     df2.crs = 3857
@@ -450,6 +466,9 @@ def test_overlay_strict(how, keep_geom_type, geom_types):
                     exp.to_file('poly_point_{p}_{s}.geojson'.format(p=p, s=s),
                                 driver='GeoJSON')
     """
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
     polys1 = GeoSeries(
         [
             Polygon([(1, 1), (3, 1), (3, 3), (1, 3)]),

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -333,8 +333,12 @@ def test_bad_how(dfs):
         overlay(df1, df2, how="spandex")
 
 
-@pytest.mark.xfail(pandas_133, reason="Regression in pandas 1.3.3 (GH #2101)")
 def test_duplicate_column_name(dfs, how):
+    if pandas_133 and how in ["symmetric_difference", "identity", "union"]:
+        pytest.xfail("Regression in pandas 1.3.3 (GH #2101)")
+
+    if how == "difference":
+        pytest.skip("Difference uses columns from one df only.")
     df1, df2 = dfs
     df2r = df2.rename(columns={"col2": "col1"})
     res = overlay(df1, df2r, how=how)

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -179,7 +179,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     >>> df1 = geopandas.GeoDataFrame({'geometry': polys1, 'df1_data':[1,2]})
     >>> df2 = geopandas.GeoDataFrame({'geometry': polys2, 'df2_data':[1,2]})
 
-    >>> geopandas.overlay(df1, df2, how='union') # doctest: +SKIP
+    >>> geopandas.overlay(df1, df2, how='union')
        df1_data  df2_data                                           geometry
     0       1.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 1.00000, 1....
     1       2.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....
@@ -195,7 +195,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     1         2         1  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....
     2         2         2  POLYGON ((4.00000 4.00000, 4.00000 3.00000, 3....
 
-    >>> geopandas.overlay(df1, df2, how='symmetric_difference') # doctest: +SKIP
+    >>> geopandas.overlay(df1, df2, how='symmetric_difference')
        df1_data  df2_data                                           geometry
     0       1.0       NaN  POLYGON ((2.00000 0.00000, 0.00000 0.00000, 0....
     1       2.0       NaN  MULTIPOLYGON (((4.00000 3.00000, 4.00000 2.000...
@@ -207,7 +207,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     0  POLYGON ((2.00000 0.00000, 0.00000 0.00000, 0....         1
     1  MULTIPOLYGON (((3.00000 3.00000, 4.00000 3.000...         2
 
-    >>> geopandas.overlay(df1, df2, how='identity') # doctest: +SKIP
+    >>> geopandas.overlay(df1, df2, how='identity')
        df1_data  df2_data                                           geometry
     0       1.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 1.00000, 1....
     1       2.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -179,7 +179,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     >>> df1 = geopandas.GeoDataFrame({'geometry': polys1, 'df1_data':[1,2]})
     >>> df2 = geopandas.GeoDataFrame({'geometry': polys2, 'df2_data':[1,2]})
 
-    >>> geopandas.overlay(df1, df2, how='union')
+    >>> geopandas.overlay(df1, df2, how='union') # doctest: +SKIP
        df1_data  df2_data                                           geometry
     0       1.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 1.00000, 1....
     1       2.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....
@@ -195,7 +195,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     1         2         1  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....
     2         2         2  POLYGON ((4.00000 4.00000, 4.00000 3.00000, 3....
 
-    >>> geopandas.overlay(df1, df2, how='symmetric_difference')
+    >>> geopandas.overlay(df1, df2, how='symmetric_difference') # doctest: +SKIP
        df1_data  df2_data                                           geometry
     0       1.0       NaN  POLYGON ((2.00000 0.00000, 0.00000 0.00000, 0....
     1       2.0       NaN  MULTIPOLYGON (((4.00000 3.00000, 4.00000 2.000...
@@ -207,7 +207,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     0  POLYGON ((2.00000 0.00000, 0.00000 0.00000, 0....         1
     1  MULTIPOLYGON (((3.00000 3.00000, 4.00000 3.000...         2
 
-    >>> geopandas.overlay(df1, df2, how='identity')
+    >>> geopandas.overlay(df1, df2, how='identity') # doctest: +SKIP
        df1_data  df2_data                                           geometry
     0       1.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 1.00000, 1....
     1       2.0       1.0  POLYGON ((2.00000 2.00000, 2.00000 3.00000, 3....

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -108,11 +108,12 @@ def _overlay_symmetric_diff(df1, df2):
     _ensure_geometry_column(dfdiff1)
     _ensure_geometry_column(dfdiff2)
     # combine both 'difference' dataframes
-    dfsym = pd.concat([dfdiff1, dfdiff2])
-    cols = dfsym.columns.tolist()
-    cols.remove(df1.geometry.name)
-    cols.append(df1.geometry.name)
-    dfsym = dfsym[cols].reset_index(drop=True)
+    dfsym = pd.concat([dfdiff1, dfdiff2], ignore_index=True)
+    # keep geometry column last
+    columns = list(dfsym.columns)
+    columns.remove("geometry")
+    columns = columns + ["geometry"]
+    dfsym = dfsym[columns]
     return dfsym
 
 

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -108,7 +108,7 @@ def _overlay_symmetric_diff(df1, df2):
     _ensure_geometry_column(dfdiff1)
     _ensure_geometry_column(dfdiff2)
     # combine both 'difference' dataframes
-    dfsym = pd.concat([dfdiff1, dfdiff2], ignore_index=True)
+    dfsym = pd.concat([dfdiff1, dfdiff2], ignore_index=True, sort=False)
     # keep geometry column last
     columns = list(dfsym.columns)
     columns.remove("geometry")

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -108,12 +108,18 @@ def _overlay_symmetric_diff(df1, df2):
     _ensure_geometry_column(dfdiff1)
     _ensure_geometry_column(dfdiff2)
     # combine both 'difference' dataframes
-    dfsym = pd.concat([dfdiff1, dfdiff2], ignore_index=True, sort=False)
-    # keep geometry column last
-    columns = list(dfsym.columns)
-    columns.remove("geometry")
-    columns = columns + ["geometry"]
-    dfsym = dfsym[columns]
+    dfsym = dfdiff1.merge(
+        dfdiff2, on=["__idx1", "__idx2"], how="outer", suffixes=("_1", "_2")
+    )
+    geometry = dfsym.geometry_1.copy()
+    geometry.name = "geometry"
+    # https://github.com/pandas-dev/pandas/issues/26468 use loc for now
+    geometry.loc[dfsym.geometry_1.isnull()] = dfsym.loc[
+        dfsym.geometry_1.isnull(), "geometry_2"
+    ]
+    dfsym.drop(["geometry_1", "geometry_2"], axis=1, inplace=True)
+    dfsym.reset_index(drop=True, inplace=True)
+    dfsym = GeoDataFrame(dfsym, geometry=geometry, crs=df1.crs)
     return dfsym
 
 

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -108,18 +108,11 @@ def _overlay_symmetric_diff(df1, df2):
     _ensure_geometry_column(dfdiff1)
     _ensure_geometry_column(dfdiff2)
     # combine both 'difference' dataframes
-    dfsym = dfdiff1.merge(
-        dfdiff2, on=["__idx1", "__idx2"], how="outer", suffixes=("_1", "_2")
-    )
-    geometry = dfsym.geometry_1.copy()
-    geometry.name = "geometry"
-    # https://github.com/pandas-dev/pandas/issues/26468 use loc for now
-    geometry.loc[dfsym.geometry_1.isnull()] = dfsym.loc[
-        dfsym.geometry_1.isnull(), "geometry_2"
-    ]
-    dfsym.drop(["geometry_1", "geometry_2"], axis=1, inplace=True)
-    dfsym.reset_index(drop=True, inplace=True)
-    dfsym = GeoDataFrame(dfsym, geometry=geometry, crs=df1.crs)
+    dfsym = pd.concat([dfdiff1, dfdiff2])
+    cols = dfsym.columns.tolist()
+    cols.remove(df1.geometry.name)
+    cols.append(df1.geometry.name)
+    dfsym = dfsym[cols].reset_index(drop=True)
     return dfsym
 
 

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -1,8 +1,10 @@
 """Tests for the clip module."""
 
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
+import pandas as pd
 
 import shapely
 from shapely.geometry import Polygon, Point, LineString, LinearRing, GeometryCollection
@@ -15,6 +17,7 @@ import pytest
 
 
 pytestmark = pytest.mark.skip_no_sindex
+pandas_133 = pd.__version__ == LooseVersion("1.3.3")
 
 
 @pytest.fixture
@@ -239,6 +242,7 @@ def test_clip_poly_series(buffered_locations, single_rectangle_gdf):
     assert all(clipped_poly.geom_type == "Polygon")
 
 
+@pytest.mark.xfail(pandas_133, reason="Regression in pandas 1.3.3 (GH #2101)")
 def test_clip_multipoly_keep_slivers(multi_poly_gdf, single_rectangle_gdf):
     """Test a multi poly object where the return includes a sliver.
     Also the bounds of the object should == the bounds of the clip object
@@ -249,6 +253,7 @@ def test_clip_multipoly_keep_slivers(multi_poly_gdf, single_rectangle_gdf):
     assert "GeometryCollection" in clipped.geom_type[0]
 
 
+@pytest.mark.xfail(pandas_133, reason="Regression in pandas 1.3.3 (GH #2101)")
 def test_clip_multipoly_keep_geom_type(multi_poly_gdf, single_rectangle_gdf):
     """Test a multi poly object where the return includes a sliver.
     Also the bounds of the object should == the bounds of the clip object


### PR DESCRIPTION
overlay based on symmetric_difference started [failing](https://github.com/geopandas/geopandas/runs/3515474201?check_suite_focus=true) on pandas master because we used an outer join based on columns full of NaNs. Refactoring the implementation to avoid it.

