### PR TITLE
BUG: support null properties in GeoJSON

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -605,7 +605,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 "geometry": shape(feature["geometry"]) if feature["geometry"] else None
             }
             # load properties
-            row.update(feature["properties"])
+            properties = feature["properties"]
+            if properties is None: properties = {}
+            row.update(properties)
             rows.append(row)
         return GeoDataFrame(rows, columns=columns, crs=crs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -606,7 +606,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             }
             # load properties
             properties = feature["properties"]
-            if properties is None: properties = {}
+            if properties is None:
+                properties = {}
             row.update(properties)
             rows.append(row)
         return GeoDataFrame(rows, columns=columns, crs=crs)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -606,6 +606,99 @@ class TestDataFrame:
         )
         assert_frame_equal(expected, result)
 
+    def test_from_features_empty_properties(self):
+        geojson_properties_object = '''{
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      11.3456529378891,
+                      46.49461446367692
+                    ],
+                    [
+                      11.345674395561216,
+                      46.494097442978195
+                    ],
+                    [
+                      11.346918940544128,
+                      46.49385370294394
+                    ],
+                    [
+                      11.347616314888,
+                      46.4938352377453
+                    ],
+                    [
+                      11.347514390945435,
+                      46.49466985846028
+                    ],
+                    [
+                      11.3456529378891,
+                      46.49461446367692
+                    ]
+                  ]
+                ]
+              }
+            }
+          ]
+        }'''
+
+        geojson_properties_null = '''{
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "properties": null,
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      11.3456529378891,
+                      46.49461446367692
+                    ],
+                    [
+                      11.345674395561216,
+                      46.494097442978195
+                    ],
+                    [
+                      11.346918940544128,
+                      46.49385370294394
+                    ],
+                    [
+                      11.347616314888,
+                      46.4938352377453
+                    ],
+                    [
+                      11.347514390945435,
+                      46.49466985846028
+                    ],
+                    [
+                      11.3456529378891,
+                      46.49461446367692
+                    ]
+                  ]
+                ]
+              }
+            }
+          ]
+        }'''
+
+        # geoJSON with empty properties
+        gjson_po = json.loads(geojson_properties_object)
+        gdf1 = GeoDataFrame.from_features(gjson_po)
+
+        # geoJSON with null properties
+        gjson_null = json.loads(geojson_properties_null)
+        gdf2 = GeoDataFrame.from_features(gjson_null)
+
+        assert_frame_equal(gdf1, gdf2)
+
     def test_from_features_geom_interface_feature(self):
         class Placemark(object):
             def __init__(self, geom, val):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -587,14 +587,14 @@ class TestDataFrame:
         p2 = Point(2, 2)
         f2 = {
             "type": "Feature",
-            "properties": None,
+            "properties": {"b": 1},
             "geometry": p2.__geo_interface__,
         }
 
         p3 = Point(3, 3)
         f3 = {
             "type": "Feature",
-            "properties": {"a": 2},
+            "properties": None,
             "geometry": p3.__geo_interface__,
         }
 
@@ -602,7 +602,7 @@ class TestDataFrame:
 
         result = df[["a", "b"]]
         expected = pd.DataFrame.from_dict(
-            [{"a": 0, "b": np.nan}, {"a": np.nan, "b": np.nan}, {"a": 2, "b": np.nan}]
+            [{"a": 0, "b": np.nan}, {"a": np.nan, "b": 1}, {"a": np.nan, "b": np.nan}]
         )
         assert_frame_equal(expected, result)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -587,7 +587,7 @@ class TestDataFrame:
         p2 = Point(2, 2)
         f2 = {
             "type": "Feature",
-            "properties": 'null',
+            "properties": None,
             "geometry": p2.__geo_interface__,
         }
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -587,7 +587,7 @@ class TestDataFrame:
         p2 = Point(2, 2)
         f2 = {
             "type": "Feature",
-            "properties": {"b": 1},
+            "properties": 'null',
             "geometry": p2.__geo_interface__,
         }
 
@@ -602,7 +602,7 @@ class TestDataFrame:
 
         result = df[["a", "b"]]
         expected = pd.DataFrame.from_dict(
-            [{"a": 0, "b": np.nan}, {"a": np.nan, "b": 1}, {"a": 2, "b": np.nan}]
+            [{"a": 0, "b": np.nan}, {"a": np.nan, "b": np.nan}, {"a": 2, "b": np.nan}]
         )
         assert_frame_equal(expected, result)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -607,7 +607,7 @@ class TestDataFrame:
         assert_frame_equal(expected, result)
 
     def test_from_features_empty_properties(self):
-        geojson_properties_object = '''{
+        geojson_properties_object = """{
           "type": "FeatureCollection",
           "features": [
             {
@@ -646,9 +646,9 @@ class TestDataFrame:
               }
             }
           ]
-        }'''
+        }"""
 
-        geojson_properties_null = '''{
+        geojson_properties_null = """{
           "type": "FeatureCollection",
           "features": [
             {
@@ -687,7 +687,7 @@ class TestDataFrame:
               }
             }
           ]
-        }'''
+        }"""
 
         # geoJSON with empty properties
         gjson_po = json.loads(geojson_properties_object)


### PR DESCRIPTION
Fixes https://github.com/geopandas/geopandas/issues/2242

It allows to have `'properties':null` in a geoJSON and still allow to use it with GeoDataFrame.from_features.
The geoJSON spec allows to use null for properties: https://geojson.org/geojson-spec.html https://datatracker.ietf.org/doc/html/rfc7946