### PR TITLE
PERF: MultiIndex creation in explode

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -812,13 +812,15 @@ class GeoSeries(GeoPandasBase, Series):
             # extract original index values based on integer index
             outer_index = self.index.take(outer_idx)
 
-            index = zip(outer_index, inner_index)
+            index_arrays = []
+            for lvl in range(outer_index.nlevels):
+                index_arrays.append(outer_index.get_level_values(lvl).values)
 
-            # if self.index is a MultiIndex then index is a list of nested tuples
-            if isinstance(self.index, MultiIndex):
-                index = [tuple(outer) + (inner,) for outer, inner in index]
+            index_arrays.append(inner_index)
+            index = MultiIndex.from_arrays(
+                index_arrays, names=self.index.names + [None]
+            )
 
-            index = MultiIndex.from_tuples(index, names=self.index.names + [None])
             return GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
         # else PyGEOS is not available or version <= 0.8

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -812,15 +812,13 @@ class GeoSeries(GeoPandasBase, Series):
             # extract original index values based on integer index
             outer_index = self.index.take(outer_idx)
 
-            index_arrays = []
-            for lvl in range(outer_index.nlevels):
-                index_arrays.append(outer_index.get_level_values(lvl).values)
-
+            nlevels = outer_index.nlevels
+            index_arrays = [outer_index.get_level_values(lvl) for lvl in range(nlevels)]
             index_arrays.append(inner_index)
+
             index = MultiIndex.from_arrays(
                 index_arrays, names=self.index.names + [None]
             )
-
             return GeoSeries(geometries, index=index, crs=self.crs).__finalize__(self)
 
         # else PyGEOS is not available or version <= 0.8


### PR DESCRIPTION
fixes #2109 

With the following setup:
```python
import numpy as np
import pandas as pd
import geopandas as gpd

outer_index = (1, 2)
nr_pts = 10000
index = pd.MultiIndex.from_arrays(
    [[outer_index] * nr_pts, np.arange(nr_pts)],
    names=("first", "second"),
)
df = gpd.GeoDataFrame(
    {"vals": np.arange(nr_pts)},
    geometry=[MultiPoint([(x, x), (x, 0)]) for x in range(nr_pts)],
    index=index,
)
```

, timing `test_df = df.explode()` I get:
`master`: `62.3 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
`explode-perf`: `51.4 ms ± 1.47 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
