### PR TITLE
CI: use shapely main instead of master

### DIFF
--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -26,7 +26,7 @@ dependencies:
     - git+https://github.com/numpy/numpy.git@main
     - git+https://github.com/pydata/pandas.git@master
     - git+https://github.com/matplotlib/matplotlib.git@main
-    - git+https://github.com/Toblerity/Shapely.git@master
+    - git+https://github.com/Toblerity/Shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@master
     - git+https://github.com/geopandas/xyzservices.git@main


### PR DESCRIPTION
I am aware that this may change again soon with the plans to move from `Toblerity` org to `shapely` org but it is good to keep our CI green in the meantime anyway.