### PR TITLE
BUG: avoid passing engine along to _to_parquet function

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1024,6 +1024,7 @@ individually so that features may have different properties
         GeoDataFrame.to_file : write GeoDataFrame to file
         """
 
+        # Accept engine keyword for compatibility with pandas.DataFrame.to_parquet
         # The only engine currently supported by GeoPandas is pyarrow, so no
         # other engine should be specified.
         engine = kwargs.pop("engine", "auto")

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1024,6 +1024,15 @@ individually so that features may have different properties
         GeoDataFrame.to_file : write GeoDataFrame to file
         """
 
+        # The only engine currently supported by GeoPandas is pyarrow, so no
+        # other engine should be specified.
+        engine = kwargs.pop("engine", "auto")
+        if engine not in ("auto", "pyarrow"):
+            raise ValueError(
+                f"GeoPandas only supports using pyarrow as the engine for "
+                f"to_parquet: {engine!r}"
+            )
+
         from geopandas.io.arrow import _to_parquet
 
         _to_parquet(self, path, compression=compression, index=index, **kwargs)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1031,7 +1031,7 @@ individually so that features may have different properties
         if engine not in ("auto", "pyarrow"):
             raise ValueError(
                 f"GeoPandas only supports using pyarrow as the engine for "
-                f"to_parquet: {engine!r}"
+                f"to_parquet: {engine!r} passed instead."
             )
 
         from geopandas.io.arrow import _to_parquet

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -184,7 +184,7 @@ def test_to_parquet_fails_on_invalid_engine():
             ValueError,
             match=(
                 "GeoPandas only supports using pyarrow as the engine for "
-                "to_parquet: 'fastparquet'"
+                "to_parquet: 'fastparquet' passed instead."
             ),
         ):
             df.to_parquet("", engine="fastparquet")

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -173,17 +173,21 @@ def test_validate_metadata_invalid(metadata, error):
         _validate_metadata(metadata)
 
 
-@mock.patch("geopandas.io.arrow._to_parquet")
-def test_to_parquet_fails_on_invalid_engine(mock_to_parquet):
+def test_to_parquet_fails_on_invalid_engine():
     df = GeoDataFrame(data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)])
-    with pytest.raises(
-        ValueError,
-        match=(
-            "GeoPandas only supports using pyarrow as the engine for "
-            "to_parquet: 'fastparquet'"
-        ),
-    ):
-        df.to_parquet("", engine="fastparquet")
+
+    # Patch geopandas.io.arrow._to_parquet to ensure that it doesn't try to run
+    # in the event that df.to_parquet doesn't raise a ValueError like it should.
+    with mock.patch("geopandas.io.arrow._to_parquet"):
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "GeoPandas only supports using pyarrow as the engine for "
+                "to_parquet: 'fastparquet'"
+            ),
+        ):
+            df.to_parquet("", engine="fastparquet")
 
 
 @mock.patch("geopandas.io.arrow._to_parquet")

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -7,7 +7,7 @@ import pytest
 from pandas import DataFrame, read_parquet as pd_read_parquet
 from pandas.testing import assert_frame_equal
 import numpy as np
-from shapely.geometry import box
+from shapely.geometry import box, Point
 
 import geopandas
 from geopandas import GeoDataFrame, read_file, read_parquet, read_feather
@@ -23,6 +23,7 @@ from geopandas.io.arrow import (
     METADATA_VERSION,
 )
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from geopandas.tests.util import mock
 
 
 # Skip all tests in this module if pyarrow is not available
@@ -170,6 +171,26 @@ def test_validate_metadata_valid():
 def test_validate_metadata_invalid(metadata, error):
     with pytest.raises(ValueError, match=error):
         _validate_metadata(metadata)
