### PR TITLE
BUG: fix importing of Fiona to avoid AttributeError on broken fiona install

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -14,17 +14,22 @@ try:
     import fiona
 
     fiona_import_error = None
+
+    # only try to import fiona.Env if the main fiona import succeeded (otherwise you
+    # can get confusing "AttributeError: module 'fiona' has no attribute '_loading'"
+    # / partially initialized module errors)
+    try:
+        from fiona import Env as fiona_env
+    except ImportError:
+        try:
+            from fiona import drivers as fiona_env
+        except ImportError:
+            fiona_env = None
+
 except ImportError as err:
     fiona = None
     fiona_import_error = str(err)
 
-try:
-    from fiona import Env as fiona_env
-except ImportError:
-    try:
-        from fiona import drivers as fiona_env
-    except ImportError:
-        fiona_env = None
 
 from geopandas import GeoDataFrame, GeoSeries
 


### PR DESCRIPTION
See https://github.com/geopandas/geopandas/issues/2123#issuecomment-927178129

We have had several reports with `AttributeError: partially initialized module 'fiona' has no attribute '_loading' (most likely due to a circular import)` or `AttributeError: module 'fiona' has no attribute '_loading'` errors. 
This PR certainly doesn't solve all of those issues (eg I don't expect it fixes the case where import fiona before geopandas helps), but I could verify that it fixes one specific case: if your fiona install is broken, it currently also breaks import geopandas (with the second attribute error). 

This seems to be due to how fiona importing works: `import fiona` can fail with a clear ImportError, but a subsequent `from fiona import Env` then gives the confusing AttributeError. 
And because we still tried `from fiona import Env` even if the main fiona import failed, we triggered this error.