### PR TITLE
DOC: Include links to matplotlib as per #2209

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -563,8 +563,8 @@ def plot_dataframe(
         Size of the resulting matplotlib.figure.Figure. If the argument
         axes is given explicitly, figsize is ignored.
     legend_kwds : dict (default None)
-        Keyword arguments to pass to matplotlib.pyplot.legend() or
-        matplotlib.pyplot.colorbar().
+        Keyword arguments to pass to :func:`matplotlib.pyplot.legend` or
+        :func:`matplotlib.pyplot.colorbar`.
         Additional accepted keywords when `scheme` is specified:
 
         fmt : string


### PR DESCRIPTION
Closes #2209

From what I could see the intersphinx mapping in `conf.py` already includes matplotlib so hpoing this works with no extra change needed.

I wasn't sure how to test to see if this would pass through to the documentation so any advice there would be appreciated.