### PR TITLE
GHA: cancel existing jobs when new commits are added

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   Linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

This avoids workflows from queuing up if a lot of commits are made, e.g. if accepting suggestions in a PR it's common to make 20 commits in <2 minutes -> it can take hours for the last one to finish running since there's a limited number of runners per repo