### PR TITLE
BUG: Use keep_geom_type logic for all overlay methods

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -310,7 +310,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     with warnings.catch_warnings():  # CRS checked above, suppress array-level warning
         warnings.filterwarnings("ignore", message="CRS mismatch between the CRS")
         if how == "difference":
-            return _overlay_difference(df1, df2)
+            result = _overlay_difference(df1, df2)
         elif how == "intersection":
             result = _overlay_intersection(df1, df2)
         elif how == "symmetric_difference":
@@ -320,6 +320,9 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
         elif how == "identity":
             dfunion = _overlay_union(df1, df2)
             result = dfunion[dfunion["__idx1"].notnull()].copy()
+
+        if how in ["intersection", "symmetric_difference", "union", "identity"]:
+            result.drop(["__idx1", "__idx2"], axis=1, inplace=True)
 
     if keep_geom_type:
         geom_type = df1.geom_type.iloc[0]
@@ -385,5 +388,4 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
             )
 
     result.reset_index(drop=True, inplace=True)
-    result.drop(["__idx1", "__idx2"], axis=1, inplace=True)
     return result


### PR DESCRIPTION
In cases of using method="difference" in overlays, we were not applying
the keep_geom_type logic. This change makes all overlay methods proceed
through that step. Closes #2163.
