### PR TITLE
Allow AttributeError during fiona import

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -8,20 +8,22 @@ import pyproj
 from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry
 
+IMPORT_ERRORS = (ImportError, AttributeError)
+
 try:
     import fiona
 
     fiona_import_error = None
-except ImportError as err:
+except IMPORT_ERRORS as err:
     fiona = None
     fiona_import_error = str(err)
 
 try:
     from fiona import Env as fiona_env
-except ImportError:
+except IMPORT_ERRORS:
     try:
         from fiona import drivers as fiona_env
-    except ImportError:
+    except IMPORT_ERRORS:
         fiona_env = None
 
 from geopandas import GeoDataFrame, GeoSeries

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,5 +1,14 @@
 from distutils.version import LooseVersion
 
+# Adapted from pandas.io.common
+from urllib.request import urlopen as _urlopen
+from urllib.parse import (
+    urlparse as parse_url,
+    uses_netloc,
+    uses_params,
+    uses_relative,
+)
+
 import warnings
 import numpy as np
 import pandas as pd
@@ -26,13 +35,7 @@ except IMPORT_ERRORS:
     except IMPORT_ERRORS:
         fiona_env = None
 
-from geopandas import GeoDataFrame, GeoSeries
-
-
-# Adapted from pandas.io.common
-from urllib.request import urlopen as _urlopen
-from urllib.parse import urlparse as parse_url
-from urllib.parse import uses_netloc, uses_params, uses_relative
+from geopandas import GeoDataFrame, GeoSeries  # noqa E402
 
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)


### PR DESCRIPTION
The following issue happens, periodically but inconsistently, when geopandas gets imported in a module that contains a function that runs on a dask cluster, although in this case that function does not actually make use of geopandas.

<details><summary>AttributeError: partially initialized module 'fiona' has no attribute '_loading' (most likely due to a circular import)</summary>

```python
/home/conda/store/9c828ea9bf6dc65c4cd4f7331f255b67f76ac3534f6383157d0ce0ddc5bdb8e2/lib/python3.8/site-packages/distributed/protocol/pickle.py in loads()
     57 def loads(x):
     58     try:
---> 59         return pickle.loads(x)
     60     except Exception:
     61         logger.info("Failed to deserialize %s", x[:10000], exc_info=True)

/root/.local/lib/python3.8/site-packages/mypkg/api/df.py in <module>

/home/conda/store/9c828ea9bf6dc65c4cd4f7331f255b67f76ac3534f6383157d0ce0ddc5bdb8e2/lib/python3.8/site-packages/geopandas/__init__.py in <module>
      5 from geopandas.array import points_from_xy  # noqa
      6 
----> 7 from geopandas.io.file import _read_file as read_file  # noqa
      8 from geopandas.io.arrow import _read_parquet as read_parquet  # noqa
      9 from geopandas.io.arrow import _read_feather as read_feather  # noqa

/home/conda/store/9c828ea9bf6dc65c4cd4f7331f255b67f76ac3534f6383157d0ce0ddc5bdb8e2/lib/python3.8/site-packages/geopandas/io/file.py in <module>
     10 
     11 try:
---> 12     import fiona
     13 
     14     fiona_import_error = None

/home/conda/store/9c828ea9bf6dc65c4cd4f7331f255b67f76ac3534f6383157d0ce0ddc5bdb8e2/lib/python3.8/site-packages/fiona/__init__.py in <module>
     83 
     84 import fiona._loading
---> 85 with fiona._loading.add_gdal_dll_directories():
     86     from fiona.collection import BytesCollection, Collection
     87     from fiona.drvsupport import supported_drivers

AttributeError: partially initialized module 'fiona' has no attribute '_loading' (most likely due to a circular import)

```

</details>

This seems like a harmless enough change, but feel free to close this PR if the change is undesirable.
