### PR TITLE
CI: Run on maintenance branches, update actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, 0.**]
   pull_request:
-    branches: [master]
+    branches: [master, 0.**]
   schedule:
     - cron: "0 0 * * *"
 
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v2
 
   Test:
     needs: Linting
@@ -120,4 +120,4 @@ jobs:
         run: |
           pytest -v --color=yes --doctest-only geopandas --ignore=geopandas/datasets
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2
+      - uses: pre-commit/action@v2.0.3
 
   Test:
     needs: Linting


### PR DESCRIPTION
A bit of CI maintenance:
- Run on pushes and pull-requests to maintenance branches (starting with `0.`)
- Lint job: Update to latest patch version [pre-commit/action](https://github.com/pre-commit/action) v2 of (currently [2.0.3](https://github.com/pre-commit/action/releases/tag/v2.0.3))
- Update [codecov/codecov-action](https://github.com/codecov/codecov-action) to v2