### PR TITLE
Combine sindex.nearest/nearest_all in single method

### DIFF
--- a/doc/source/docs/reference/sindex.rst
+++ b/doc/source/docs/reference/sindex.rst
@@ -31,7 +31,6 @@ methods:
     intersection
     is_empty
     nearest
-    nearest_all
     query
     query_bulk
     size

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -774,7 +774,7 @@ if compat.HAS_PYGEOS:
                 # trick to get
                 uniques = np.diff(indices[0, :])
                 # always select the first element
-                uniques = np.insert(uniques, 0, 1)
+                uniques = np.insert(uniques, 0, 1).astype('bool')
 
                 indices = indices[:, uniques]
                 if return_distance:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -210,7 +210,7 @@ geometries}
             (GeoSeries, GeometryArray), or a numpy array of PyGEOS geometries to query
             against the spatial index.
         return_all : bool, default True
-            If there are multiple equi-distance nearest geometries, return all those
+            If there are multiple equidistant or intersecting nearest geometries, return all those
             geometries instead of a single nearest geometry.
         max_distance : float, optional
             Maximum distance within which to query for nearest items in tree.

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -168,18 +168,39 @@ class BaseSpatialIndex:
         """
         raise NotImplementedError
 
-    def nearest(self, geometry):
+    def nearest(
+        self, geometry, return_all=True, max_distance=None, return_distance=False
+    ):
         """
-        Returns the nearest geometry to the input geometries.
+        Return the nearest geometry in the tree for each input geometry in
+        ``geometry``.
 
         .. note::
             ``nearest`` currently only works with PyGEOS >= 0.10.
 
-        Note that if pygeos is not available, geopandas
-        will use rtree for the spatial index, where nearest temporarily has a different
-        function signature to temporarily preserve existing functionality. See the
-        documentation of :meth:`rtree.index.Index.nearest` for the details on the
-        ``rtree``-based implementation.
+            Note that if PyGEOS is not available, geopandas will use rtree
+            for the spatial index, where nearest temporarily has a different
+            function signature to temporarily preserve existing
+            functionality. See the documentation of
+            :meth:`rtree.index.Index.nearest` for the details on the
+            ``rtree``-based implementation.
+
+        If multiple tree geometries have the same distance from an input geometry,
+        multiple results will be returned for that input geometry by default.
+        Specify ``return_all=False`` to only get a single nearest geometry
+        (non-deterministic which nearest is returned).
+
+        In the context of a spatial join, input geometries are the "left"
+        geometries that determine the order of the results, and tree geometries
+        are "right" geometries that are joined against the left geometries.
+        If ``max_distance`` is not set, this will effectively be a left join
+        because every geometry in ``geometry`` will have a nearest geometry in
+        the tree. However, if ``max_distance`` is used, this becomes an
+        inner join, since some geometries in ``geometry`` may not have a match
+        in the tree.
+
+        For performance reasons, it is highly recommended that you set
+        the ``max_distance`` parameter.
 
         Parameters
         ----------
@@ -188,12 +209,22 @@ geometries}
             A single shapely geometry, one of the GeoPandas geometry iterables
             (GeoSeries, GeometryArray), or a numpy array of PyGEOS geometries to query
             against the spatial index.
+        return_all : bool, default True
+            If there are multiple equi-distance nearest geometries, return all those
+            geometries instead of a single nearest geometry.
+        max_distance : float, optional
+            Maximum distance within which to query for nearest items in tree.
+            Must be greater than 0. By default None, indicating no distance limit.
+        return_distance : bool, optional
+            If True, will return distances in addition to indexes. By default False
 
         Returns
         -------
-        matches : ndarray with shape (2, n)
-            The first subarray contains input geometry integer indexes.
-            The second subarray contains tree geometry integer indexes.
+        Indices or tuple of (indices, distances)
+            Indices is an ndarray of shape (2,n) and distances (if present) an
+            ndarray of shape (n).
+            The first subarray of indices contains input geometry indices.
+            The second subarray of indices contains tree geometry indices.
 
         Examples
         --------
@@ -224,51 +255,6 @@ geometries}
         >>> s.sindex.nearest(s2)
         array([[0, 1],
                [8, 9]])