+
+
+@mock.patch("geopandas.io.arrow._to_parquet")
+def test_to_parquet_fails_on_invalid_engine(mock_to_parquet):
+    df = GeoDataFrame(data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)])
+    with pytest.raises(
+        ValueError,
+        match=(
+            "GeoPandas only supports using pyarrow as the engine for "
+            "to_parquet: 'fastparquet'"
+        ),
+    ):
+        df.to_parquet("", engine="fastparquet")
+
+
+@mock.patch("geopandas.io.arrow._to_parquet")
+def test_to_parquet_does_not_pass_engine_along(mock_to_parquet):
+    df = GeoDataFrame(data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)])
+    df.to_parquet("", engine="pyarrow")
+    mock_to_parquet.assert_called_with(df, "", compression="snappy", index=None)
 
 
 # TEMPORARY: used to determine if pyarrow fails for roundtripping pandas data

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -18,7 +18,7 @@ from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 from geopandas._compat import ignore_shapely2_warnings
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
-from geopandas.tests.util import mock, PACKAGE_DIR, validate_boro_df
+from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 import pytest
 
@@ -831,28 +831,6 @@ class TestDataFrame:
 
         expected_df = pd.DataFrame({"gs0": wkts0, "gs1": wkts1})
         assert_frame_equal(expected_df, gdf.to_wkt())
-
-    @mock.patch("geopandas.io.arrow._to_parquet")
-    def test_to_parquet_fails_on_invalid_engine(self, mock_to_parquet):
-        df = GeoDataFrame(
-            data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)]
-        )
-        with pytest.raises(
-            ValueError,
-            match=(
-                "GeoPandas only supports using pyarrow as the engine for "
-                "to_parquet: 'fastparquet'"
-            ),
-        ):
-            df.to_parquet("", engine="fastparquet")
-
-    @mock.patch("geopandas.io.arrow._to_parquet")
-    def test_to_parquet_does_not_pass_engine_along(self, mock_to_parquet):
-        df = GeoDataFrame(
-            data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)]
-        )
-        df.to_parquet("", engine="pyarrow")
-        mock_to_parquet.assert_called_with(df, "", compression="snappy", index=None)
 
     @pytest.mark.parametrize("how", ["left", "inner", "right"])
     @pytest.mark.parametrize("predicate", ["intersects", "within", "contains"])

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -18,7 +18,7 @@ from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 from geopandas._compat import ignore_shapely2_warnings
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
-from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
+from geopandas.tests.util import mock, PACKAGE_DIR, validate_boro_df
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 import pytest
 
@@ -831,6 +831,28 @@ class TestDataFrame:
 
         expected_df = pd.DataFrame({"gs0": wkts0, "gs1": wkts1})
         assert_frame_equal(expected_df, gdf.to_wkt())
+
+    @mock.patch("geopandas.io.arrow._to_parquet")
+    def test_to_parquet_fails_on_invalid_engine(self, mock_to_parquet):
+        df = GeoDataFrame(
+            data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)]
+        )
+        with pytest.raises(
+            ValueError,
+            match=(
+                "GeoPandas only supports using pyarrow as the engine for "
+                "to_parquet: 'fastparquet'"
+            ),
+        ):
+            df.to_parquet("", engine="fastparquet")
+
+    @mock.patch("geopandas.io.arrow._to_parquet")
+    def test_to_parquet_does_not_pass_engine_along(self, mock_to_parquet):
+        df = GeoDataFrame(
+            data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)]
+        )
+        df.to_parquet("", engine="pyarrow")
+        mock_to_parquet.assert_called_with(df, "", compression="snappy", index=None)
 
     @pytest.mark.parametrize("how", ["left", "inner", "right"])
     @pytest.mark.parametrize("predicate", ["intersects", "within", "contains"])


### PR DESCRIPTION
The `GeoDataFrame.to_parquet` function does not match the signature of [`pandas.DataFrame.to_parquet`](https://github.com/pandas-dev/pandas/blob/a07561e5a33b78cb54d163e81dd7a4444ca41554/pandas/core/frame.py#L2686-L2695), so when the function is called from [`google.cloud.bigquery.client.Client.load_table_from_dataframe`](https://github.com/googleapis/python-bigquery/blob/9a5a888bad569c8c1d8d72994d428ed92fe5ac47/google/cloud/bigquery/client.py#L2669-L2678) with the `engine` keyword, it ends up passing that keyword along to pyarrow, which eventually results in a `TypeError`:
```
  File "pyarrow/_parquet.pyx", line 1377, in pyarrow._parquet.ParquetWriter.__cinit__
TypeError: __cinit__() got an unexpected keyword argument 'engine'
```

While `engine` isn't useful for `GeoDataFrame.to_parquet` right now, it must not be passed along.