### PR TITLE
BUG: Make explode() handle empty singular geom with shapely<2

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -925,10 +925,13 @@ class GeoSeries(GeoPandasBase, Series):
             if s.type == "GeometryCollection" and s.is_empty:
                 continue
             elif s.type.startswith("Multi") and s.is_empty:
-                # Hack to retain type after exploding
-                s_type_exploded = s.type.removeprefix("Multi").upper()
-                s_exploded = wkt.loads(f"{s_type_exploded} EMPTY")
-                geoms = [s_exploded]
+                # Create empty geometry of singular type
+                start_idx = len("Multi")
+                s_type_singular = s.type[start_idx:]
+                s_singular = wkt.loads(
+                    f"{s_type_singular.upper()} EMPTY"
+                )  # e.g. POINT EMPTY
+                geoms = [s_singular]
                 idxs = [(idx, 0)]
             elif s.type.startswith("Multi") or s.type == "GeometryCollection":
                 geoms = s.geoms

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -921,7 +921,9 @@ class GeoSeries(GeoPandasBase, Series):
         index = []
         geometries = []
         for idx, s in self.geometry.iteritems():
-            if s.type.startswith("Multi") or (s.type == "GeometryCollection" and not s.is_empty):
+            if s.type.startswith("Multi") or (
+                s.type == "GeometryCollection" and not s.is_empty
+            ):
                 geoms = s.geoms
                 idxs = [(idx, i) for i in range(len(geoms))]
             else:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -921,8 +921,10 @@ class GeoSeries(GeoPandasBase, Series):
         index = []
         geometries = []
         for idx, s in self.geometry.iteritems():
-            if s.type.startswith("Multi") or (
-                s.type == "GeometryCollection" and not s.is_empty
+            if s.type == "GeometryCollection" and s.is_empty:
+                continue
+            elif s.type.startswith("Multi") or (
+                s.type == "GeometryCollection" and hasattr(s, "geoms")
             ):
                 geoms = s.geoms
                 idxs = [(idx, i) for i in range(len(geoms))]

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -921,7 +921,7 @@ class GeoSeries(GeoPandasBase, Series):
         index = []
         geometries = []
         for idx, s in self.geometry.iteritems():
-            if s.type.startswith("Multi") or s.type == "GeometryCollection":
+            if s.type.startswith("Multi") or (s.type == "GeometryCollection" and not s.is_empty):
                 geoms = s.geoms
                 idxs = [(idx, i) for i in range(len(geoms))]
             else:

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -572,3 +572,14 @@ class TestConstructor:
         # index_parts is ignored if ignore_index=True
         s = s.explode(index_parts=True, ignore_index=True)
         assert_index_equal(s.index, expected_index)
+
+    @pytest.mark.parametrize(
+        "geom_types",
+        [(Point, MultiPoint), (LineString, MultiLineString), (Polygon, MultiPolygon)],
+    )
+    def test_explode_empty_geometrycollection(self, geom_types):
+        type_singular, type_multi = geom_types
+        empty_singular_exploded = GeoSeries([type_singular()]).explode()
+        empty_multi_exploded = GeoSeries([type_multi()]).explode()
+
+        assert_geoseries_equal(empty_singular_exploded, empty_multi_exploded)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -19,6 +19,7 @@ from shapely.geometry import (
     Polygon,
 )
 from shapely.geometry.base import BaseGeometry
+from shapely import wkt
 
 from geopandas import GeoSeries, GeoDataFrame, read_file, datasets, clip
 from geopandas._compat import PYPROJ_LT_3, ignore_shapely2_warnings
@@ -579,7 +580,23 @@ class TestConstructor:
     )
     def test_explode_empty_geometrycollection(self, geom_types):
         type_singular, type_multi = geom_types
+
+        # Test that empty constructors yield the same result for singular and multi geom
+        # In this case the type is not possible to retain
+        # as shapely instantiate GeometryCollection
         empty_singular_exploded = GeoSeries([type_singular()]).explode()
         empty_multi_exploded = GeoSeries([type_multi()]).explode()
 
         assert_geoseries_equal(empty_singular_exploded, empty_multi_exploded)
+
+        # Test that instantiation of empty geoms from wkt
+        # yields same result for singular and multi geom
+        # In this case the geom type is retained
+        empty_singular_exploded2 = GeoSeries(
+            [wkt.loads(f"{type_singular.__name__.upper()} EMPTY")]
+        ).explode()
+        empty_multi_exploded2 = GeoSeries(
+            [wkt.loads(f"{type_multi.__name__.upper()} EMPTY")]
+        ).explode()
+
+        assert_geoseries_equal(empty_singular_exploded2, empty_multi_exploded2)


### PR DESCRIPTION
Make explode() handle empty singular geom
```python
gs = gpd.GeoSeries(Point())
gs.explode()  # -> AttributeError: 'Point' object has no attribute 'geoms'
```

The above example throws an error on line 925, as an empty singular geometry object has `s.type == "GeometryCollection"`, but does not have the attribute `geoms`.

The proposed change checks if the geom is empty, and thus is passed on to the `else` statement on line 927.