### PR TITLE
WIP: Use postgres search_path instead of assuming "public" schema when using geopandas.GeoDataFrame.to_postgis(schema=None)

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 import pandas as pd
 
 import shapely.wkb
+import sqlalchemy.exc
+import psycopg2.errors
 
 from geopandas import GeoDataFrame
 
@@ -306,9 +308,14 @@ def _psql_insert_copy(tbl, conn, keys, data_iter):
 
     dbapi_conn = conn.connection
     with dbapi_conn.cursor() as cur:
-        sql = 'COPY "{}"."{}" ({}) FROM STDIN WITH CSV'.format(
-            tbl.table.schema, tbl.table.name, columns
-        )
+        if tbl.table.schema is not None:
+            sql = 'COPY "{}"."{}" ({}) FROM STDIN WITH CSV'.format(
+                tbl.table.schema, tbl.table.name, columns
+            )
+        else:
+            sql = 'COPY "{}" ({}) FROM STDIN WITH CSV'.format(
+                tbl.table.name, columns
+            )
         cur.copy_expert(sql=sql, file=s_buf)
 
 
@@ -401,43 +408,82 @@ def _write_postgis(
     # Convert geometries to EWKB
     gdf = _convert_to_ewkb(gdf, geom_name, srid)
 
+    # It is possible that the search path have schemas which do not exist, or the user does not have write access
+    # We must then get the possible schemas as a list and then test them in order.
     if schema is not None:
-        schema_name = schema
+        schema_names = [schema]
     else:
-        schema_name = "public"
-
-    if if_exists == "append":
-        # Check that the geometry srid matches with the current GeoDataFrame
         with _get_conn(con) as connection:
-            # Only check SRID if table exists
-            if connection.dialect.has_table(connection, name, schema):
-                target_srid = connection.execute(
-                    "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
-                        schema=schema_name, table=name, geom_col=geom_name
-                    )
-                ).fetchone()[0]
+            schema_names = connection.execute("SHOW search_path;").fetchone()[0].split(",")
 
-                if target_srid != srid:
-                    msg = (
-                        "The CRS of the target table (EPSG:{epsg_t}) differs from the "
-                        "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
-                            epsg_t=target_srid, epsg_src=srid
+    found_schema = False
+    for schema_name in schema_names:
+
+        if if_exists == "append":
+            # Check that the geometry srid matches with the current GeoDataFrame
+            with _get_conn(con) as connection:
+                # Only check SRID if table exists
+                if connection.dialect.has_table(connection, name, schema):
+
+                    try:
+                        target_srid = connection.execute(
+                            "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
+                                schema=schema_name, table=name, geom_col=geom_name
+                            )
+                        ).fetchone()[0]
+                    except sqlalchemy.exc.InternalError as e:
+                        if "could not find the corresponding SRID" in e.args[0]:
+                            # Table does not exist in this schema
+                            continue
+                        raise e
+
+                    if target_srid != srid:
+                        msg = (
+                            "The CRS of the target table (EPSG:{epsg_t}) differs from the "
+                            "CRS of current GeoDataFrame (EPSG:{epsg_src}).".format(
+                                epsg_t=target_srid, epsg_src=srid
+                            )
                         )
-                    )
-                    raise ValueError(msg)
+                        raise ValueError(msg)
 
-    with _get_conn(con) as connection:
+        with _get_conn(con) as connection:
 
