### PR TITLE
BUG: convert_dtypes() converts GeoDataFrame to DataFrame

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1663,7 +1663,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         """
         Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
 
-        Returns a GeoDataFrame always, as no conversions are applied to the
+        Always returns a GeoDataFrame as no conversions are applied to the
         geometry column.
 
         See the pandas.DataFrame.convert_dtypes docstring for more details.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1652,14 +1652,7 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         # do not return a GeoDataFrame
         return pd.DataFrame(df)
 
-    def convert_dtypes(
-        self,
-        infer_objects=True,
-        convert_string=True,
-        convert_integer=True,
-        convert_boolean=True,
-        convert_floating=True,
-    ):
+    def convert_dtypes(self, *args, **kwargs):
         """
         Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
 
@@ -1676,29 +1669,13 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         # Overridden to fix GH1870, that return type is not preserved always
         # (and where it was, geometry col was not)
 
-        kwargs = dict(
-            infer_objects=infer_objects,
-            convert_string=convert_string,
-            convert_integer=convert_integer,
-            convert_boolean=convert_boolean,
-            convert_floating=convert_floating,
-        )
-        print(compat.PANDAS_GE_10)
         if not compat.PANDAS_GE_10:
             raise NotImplementedError(
                 "GeoDataFrame.convert_dtypes requires pandas >= 1.0"
             )
