### PR TITLE
TST: fix explore() tests for change in CartoDB max zoom level in latest xyzservices

### DIFF
--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -25,7 +25,7 @@ dependencies:
     # dev versions of packages
     - git+https://github.com/numpy/numpy.git@main
     - git+https://github.com/pydata/pandas.git@master
-    - git+https://github.com/matplotlib/matplotlib.git@master
+    - git+https://github.com/matplotlib/matplotlib.git@main
     - git+https://github.com/Toblerity/Shapely.git@master
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@master

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -608,7 +608,7 @@ class TestExplore:
             'attribution":"\\u0026copy;\\u003cahref=\\"https://www.openstreetmap.org'
             in out_str
         )
-        assert '"maxNativeZoom":19,"maxZoom":19,"minZoom":0' in out_str
+        assert '"maxNativeZoom":20,"maxZoom":20,"minZoom":0' in out_str
 
     def test_xyzservices_query_name(self):
         pytest.importorskip("xyzservices")
@@ -624,7 +624,7 @@ class TestExplore:
             'attribution":"\\u0026copy;\\u003cahref=\\"https://www.openstreetmap.org'
             in out_str
         )
-        assert '"maxNativeZoom":19,"maxZoom":19,"minZoom":0' in out_str
+        assert '"maxNativeZoom":20,"maxZoom":20,"minZoom":0' in out_str
 
     def test_linearrings(self):
         rings = self.nybb.explode(index_parts=True).exterior


### PR DESCRIPTION
As mentioned in https://github.com/geopandas/xyzservices/blob/main/CHANGELOG.md#xyzservices-2021100-october-19-2021

@martinfleis I am not sure if we want to care about being able to run the tests with older xyzservices versions? (or we could change the test a bit to not rely on the exact number)