### PR TITLE
REGR: avoid bbox check in overlay if how != intersection

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -265,23 +265,24 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
                 "df{} contains mixed geometry types.".format(i + 1)
             )
 
-    box_gdf1 = df1.total_bounds
-    box_gdf2 = df2.total_bounds
+    if how == "intersection":
+        box_gdf1 = df1.total_bounds
+        box_gdf2 = df2.total_bounds
 
-    if not (
-        ((box_gdf1[0] <= box_gdf2[2]) and (box_gdf2[0] <= box_gdf1[2]))
-        and ((box_gdf1[1] <= box_gdf2[3]) and (box_gdf2[1] <= box_gdf1[3]))
-    ):
-        return GeoDataFrame(
-            [],
-            columns=list(
-                set(
-                    df1.drop(df1.geometry.name, axis=1).columns.to_list()
-                    + df2.drop(df2.geometry.name, axis=1).columns.to_list()
+        if not (
+            ((box_gdf1[0] <= box_gdf2[2]) and (box_gdf2[0] <= box_gdf1[2]))
+            and ((box_gdf1[1] <= box_gdf2[3]) and (box_gdf2[1] <= box_gdf1[3]))
+        ):
+            return GeoDataFrame(
+                [],
+                columns=list(
+                    set(
+                        df1.drop(df1.geometry.name, axis=1).columns.to_list()
+                        + df2.drop(df2.geometry.name, axis=1).columns.to_list()
+                    )
                 )
+                + ["geometry"],
             )
-            + ["geometry"],
-        )
 
     # Computations
     def _make_valid(df):


### PR DESCRIPTION
Fixes #2156

The bbox check makes sense only for `intersection`, not the other overlay options.