-        """
-        raise NotImplementedError
-
-    def nearest_all(self, geometry, max_distance=None, return_distance=False):
-        """Return the nearest geometry in the tree for each input geometry in
-        ``geometry``.
-
-        If multiple tree geometries have the same distance from an input geometry,
-        multiple results will be returned for that input geometry.
-
-        .. note::
-            ``nearest_all`` currently only works with PyGEOS >= 0.10.
-
-        In the context of a spatial join, input geometries are the “left”
-        geometries that determine the order of the results, and tree geometries
-        are “right” geometries that are joined against the left geometries.
-        If max_distance is not set, this will effectively be a left join
-        because every geometry in ``geometry`` will have a nearest geometry in
-        the tree. However, if ``max_distance`` is used, this becomes an
-        inner join, since some geometries in ``geometry`` may not have a match
-        in the tree.
-
-        For performance reasons, it is highly recommended that you set
-        the ``max_distance`` parameter.
-
-        Parameters
-        ----------
-        geometry : {shapely.geometry, GeoSeries, GeometryArray, numpy.array of PyGEOS \
-geometries}
-            A single shapely geometry, one of the GeoPandas geometry iterables
-            (GeoSeries, GeometryArray), or a numpy array of PyGEOS geometries to query
-            against the spatial index.
-        max_distance : float, optional
-            Maximum distance within which to query for nearest items in tree.
-            Must be greater than 0. By default None, indicating no distance limit.
-        return_distance : bool, optional
-            If True, will return distances in addition to indexes. By default False
-
-        Returns
-        -------
-        Indices or tuple of (indices, distances)
-            Indices is an ndarray of shape (2,n) and distances (if present) an
-            ndarray of shape (n).
-            The first subarray of indices contains input geometry indices.
-            The second subarray of indices contains tree geometry indices.
         """
         raise NotImplementedError
 
@@ -764,19 +750,40 @@ if compat.HAS_PYGEOS:
             return res
 
         @doc(BaseSpatialIndex.nearest)
-        def nearest(self, geometry):
+        def nearest(
+            self, geometry, return_all=True, max_distance=None, return_distance=False
+        ):
             if not compat.PYGEOS_GE_010:
                 raise NotImplementedError("sindex.nearest requires pygeos >= 0.10")
 
             geometry = self._as_geometry_array(geometry)
-            return super().nearest(geometry)
 
-        @doc(BaseSpatialIndex.nearest_all)
-        def nearest_all(self, geometry, max_distance=None, return_distance=False):
-            geometry = self._as_geometry_array(geometry)
-            return super().nearest_all(
+            if not return_all and max_distance is None:
+                return super().nearest(geometry)
+
+            result = super().nearest_all(
                 geometry, max_distance=max_distance, return_distance=return_distance
             )
+            if return_distance:
+                indices, distances = result
+            else:
+                indices = result
+
+            if not return_all:
+                # first subarray of geometry indices is sorted, so we can use this
+                # trick to get
+                uniques = np.diff(indices[0, :])
+                # always select the first element
+                uniques = np.insert(uniques, 0, 1)
+
+                indices = indices[:, uniques]
+                if return_distance:
+                    distances = distances[uniques]
+
+            if return_distance:
+                return indices, distances
+            else:
+                return indices
 
         @doc(BaseSpatialIndex.intersection)
         def intersection(self, coordinates):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -179,7 +179,7 @@ class BaseSpatialIndex:
             ``nearest`` currently only works with PyGEOS >= 0.10.
 
             Note that if PyGEOS is not available, geopandas will use rtree
-            for the spatial index, where nearest temporarily has a different
+            for the spatial index, where nearest has a different
             function signature to temporarily preserve existing
             functionality. See the documentation of
             :meth:`rtree.index.Index.nearest` for the details on the

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -210,8 +210,9 @@ geometries}
             (GeoSeries, GeometryArray), or a numpy array of PyGEOS geometries to query
             against the spatial index.
         return_all : bool, default True
-            If there are multiple equidistant or intersecting nearest geometries, return all those
-            geometries instead of a single nearest geometry.
+            If there are multiple equidistant or intersecting nearest
+            geometries, return all those geometries instead of a single
+            nearest geometry.
         max_distance : float, optional
             Maximum distance within which to query for nearest items in tree.
             Must be greater than 0. By default None, indicating no distance limit.
@@ -771,14 +772,14 @@ if compat.HAS_PYGEOS:
 
             if not return_all:
                 # first subarray of geometry indices is sorted, so we can use this
-                # trick to get
-                uniques = np.diff(indices[0, :])
+                # trick to get the first of each index value
+                mask = np.diff(indices[0, :]).astype("bool")
                 # always select the first element
-                uniques = np.insert(uniques, 0, 1).astype('bool')
+                mask = np.insert(mask, 0, True)
 
-                indices = indices[:, uniques]
+                indices = indices[:, mask]
                 if return_distance:
-                    distances = distances[uniques]
+                    distances = distances[mask]
 
             if return_distance:
                 return indices, distances

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -758,7 +758,7 @@ if compat.HAS_PYGEOS:
 
             geometry = self._as_geometry_array(geometry)
 
-            if not return_all and max_distance is None:
+            if not return_all and max_distance is None and not return_distance:
                 return super().nearest(geometry)
 
             result = super().nearest_all(

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -706,11 +706,11 @@ class TestPygeosInterface:
         df = geopandas.GeoDataFrame({"geometry": geoms})
 
         p = Point(geometry)
-        res = df.sindex.nearest(p)
+        res = df.sindex.nearest(p, return_all=False)
         assert_array_equal(res, expected)
 
         p = pygeos.points(geometry)
-        res = df.sindex.nearest(p)
+        res = df.sindex.nearest(p, return_all=False)
         assert_array_equal(res, expected)
 
     @pytest.mark.skipif(
@@ -729,26 +729,27 @@ class TestPygeosInterface:
         df = geopandas.GeoDataFrame({"geometry": geoms})
 
         ps = [Point(p) for p in geometry]
-        res = df.sindex.nearest(ps)
+        res = df.sindex.nearest(ps, return_all=False)
         assert_array_equal(res, expected)
 
         ps = pygeos.points(geometry)
-        res = df.sindex.nearest(ps)
+        res = df.sindex.nearest(ps, return_all=False)
         assert_array_equal(res, expected)
 
         s = geopandas.GeoSeries(ps)
-        res = df.sindex.nearest(s)
+        res = df.sindex.nearest(s, return_all=False)
         assert_array_equal(res, expected)
 
         x, y = zip(*geometry)
         ga = geopandas.points_from_xy(x, y)
-        res = df.sindex.nearest(ga)
+        res = df.sindex.nearest(ga, return_all=False)
         assert_array_equal(res, expected)
 
     @pytest.mark.skipif(
         not compat.USE_PYGEOS or not compat.PYGEOS_GE_010,
         reason=("PyGEOS >= 0.10 is required to test sindex.nearest"),
     )
+    @pytest.mark.parametrize("return_all", [True, False])
     @pytest.mark.parametrize(
         "geometry,expected",
         [
@@ -756,11 +757,11 @@ class TestPygeosInterface:
             ([None], [[], []]),
         ],
     )
-    def test_nearest_none(self, geometry, expected):
+    def test_nearest_none(self, geometry, expected, return_all):
         geoms = pygeos.points(np.arange(10), np.arange(10))
         df = geopandas.GeoDataFrame({"geometry": geoms})
 
-        res = df.sindex.nearest(geometry)
+        res = df.sindex.nearest(geometry, return_all=return_all)
         assert_array_equal(res, expected)
 
     # --------------------------- misc tests ---------------------------- #

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -1,3 +1,5 @@
+from math import sqrt
+
 from shapely.geometry import (
     Point,
     Polygon,
@@ -694,6 +696,7 @@ class TestPygeosInterface:
         not (compat.USE_PYGEOS and compat.PYGEOS_GE_010),
         reason=("PyGEOS >= 0.10 is required to test sindex.nearest"),
     )
+    @pytest.mark.parametrize("return_all", [True, False])
     @pytest.mark.parametrize(
         "geometry,expected",
         [
@@ -701,22 +704,23 @@ class TestPygeosInterface:
             ([0.75, 0.75], [[0], [1]]),
         ],
     )
-    def test_nearest_single(self, geometry, expected):
+    def test_nearest_single(self, geometry, expected, return_all):
         geoms = pygeos.points(np.arange(10), np.arange(10))
         df = geopandas.GeoDataFrame({"geometry": geoms})
 
         p = Point(geometry)
-        res = df.sindex.nearest(p, return_all=False)
+        res = df.sindex.nearest(p, return_all=return_all)
         assert_array_equal(res, expected)
 
         p = pygeos.points(geometry)
-        res = df.sindex.nearest(p, return_all=False)
+        res = df.sindex.nearest(p, return_all=return_all)
         assert_array_equal(res, expected)
 
     @pytest.mark.skipif(
         not compat.USE_PYGEOS or not compat.PYGEOS_GE_010,
         reason=("PyGEOS >= 0.10 is required to test sindex.nearest"),
     )
+    @pytest.mark.parametrize("return_all", [True, False])
     @pytest.mark.parametrize(
         "geometry,expected",
         [
@@ -724,25 +728,25 @@ class TestPygeosInterface:
             ([(1, 1), (0.25, 1)], [[0, 1], [1, 1]]),
         ],
     )
-    def test_nearest_multi(self, geometry, expected):
+    def test_nearest_multi(self, geometry, expected, return_all):
         geoms = pygeos.points(np.arange(10), np.arange(10))
         df = geopandas.GeoDataFrame({"geometry": geoms})
 
         ps = [Point(p) for p in geometry]
-        res = df.sindex.nearest(ps, return_all=False)
+        res = df.sindex.nearest(ps, return_all=return_all)
         assert_array_equal(res, expected)
 
         ps = pygeos.points(geometry)
-        res = df.sindex.nearest(ps, return_all=False)
+        res = df.sindex.nearest(ps, return_all=return_all)
         assert_array_equal(res, expected)
 
         s = geopandas.GeoSeries(ps)
-        res = df.sindex.nearest(s, return_all=False)
+        res = df.sindex.nearest(s, return_all=return_all)
         assert_array_equal(res, expected)
 
         x, y = zip(*geometry)
         ga = geopandas.points_from_xy(x, y)
-        res = df.sindex.nearest(ga, return_all=False)
+        res = df.sindex.nearest(ga, return_all=return_all)
         assert_array_equal(res, expected)
 
     @pytest.mark.skipif(
@@ -763,6 +767,39 @@ class TestPygeosInterface:
 
         res = df.sindex.nearest(geometry, return_all=return_all)
         assert_array_equal(res, expected)
+
+    @pytest.mark.skipif(
+        not compat.USE_PYGEOS or not compat.PYGEOS_GE_010,
+        reason=("PyGEOS >= 0.10 is required to test sindex.nearest"),
+    )
+    @pytest.mark.parametrize("return_distance", [True, False])
+    @pytest.mark.parametrize(
+        "return_all,max_distance,expected",
+        [
+            (True, None, ([[0, 0, 1], [0, 1, 5]], [sqrt(0.5), sqrt(0.5), sqrt(50)])),
+            (False, None, ([[0, 1], [0, 5]], [sqrt(0.5), sqrt(50)])),
+            (True, 1, ([[0, 0], [0, 1]], [sqrt(0.5), sqrt(0.5)])),
+            (False, 1, ([[0], [0]], [sqrt(0.5)])),
+        ],
+    )
+    def test_nearest_max_distance(
+        self, expected, max_distance, return_all, return_distance
+    ):
+        geoms = pygeos.points(np.arange(10), np.arange(10))
+        df = geopandas.GeoDataFrame({"geometry": geoms})
+
+        ps = [Point(0.5, 0.5), Point(0, 10)]
+        res = df.sindex.nearest(
+            ps,
+            return_all=return_all,
+            max_distance=max_distance,
+            return_distance=return_distance,
+        )
+        if return_distance:
+            assert_array_equal(res[0], expected[0])
+            assert_array_equal(res[1], expected[1])
+        else:
+            assert_array_equal(res, expected[0])
 
     # --------------------------- misc tests ---------------------------- #
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -372,8 +372,11 @@ def _nearest_query(
         sindex = right_df.sindex
         query = left_df.geometry
     if sindex:
-        res = sindex.nearest_all(
-            query, max_distance=max_distance, return_distance=return_distance
+        res = sindex.nearest(
+            query,
+            return_all=True,
+            max_distance=max_distance,
+            return_distance=return_distance,
         )
         if return_distance:
             (input_idx, tree_idx), distances = res


### PR DESCRIPTION
Closes https://github.com/geopandas/geopandas/issues/1977

This adds a new keyword `return_all=True/False` (with a default of True, so matching the `nearest_all` behaviour). But other ideas for the name of the keyword are certainly welcome as well.

This already combines both methods and updates the code/tests using it. Since this adds new functionality (currently unique to geopandas), i.e. using a `max_distance` when only wanting a single return value, I will also need to add new tests for that (still to do).