-        gdf.to_sql(
-            name,
-            connection,
-            schema=schema_name,
-            if_exists=if_exists,
-            index=index,
-            index_label=index_label,
-            chunksize=chunksize,
-            dtype=dtype,
-            method=_psql_insert_copy,
+            try:
+                gdf.to_sql(
+                    name,
+                    connection,
+                    schema=schema_name,
+                    if_exists=if_exists,
+                    index=index,
+                    index_label=index_label,
+                    chunksize=chunksize,
+                    dtype=dtype,
+                    method=_psql_insert_copy,
+                )
+            # This will still throw a ValueError if a table exists in the schema with the same name, and will not try
+            # any further schemas. This is native pandas behaviour.
+            except sqlalchemy.exc.ProgrammingError as e:
+                if "psycopg2.errors.InvalidSchemaName" in e.args[0]:
+                    # Schema does not exist
+                    continue
+                elif "psycopg2.errors.InsufficientPrivilege" in e.args[0]:
+                    # User does not have required privileges for this SCHEMA (happens when creating)
+                    continue
+                raise e
+            except psycopg2.errors.InsufficientPrivilege:
+                # User does not have required privileges for this TABLE (only happens when appending)
+                continue
+
+        found_schema = True
+        break
+
+    if not found_schema:
+        # If we made it here and found_schema is still false, then all attempts to write have failed
+        msg = (
+            "No suitable schema found in the connection role's search_path ('{}')".format(
+                "', ".join(schema_names)
+            )
         )
+        raise RuntimeError(msg)
 
     return

--- a/geopandas/tests/test_postgis_search_path.py
+++ b/geopandas/tests/test_postgis_search_path.py
@@ -1,0 +1,108 @@
+import sqlalchemy as sa
+import geopandas as gpd
+import pandas as pd
+
+def test_postgis_search_path():
+
+    """
+    Not a real test - feature WIP!
+    """
+
+    engine = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres")
+    engine.execute("DROP TABLE IF EXISTS public.pd_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.pd_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.pd_nonexistentschema_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.pd_restrictedschema_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS public.gpd_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.gpd_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.gpd_nonexistentschema_myschema_public;")
+    engine.execute("DROP TABLE IF EXISTS myschema.gpd_restrictedschema_myschema_public;")
+
+    engine_myschema_public = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres",
+                                              connect_args={'options': f'-csearch_path=myschema,public'},)
+    engine_nonexistentschema_myschema_public = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres",
+                                                                connect_args={'options': f'-csearch_path=nonexistentschema,myschema,public'},)
+    engine_restrictedschema_myschema_public = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres",
+                                                                connect_args={'options': f'-csearch_path=restrictedschema,myschema,public'},)
+    engine_nonexistentschema = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres",
+                                                connect_args={'options': f'-csearch_path=nonexistentschema'},)
+    engine_restrictedschema = sa.create_engine("postgresql://myuser:myuser@localhost:5432/postgres",
+                                               connect_args={'options': f'-csearch_path=restrictedschema'},)
+
+    # Pandas
+    print("Testing pandas...")
+    df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
+
+    # Create new table with custom-configured search_path and no explicit schema passed to .to_sql()
+    #   -> Should create table in myschema
+    print("Writing to myschema directly...")
+    df.to_sql("pd_myschema_public", engine_myschema_public, schema=None)
+    print("...Done")
+
+    # Create new table with custom-configured search_path, but the first schema does not exist
+    #   -> Should bypass nonexistentschema (because it doesn't exist) and create table in myschema
+    print("Writing to myschema indirectly, bypassing nonexistent schema...")
+    df.to_sql("pd_nonexistentschema_myschema_public", engine_nonexistentschema_myschema_public, schema=None)
+    print("...Done")
+
+    # Create new table with custom-configured search_path, but the first schema is restricted
+    #   -> Should bypass restrictedschema (due to insufficient priveleges) and create table in myschema
+    print("Writing to myschema indirectly, bypassing restricted schema...")
+    df.to_sql("pd_restrictedschema_myschema_public", engine_restrictedschema_myschema_public, schema=None)
+    print("...Done")
+
+    # Write to existing table, where the same table exists in two schemas already
+    df.to_sql("pd_myschema_public", engine_myschema_public, schema="public")
+    # Try to append without specifying schema
+    #   -> Should append to the one in myschema
+    df.to_sql("pd_myschema_public", engine_myschema_public, schema=None, if_exists="append")
+
+
+    # Geopandas
+    print("Testing geopandas...")
+    gdf = gpd.GeoDataFrame.from_file(gpd.datasets.get_path("naturalearth_lowres"))
+
+    # Create new table with custom-configured search_path and no explicit schema passed to .to_postgis()
+    #   -> Should create table in myschema
+    print("Writing to myschema directly...")
+    gdf.to_postgis("gpd_myschema_public", engine_myschema_public, schema=None)
+    print("...Done")
+
+    # Create new table with custom-configured search_path, but the first schema does not exist
+    #   -> Should bypass nonexistentschema (because it doesn't exist) and create table in myschema
+    print("Writing to myschema indirectly, bypassing nonexistent schema...")
+    gdf.to_postgis("gpd_nonexistentschema_myschema_public", engine_nonexistentschema_myschema_public, schema=None)
+    print("...Done")
+
+    # Create new table with custom-configured search_path, but the first schema is restricted
+    #   -> Should bypass restrictedschema (due to insufficient priveleges) and create table in myschema
+    print("Writing to myschema indirectly, bypassing restricted schema...")
+    gdf.to_postgis("gpd_restrictedschema_myschema_public", engine_restrictedschema_myschema_public, schema=None)
+    print("...Done")
+
+    # Write to existing table, where the same table exists in two schemas already
+    print("Writing to table which exists in two schemas...")
+    gdf.to_postgis("gpd_myschema_public", engine_myschema_public, schema="public")
+    # Try to append without specifying schema
+    #   -> Should append to the one in myschema
+    gdf.to_postgis("gpd_myschema_public", engine_myschema_public, schema=None, if_exists="append")
+    print("...Done")
+
+
+    # Impossible situations
+
+    # Try to create a table with a schema containing only an non-existent schema
+    try:
+        gdf.to_postgis("gpd_nonexistentschema", engine_nonexistentschema, schema=None)
+    except RuntimeError as e:
+        print("Failed with exception:")
+        print(e.args[0])
+
+    # Try to create a table with a schema containing only an non-existent schema
+    try:
+        gdf.to_postgis("gpd_restrictedschema", engine_restrictedschema, schema=None)
+    except RuntimeError as e:
+        print("Failed with exception:")
+        print(e.args[0])
+
+    assert True


### PR DESCRIPTION
This PR is WIP.

Basically, the problem is that geopandas assumes that `public` should be the default schema if the `schema` parameter is omitted or set to `None` in `geopandas.GeoDataFrame.to_postgis()`. This is missing a common misconception about postgres in general - The `public` schema is not necessarily the "default schema", but rather the "default schema configured by default". This can be changed via a `search_path`, which can be set at user or session level. So if you set the search_path at the SQLAlchemy level, Geopandas incorrectly assumes that `public` is where the data should be written to unless explicitly stated. It should use the `search_path` as per the connection.

I should have done this before, but I went back and made sure that this intended behaviour is also present in pandas. It is. Pandas respects the `search_path` at connection level and does not ever appear to assume `public` to be the default schema.

This ended up being a bit tricky, because the `search_path` can actually be set inconveniently or even nonsensically, with schemas included which are non-writeable (for the current role), or even non-existent. So it has to try each one in order until it works. And it can fail for different reasons, including:

* Schema does not exist
* Schema exists, but is not writeable for the current role

So I used exception handling to move along the `search_path` entries, until it breaks off upon finding a valid schema. If nothing works, it raises a `RunfimeError` indicating that the current `search_path` doesn't allow the table to be written anywhere.

I did not figure out how the PostGIS tests work, they look kind of tricky. So for now everything is just in a single "test" which just asserts True. I will work on making proper tests, but I think that the main meat of the changes to `geopandas/io/sql.py` are fixed.