### PR TITLE
PERF: pre-define PyGEOSSTRTreeIndex.valid_query_predicates

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -470,6 +470,8 @@ if compat.HAS_PYGEOS:
     from . import array  # noqa
     import pygeos  # noqa
 
+    _PYGEOS_PREDICATES = {p.name for p in pygeos.strtree.BinaryPredicate} | set([None])
+
     class PyGEOSSTRTreeIndex(pygeos.STRtree):
         """A simple wrapper around pygeos's STRTree.
 
@@ -509,7 +511,7 @@ if compat.HAS_PYGEOS:
             {'contains', 'crosses', 'covered_by', None, 'intersects', 'within', \
 'touches', 'overlaps', 'contains_properly', 'covers'}
             """
-            return {p.name for p in pygeos.strtree.BinaryPredicate} | set([None])
+            return _PYGEOS_PREDICATES
 
         @doc(BaseSpatialIndex.query)
         def query(self, geometry, predicate=None, sort=False):


### PR DESCRIPTION
Xref https://github.com/geopandas/geopandas/issues/2076#issuecomment-927163830

This gives a 3x speed-up in the `sindex.BenchQuery.time_query('intersects', 'points', 'points')` speed-up case (the one with the biggest slowdown). 

It's in the scalar `query` (not `query_bulk`), so typically you won't call this method many times in a loop like the benchmark does (because you can then use `query_bulk`), but it's an easy fix, so can do that anyway.

cc @adriangb 