### PR TITLE
GHA: Use github.ref instead of github.ref_head in concurrency group

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
     - cron: "0 0 * * *"
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Attempt to fix #2121; I'm only 85% sure this will work 😛 