### PR TITLE
PERF: avoid calculating total_bounds in sjoin

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -117,26 +117,6 @@ stria    AUT    416600.0
 
     _basic_checks(left_df, right_df, how, lsuffix, rsuffix)
 
-    box_left_gdf = left_df.total_bounds
-    box_right_gdf = right_df.total_bounds
-
-    if not (
-        (
-            (box_left_gdf[0] <= box_right_gdf[2])
-            and (box_right_gdf[0] <= box_left_gdf[2])
-        )
-        and (
-            (box_left_gdf[1] <= box_right_gdf[3])
-            and (box_right_gdf[1] <= box_left_gdf[3])
-        )
-    ):
-        copy_df = left_df.copy()
-        copy_df["index_left"] = 0
-        copy_df["index_right"] = 0
-        indices = pd.DataFrame(columns=["_key_left", "_key_right"], dtype=float)
-        copy_df = _frame_join(indices, left_df, right_df, how, lsuffix, rsuffix)
-        return copy_df.iloc[:0]
-
     indices = _geom_predicate_query(left_df, right_df, predicate)
 
     joined = _frame_join(indices, left_df, right_df, how, lsuffix, rsuffix)


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/2116

This removes it altogether. Alternative is put it behind a `if left_df.has_sindex:` check.