### PR TITLE
PERF: Add new overlay benchmarks

### DIFF
--- a/benchmarks/overlay.py
+++ b/benchmarks/overlay.py
@@ -1,10 +1,11 @@
 from geopandas import GeoDataFrame, GeoSeries, read_file, datasets, overlay
-from shapely.geometry import Polygon
+import numpy as np
+from shapely.geometry import Point, Polygon
 
 
 class Countries:
 
-    param_names = ['op']
+    param_names = ['how']
     params = [('intersection', 'union', 'identity', 'symmetric_difference',
                'difference')]
 
@@ -20,13 +21,13 @@ class Countries:
         self.countries = countries
         self.capitals = capitals
 
-    def time_overlay(self, op):
-        overlay(self.countries, self.capitals, how=op)
+    def time_overlay(self, how):
+        overlay(self.countries, self.capitals, how=how)
 
 
 class Small:
 
-    param_names = ['op']
+    param_names = ['how']
     params = [('intersection', 'union', 'identity', 'symmetric_difference',
                'difference')]
 
@@ -41,5 +42,24 @@ class Small:
 
         self.df1, self.df2 = df1, df2
 
-    def time_overlay(self, op):
-        overlay(self.df1, self.df2, how=op)
+    def time_overlay(self, how):
+        overlay(self.df1, self.df2, how=how)
+
+
+class ManyPoints:
+
+    param_names = ['how']
+    params = [('intersection', 'union', 'identity', 'symmetric_difference',
+               'difference')]
+
+    def setup(self, *args):
+
+        points = GeoDataFrame(geometry=[Point(i, i) for i in range(1000)])
+        base = np.array([[0, 0], [0, 100], [100, 100], [100, 0]])
+        polys = GeoDataFrame(
+            geometry=[Polygon(base + i * 100) for i in range(10)])
+
+        self.df1, self.df2 = points, polys
+
+    def time_overlay(self, how):
+        overlay(self.df1, self.df2, how=how)


### PR DESCRIPTION
Motivated by the pretty serious performance regression on overlays
I accidentally introduced in #1582, and reported in #2089, here's a new
benchmark for overlays that makes the regression more apparent than the
existing overlay benchmarks.

On master:
```
[  0.07%] ··· overlay.Countries.time_overlay                                                                        3/5 failed
[  0.07%] ··· ====================== ===========
                       how                      
              ---------------------- -----------
                   intersection        337±6ms  
                      union             failed  
                     identity           failed  
               symmetric_difference     failed  
                    difference        143±0.8ms 
              ====================== ===========

[  0.09%] ··· overlay.ManyPoints.time_overlay                                                                               ok
[  0.09%] ··· ====================== ===========
                       how                      
              ---------------------- -----------
                   intersection        299±4ms  
                      union            510±8ms  
                     identity          524±7ms  
               symmetric_difference   229±0.3ms 
                    difference        177±0.7ms 
              ====================== ===========

[  0.11%] ··· overlay.Small.time_overlay                                                                            3/5 failed
[  0.11%] ··· ====================== =============
                       how                        
              ---------------------- -------------
                   intersection       14.6±0.07ms 
                      union              failed   
                     identity            failed   
               symmetric_difference      failed   
                    difference        5.20±0.09ms 
              ====================== =============
```

On #2103:
```
[ 22.22%] ··· overlay.Countries.time_overlay                                                                        3/5 failed
[ 22.22%] ··· ====================== ===========
                       how                      
              ---------------------- -----------
                   intersection        78.9±1ms 
                      union             failed  
                     identity           failed  
               symmetric_difference     failed  
                    difference        141±0.7ms 
              ====================== ===========

[ 27.78%] ··· overlay.ManyPoints.time_overlay                                                                               ok
[ 27.78%] ··· ====================== =============
                       how                        
              ---------------------- -------------
                   intersection       9.57±0.01ms 
                      union            224±0.4ms  
                     identity           226±1ms   
               symmetric_difference     219±2ms   
                    difference          174±2ms   
              ====================== =============

[ 33.33%] ··· overlay.Small.time_overlay                                                                            3/5 failed
[ 33.33%] ··· ====================== =============
                       how                        
              ---------------------- -------------
                   intersection        7.22±0.1ms 
                      union              failed   
                     identity            failed   
               symmetric_difference      failed   
                    difference        5.14±0.05ms 
              ====================== =============
```

I initially thought the existing benchmarks didn't catch this at all, but I was a bit out of practice with `asv`, and wasn't correctly comparing the branch @jorisvandenbossche is working on with the master branch. 