### PR TITLE
DOC: Added sjoin_nearest method to examples gallery.

### DIFF
--- a/doc/source/gallery/spatial_joins.ipynb
+++ b/doc/source/gallery/spatial_joins.ipynb
@@ -213,6 +213,24 @@
    "source": [
     "pointdf.sjoin(polydf, how=\"left\", predicate=\"within\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also conduct a nearest neighbour join with `sjoin_nearest`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pointdf.sjoin_nearest(polydf, how=\"left\", distance_col=\"Distances\")\n",
+    "# Note the optional Distances column with computed distances between each point\n",
+    "# and the nearest polydf geometry."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Closes #2211.

Added new example demonstrating sjoin_nearest including using the optional parameter distance_col.

My addition is:

_Markdown_
> We can also conduct a nearest neighbour join with `sjoin_nearest`.

_Code_
> pointdf.sjoin_nearest(polydf, how="left", distance_col="Distances")
> \# Note the optional Distances column with computed distances between each point
> \# and the nearest polydf geometry.

Output in gallery is (pretty printed in gdf):
>	geometry	value1	value2	index_right	BoroCode	BoroName	Shape_Leng	Shape_Area	Distances
> 0	POINT (913175 120121)	1033296	793054	0	5	Staten Island	330470.010332	1623819823.81	1479.2910924795774
> 1	POINT (932450 139211)	1071661	793239	0	5	Staten Island	330470.010332	1623819823.81	0.0
> 2	POINT (951725 158301)	1110026	793424	0	5	Staten Island	330470.010332	1623819823.81	0.0
> 3	POINT (971000 177391)	1148391	793609	2	3	Brooklyn	741080.523166	1937478507.61	5075.979291209011
> 4	POINT (990275 196481)	1186756	793794	2	3	Brooklyn	741080.523166	1937478507.61	22.36146714547065
> 5	POINT (1009550 215571)	1225121	793979	1	4	Queens	896344.047763	3045212795.2	0.0
> 6	POINT (1028825 234661)	1263486	794164	4	2	Bronx	464392.991824	1186924686.49	0.0
> 7	POINT (1048100 253751)	1301851	794349	4	2	Bronx	464392.991824	1186924686.49	818.9403766556778
> 8	POINT (1067375 272841)	1340216	794534	4	2	Bronx	464392.991824	1186924686.49	25368.108999970773