-        if not compat.PANDAS_GE_11:
-            kwargs.pop("convert_floating")
-            if (
-                not convert_floating
-            ):  # If they passed a non-default convert_floating value
-                warnings.warn(
-                    "convert_floating kwarg is not supported for pandas < 1.1.0"
-                )
 
         return GeoDataFrame(
-            super().convert_dtypes(kwargs),
+            super().convert_dtypes(*args, **kwargs),
             geometry=self.geometry.name,
             crs=self.crs,
         )

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1673,16 +1673,32 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         GeoDataFrame
 
         """
-        # Overidden to fix GH1870, that return type is not preserved always
+        # Overridden to fix GH1870, that return type is not preserved always
         # (and where it was, geometry col was not)
+
+        kwargs = dict(
+            infer_objects=infer_objects,
+            convert_string=convert_string,
+            convert_integer=convert_integer,
+            convert_boolean=convert_boolean,
+            convert_floating=convert_floating,
+        )
+        print(compat.PANDAS_GE_10)
+        if not compat.PANDAS_GE_10:
+            raise NotImplementedError(
+                "GeoDataFrame.convert_dtypes requires pandas >= 1.0"
+            )
+        if not compat.PANDAS_GE_11:
+            kwargs.pop("convert_floating")
+            if (
+                not convert_floating
+            ):  # If they passed a non-default convert_floating value
+                warnings.warn(
+                    "convert_floating kwarg is not supported for pandas < 1.1.0"
+                )
+
         return GeoDataFrame(
-            super().convert_dtypes(
-                infer_objects,
-                convert_string,
-                convert_integer,
-                convert_boolean,
-                convert_floating,
-            ),
+            super().convert_dtypes(kwargs),
             geometry=self.geometry.name,
             crs=self.crs,
         )

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1652,6 +1652,41 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
         # do not return a GeoDataFrame
         return pd.DataFrame(df)
 
+    def convert_dtypes(
+        self,
+        infer_objects=True,
+        convert_string=True,
+        convert_integer=True,
+        convert_boolean=True,
+        convert_floating=True,
+    ):
+        """
+        Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
+
+        Returns a GeoDataFrame always, as no conversions are applied to the
+        geometry column.
+
+        See the pandas.DataFrame.convert_dtypes docstring for more details.
+
+        Returns
+        -------
+        GeoDataFrame
+
+        """
+        # Overidden to fix GH1870, that return type is not preserved always
+        # (and where it was, geometry col was not)
+        return GeoDataFrame(
+            super().convert_dtypes(
+                infer_objects,
+                convert_string,
+                convert_integer,
+                convert_boolean,
+                convert_floating,
+            ),
+            geometry=self.geometry.name,
+            crs=self.crs,
+        )
+
     def to_postgis(
         self,
         name,

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -267,23 +267,29 @@ def test_convert_dtypes(df):
 
     # Test geom first, geom_col=geometry (order is important in concat,
     #   used internally)
+    expected1 = GeoDataFrame(
+        pd.DataFrame(df).convert_dtypes(), crs=df.crs, geometry=df.geometry.name
+    )
     res1 = df.convert_dtypes()
     # Checking type and metadata are right
-    assert_geodataframe_equal(df, res1)
+    assert_geodataframe_equal(expected1, res1)
 
     # Test geom last, geom_col=geometry
     res2 = df[["value1", "value2", "geometry"]].convert_dtypes()
-    assert_geodataframe_equal(df[["value1", "value2", "geometry"]], res2)
+    assert_geodataframe_equal(expected1[["value1", "value2", "geometry"]], res2)
 
     # Test again with crs set and custom geom col name
     df2 = df.set_crs(epsg=4326).rename_geometry("points")
+    expected2 = GeoDataFrame(
+        pd.DataFrame(df2).convert_dtypes(), crs=df2.crs, geometry=df2.geometry.name
+    )
     res3 = df2.convert_dtypes()
     # Checking type and metadata are right
-    assert_geodataframe_equal(df2, res3)
+    assert_geodataframe_equal(expected2, res3)
 
     # Test geom last, geom_col=geometry
-    res4 = df2[["value1", "value2", "geometry"]].convert_dtypes()
-    assert_geodataframe_equal(df2[["value1", "value2", "geometry"]], res4)
+    res4 = df2[["value1", "value2", "points"]].convert_dtypes()
+    assert_geodataframe_equal(expected2[["value1", "value2", "points"]], res4)
 
 
 def test_to_csv(df):

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -262,19 +262,26 @@ def test_astype_invalid_geodataframe():
     assert res["a"].dtype == object
 
 
+@pytest.mark.xfail(
+    not compat.PANDAS_GE_10,
+    reason="Convert dtypes new in pandas 1.0",
+    raises=NotImplementedError,
+)
 def test_convert_dtypes(df):
     # https://github.com/geopandas/geopandas/issues/1870
 
-    # Test geom first, geom_col=geometry (order is important in concat,
-    #   used internally)
+    # Test geometry col is first col, first, geom_col_name=geometry
+    # (order is important in concat, used internally)
+    res1 = df.convert_dtypes()  # note res1 done first for pandas < 1 xfail check
+
     expected1 = GeoDataFrame(
         pd.DataFrame(df).convert_dtypes(), crs=df.crs, geometry=df.geometry.name
     )
-    res1 = df.convert_dtypes()
+
     # Checking type and metadata are right
     assert_geodataframe_equal(expected1, res1)
 
-    # Test geom last, geom_col=geometry
+    # Test geom last, geom_col_name=geometry
     res2 = df[["value1", "value2", "geometry"]].convert_dtypes()
     assert_geodataframe_equal(expected1[["value1", "value2", "geometry"]], res2)
 
@@ -284,7 +291,6 @@ def test_convert_dtypes(df):
         pd.DataFrame(df2).convert_dtypes(), crs=df2.crs, geometry=df2.geometry.name
     )
     res3 = df2.convert_dtypes()
-    # Checking type and metadata are right
     assert_geodataframe_equal(expected2, res3)
 
     # Test geom last, geom_col=geometry

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -262,6 +262,30 @@ def test_astype_invalid_geodataframe():
     assert res["a"].dtype == object
 
 
+def test_convert_dtypes(df):
+    # https://github.com/geopandas/geopandas/issues/1870
+
+    # Test geom first, geom_col=geometry (order is important in concat,
+    #   used internally)
+    res1 = df.convert_dtypes()
+    # Checking type and metadata are right
+    assert_geodataframe_equal(df, res1)
+
+    # Test geom last, geom_col=geometry
+    res2 = df[["value1", "value2", "geometry"]].convert_dtypes()
+    assert_geodataframe_equal(df[["value1", "value2", "geometry"]], res2)
+
+    # Test again with crs set and custom geom col name
+    df2 = df.set_crs(epsg=4326).rename_geometry("points")
+    res3 = df2.convert_dtypes()
+    # Checking type and metadata are right
+    assert_geodataframe_equal(df2, res3)
+
+    # Test geom last, geom_col=geometry
+    res4 = df2[["value1", "value2", "geometry"]].convert_dtypes()
+    assert_geodataframe_equal(df2[["value1", "value2", "geometry"]], res4)
+
+
 def test_to_csv(df):
 
     exp = (


### PR DESCRIPTION
Fixes #1870 

Decided to have another look at this - was actually trying to construct a simple case to report an issue to Pandas itself as discussed in the above thread. I'm actually not convinced it really is a bug in pandas (more on that below) and so this is a fix in geopandas.

It was pretty straightforward to overload convert_dtypes, and I've added tests for some obvious edge cases.

-----------------------------------------------------------------------

This is the example that makes me question whether this is really a bug in pandas / or perhaps whether this use case is supported by pandas:
```python
import pandas as pd

class SubclassedSeries(pd.Series):
    @property
    def _constructor(self):
        return SubclassedSeries

    @property
    def _constructor_expanddim(self):
        return SubclassedDataFrame


class SubclassedDataFrame(pd.DataFrame):
    @property
    def _constructor(self):
        return SubclassedDataFrame

    @property
    def _constructor_sliced(self):
        return SubclassedSeries


test_df = SubclassedSeries([1, 2]).to_frame(name='a')
test_df['b'] = pd.Series([3, 4])
print(type(test_df['b']))  # = <class '__main__.SubclassedSeries'>
# The type of 'b' is going to be consistently subclassed series
# Issue arises in geopandas because `_constructor_sliced` is not defined, and then getitem promotes
# series up to GeoSeries. Without doing this, I don't think a mix of series types in a df is possible?
```
In the example case of subclassing pandas (https://pandas.pydata.org/pandas-docs/stable/development/extending.html#subclassing-pandas-data-structures), this kind of problem won't occur, because all columns of the `SubclassedDataFrame` will be returned as `SubclassedSeries`.

I'm not sure if the pattern of mixed series dtypes (GeoSeries and Series) is used elsewhere, so didn't think it was worth raising on the pandas side.


