### PR TITLE
BENCH: fix plotting fixture

### DIFF
--- a/benchmarks/plotting.py
+++ b/benchmarks/plotting.py
@@ -7,44 +7,63 @@ import numpy as np
 
 class Bench:
 
-    param_names = ['geom_type']
-    params = [('Point', 'LineString', 'Polygon', 'MultiPolygon', 'mixed')]
+    param_names = ["geom_type"]
+    params = [("Point", "LineString", "Polygon", "MultiPolygon", "mixed")]
 
     def setup(self, geom_type):
 
-        if geom_type == 'Point':
+        if geom_type == "Point":
             geoms = GeoSeries([Point(i, i) for i in range(1000)])
-        elif geom_type == 'LineString':
-            geoms = GeoSeries([LineString([(random.random(), random.random())
-                                           for _ in range(5)])
-                               for _ in range(100)])
-        elif geom_type == 'Polygon':
-            geoms = GeoSeries([Polygon([(random.random(), random.random())
-                                        for _ in range(3)])
-                               for _ in range(100)])
-        elif geom_type == 'MultiPolygon':
+        elif geom_type == "LineString":
             geoms = GeoSeries(
-                [MultiPolygon([Polygon([(random.random(), random.random())
-                                        for _ in range(3)])
-                               for _ in range(3)])
-                 for _ in range(20)])
-        elif geom_type == 'mixed':
+                [
+                    LineString([(random.random(), random.random()) for _ in range(5)])
+                    for _ in range(100)
+                ]
+            )
+        elif geom_type == "Polygon":
+            geoms = GeoSeries(
+                [
+                    Polygon([(random.random(), random.random()) for _ in range(3)])
+                    for _ in range(100)
+                ]
+            )
+        elif geom_type == "MultiPolygon":
+            geoms = GeoSeries(
+                [
+                    MultiPolygon(
+                        [
+                            Polygon(
+                                [(random.random(), random.random()) for _ in range(3)]
+                            )
+                            for _ in range(3)
+                        ]
+                    )
+                    for _ in range(20)
+                ]
+            )
+        elif geom_type == "mixed":
             g1 = GeoSeries([Point(i, i) for i in range(100)])
-            g2 = GeoSeries([LineString([(random.random(), random.random())
-                                        for _ in range(5)])
-                            for _ in range(100)])
-            g3 = GeoSeries([Polygon([(random.random(), random.random())
-                                     for _ in range(3)])
-                            for _ in range(100)])
+            g2 = GeoSeries(
+                [
+                    LineString([(random.random(), random.random()) for _ in range(5)])
+                    for _ in range(100)
+                ]
+            )
+            g3 = GeoSeries(
+                [
+                    Polygon([(random.random(), random.random()) for _ in range(3)])
+                    for _ in range(100)
+                ]
+            )
 
             geoms = g1
-            geoms.iloc[np.random.randint(0, 100, 50)] = g2
-            geoms.iloc[np.random.randint(0, 100, 33)] = g3
+            geoms.iloc[np.random.randint(0, 100, 50)] = g2.iloc[:50]
+            geoms.iloc[np.random.randint(0, 100, 33)] = g3.iloc[:33]
 
             print(geoms.geom_type.value_counts())
 
-        df = GeoDataFrame({'geometry': geoms,
-                           'values': np.random.randn(len(geoms))})
+        df = GeoDataFrame({"geometry": geoms, "values": np.random.randn(len(geoms))})
 
         self.geoms = geoms
         self.df = df
@@ -53,5 +72,4 @@ class Bench:
         self.geoms.plot()
 
     def time_plot_values(self, *args):
-        self.df.plot(column='values')
-
+        self.df.plot(column="values")


### PR DESCRIPTION
While running the benchmarks, I've noticed that `mixed` plotting fails. The fixture creation raises `ValueError: cannot set using a list-like indexer with a different length than the value`.

The change is only on lines 61, 61, the rest is just `black` formatting.

<details>

```py
ValueError: cannot set using a list-like indexer with a different length than the value
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/var/folders/kp/fxnnw89x5qbb9gryn507p03c0000gn/T/ipykernel_11467/436023914.py in <module>
      8 
      9 geoms = g1
---> 10 geoms.iloc[np.random.randint(0, 100, 50)] = g2
     11 geoms.iloc[np.random.randint(0, 100, 33)] = g3
     12 

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/indexing.py in __setitem__(self, key, value)
    721 
    722         iloc = self if self.name == "iloc" else self.obj.iloc
--> 723         iloc._setitem_with_indexer(indexer, value, self.name)
    724 
    725     def _validate_key(self, key, axis: int):

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/indexing.py in _setitem_with_indexer(self, indexer, value, name)
   1730             self._setitem_with_indexer_split_path(indexer, value, name)
   1731         else:
-> 1732             self._setitem_single_block(indexer, value, name)
   1733 
   1734     def _setitem_with_indexer_split_path(self, indexer, value, name: str):

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/indexing.py in _setitem_single_block(self, indexer, value, name)
   1966 
   1967         # actually do the set
-> 1968         self.obj._mgr = self.obj._mgr.setitem(indexer=indexer, value=value)
   1969         self.obj._maybe_update_cacher(clear=True)
   1970 

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/internals/managers.py in setitem(self, indexer, value)
    353 
    354     def setitem(self: T, indexer, value) -> T:
--> 355         return self.apply("setitem", indexer=indexer, value=value)
    356 
    357     def putmask(self, mask, new, align: bool = True):

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/internals/managers.py in apply(self, f, align_keys, ignore_failures, **kwargs)
    325                     applied = b.apply(f, **kwargs)
    326                 else:
--> 327                     applied = getattr(b, f)(**kwargs)
    328             except (TypeError, NotImplementedError):
    329                 if not ignore_failures:

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/internals/blocks.py in setitem(self, indexer, value)
   1489             indexer = indexer[0]
   1490 
-> 1491         check_setitem_lengths(indexer, value, self.values)
   1492         self.values[indexer] = value
   1493         return self

/opt/miniconda3/envs/geo_dev/lib/python3.9/site-packages/pandas/core/indexers.py in check_setitem_lengths(indexer, value, values)
    174                     and len(indexer[indexer]) == len(value)
    175                 ):
--> 176                     raise ValueError(
    177                         "cannot set using a list-like indexer "
    178                         "with a different length than the value"

ValueError: cannot set using a list-like indexer with a different length than the value
```

</details>