### PR TITLE
DOC: Added sjoin_nearest method to examples gallery.

### DIFF
--- a/doc/source/gallery/spatial_joins.ipynb
+++ b/doc/source/gallery/spatial_joins.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Spatial Joins\n",
     "\n",
@@ -12,11 +13,11 @@
     "A common use case might be a spatial join between a point layer and a polygon layer where you want to retain the point geometries and grab the attributes of the intersecting polygons.\n",
     "\n",
     "![illustration](https://web.natur.cuni.cz/~langhamr/lectures/vtfg1/mapinfo_1/about_gis/Image23.gif)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "\n",
     "## Types of spatial joins\n",
@@ -84,21 +85,22 @@
     " 0101000000F0D88AA0E1A4EEBF7052F7E5B115E9BF |    2 |     20\n",
     "(4 rows) \n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Spatial Joins between two GeoDataFrames\n",
     "\n",
     "Let's take a look at how we'd implement these using `GeoPandas`. First, load up the NYC test data into `GeoDataFrames`:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "from shapely.geometry import Point\n",
@@ -118,101 +120,117 @@
     "\n",
     "# Make sure they're using the same projection reference\n",
     "pointdf.crs = polydf.crs"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pointdf"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "polydf"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pointdf.plot()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "polydf.plot()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Joins"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "join_left_df = pointdf.sjoin(polydf, how=\"left\")\n",
     "join_left_df\n",
     "# Note the NaNs where the point did not intersect a boro"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "join_right_df = pointdf.sjoin(polydf, how=\"right\")\n",
     "join_right_df\n",
     "# Note Staten Island is repeated"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "join_inner_df = pointdf.sjoin(polydf, how=\"inner\")\n",
     "join_inner_df\n",
     "# Note the lack of NaNs; dropped anything that didn't intersect"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We're not limited to using the `intersection` binary predicate. Any of the `Shapely` geometry methods that return a Boolean can be used by specifying the `op` kwarg."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pointdf.sjoin(polydf, how=\"left\", op=\"within\")"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also conduct a nearest neighbour join with `sjoin_nearest`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "pointdf.sjoin_nearest(polydf, how=\"left\", distance_col=\"Distances\")\n",
+    "# Note the optional Distances column with computed distances between each point\n",
+    "# and the nearest polydf geometry."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #2211.

Added new example demonstrating `sjoin_nearest` including using the optional parameter `distance_col`.

Not sure why `metadata` and `outputs` names are in a different order in my jupyter JSON but it didn't affect the build locally.