### PR TITLE
ENH: expose make_valid and explain_validity as GeoSeries attributes.

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2207,7 +2207,7 @@ GeometryCollection
         https://shapely.readthedocs.io/en/stable/manual.html#diagnostics
 
         example:
-         >>> from shapely.geometry import Polygon,LineString,Point
+            from shapely.geometry import Polygon,LineString,Point
             s = geopandas.GeoSeries(
                 [
                     Polygon([(0, 0), (2, 2), (0, 2)]),
@@ -2269,7 +2269,7 @@ GeometryCollection
         4                              POINT (0.00000 1.00000)
         dtype: geometry
 
-        >>> s.make_valid().explain_validity()
+        s.make_valid().explain_validity()
         ---------------------------
         0    Valid Geometry
         1    Valid Geometry

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2203,7 +2203,8 @@ GeometryCollection
         -------
         Series
 
-        the Shapely Docs: https://shapely.readthedocs.io/en/stable/manual.html#diagnostics
+        the Shapely Docs:
+        https://shapely.readthedocs.io/en/stable/manual.html#diagnostics
 
         example:
          >>> from shapely.geometry import Polygon,LineString,Point
@@ -2228,16 +2229,21 @@ GeometryCollection
         try:
             from shapely.validation import explain_validity
         except ImportError:
-            raise ImportError('cannot import explain_validity from shapely.validation.Please upgrade your shapely')
+            raise ImportError(
+                "cannot import explain_validity from shapely.validation."
+                "Please upgrade your shapely"
+            )
         this = self.geometry
         a_this = GeometryArray(this.values)
         return Series([explain_validity(i) for i in a_this])
 
     def make_valid(self):
         """
-        Returns a valid representation of the GeoSeries, if it is invalid. If it is valid, the raw GeoSeries will be returned.
+        Returns a valid representation of the GeoSeries, if it is invalid.
+        If it is valid, the raw GeoSeries will be returned.
 
-        the Shapely Docs:https://shapely.readthedocs.io/en/stable/manual.html#validation.make_valid
+        the Shapely Docs:
+        https://shapely.readthedocs.io/en/stable/manual.html#validation.make_valid
 
         Returns
         -------
@@ -2276,7 +2282,10 @@ GeometryCollection
             from shapely.validation import make_valid
             from .geoseries import GeoSeries
         except ImportError:
-            raise ImportError('cannot import make_valid from shapely.validation.Please upgrade your shapely')
+            raise ImportError(
+                "cannot import make_valid from shapely.validation."
+                "Please upgrade your shapely"
+            )
         this = self.geometry
         a_this = GeometryArray(this.values)
         return GeoSeries([make_valid(i) for i in a_this])

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2195,6 +2195,92 @@ GeometryCollection
         """
         return _binary_geo("difference", self, other, align)
 
+    def explain_validity(self):
+        """
+        Returns a string explaining the validity or invalidity of the object.
+
+        Returns
+        -------
+        Series
+
+        the Shapely Docs: https://shapely.readthedocs.io/en/stable/manual.html#diagnostics
+
+        example:
+         >>> from shapely.geometry import Polygon,LineString,Point
+            s = geopandas.GeoSeries(
+                [
+                    Polygon([(0, 0), (2, 2), (0, 2)]),
+                    Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
+                    LineString([(0, 0), (2, 2)]),
+                    LineString([(2, 0), (0, 2)]),
+                    Point(0, 1),
+                ],
+            )
+            s.explain_validity()
+            --------------------------------
+            0            Valid Geometry
+            1    Self-intersection[0 0]
+            2            Valid Geometry
+            3            Valid Geometry
+            4            Valid Geometry
+            dtype: object
+        """
+        try:
+            from shapely.validation import explain_validity
+        except ImportError:
+            raise ImportError('cannot import explain_validity from shapely.validation.Please upgrade your shapely')
+        this = self.geometry
+        a_this = GeometryArray(this.values)
+        return Series([explain_validity(i) for i in a_this])
+
+    def make_valid(self):
+        """
+        Returns a valid representation of the GeoSeries, if it is invalid. If it is valid, the raw GeoSeries will be returned.
+
+        the Shapely Docs:https://shapely.readthedocs.io/en/stable/manual.html#validation.make_valid
+
+        Returns
+        -------
+        GeoSeries
+
+        example:
+        from shapely.geometry import Polygon,LineString,Point
+        s = geopandas.GeoSeries(
+                [
+                    Polygon([(0, 0), (2, 2), (0, 2)]),
+                    Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
+                    LineString([(0, 0), (2, 2)]),
+                    LineString([(2, 0), (0, 2)]),
+                    Point(0, 1),
+                ],
+            )
+        s.make_valid()
+        ---------------------------
+        0    POLYGON ((0.00000 0.00000, 2.00000 2.00000, 0....
+        1    MULTILINESTRING ((0.00000 0.00000, 2.00000 2.0...
+        2        LINESTRING (0.00000 0.00000, 2.00000 2.00000)
+        3        LINESTRING (2.00000 0.00000, 0.00000 2.00000)
+        4                              POINT (0.00000 1.00000)
+        dtype: geometry
+
+        >>> s.make_valid().explain_validity()
+        ---------------------------
+        0    Valid Geometry
+        1    Valid Geometry
+        2    Valid Geometry
+        3    Valid Geometry
+        4    Valid Geometry
+        dtype: object
+        """
+        try:
+            from shapely.validation import make_valid
+            from .geoseries import GeoSeries
+        except ImportError:
+            raise ImportError('cannot import make_valid from shapely.validation.Please upgrade your shapely')
+        this = self.geometry
+        a_this = GeometryArray(this.values)
+        return GeoSeries([make_valid(i) for i in a_this])
+
     def symmetric_difference(self, other, align=True):
         """Returns a ``GeoSeries`` of the symmetric difference of points in
         each aligned geometry with `other`.

--- a/geopandas/tests/test_make_valid_and_explain.py
+++ b/geopandas/tests/test_make_valid_and_explain.py
@@ -13,7 +13,7 @@ def test_explain():
         ],
     )
     result = s.explain_validity()
-    assert result[1] != 'Valid Geometry'
+    assert result[1] != "Valid Geometry"
 
 
 def test_make_valid():
@@ -28,4 +28,4 @@ def test_make_valid():
     )
     sn = s.make_valid()
     result = sn.explain_validity()
-    assert result[1] == 'Valid Geometry'
+    assert result[1] == "Valid Geometry"

--- a/geopandas/tests/test_make_valid_and_explain.py
+++ b/geopandas/tests/test_make_valid_and_explain.py
@@ -1,0 +1,31 @@
+from shapely.geometry import Polygon, LineString, Point
+import geopandas
+
+
+def test_explain():
+    s = geopandas.GeoSeries(
+        [
+            Polygon([(0, 0), (2, 2), (0, 2)]),
+            Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
+            LineString([(0, 0), (2, 2)]),
+            LineString([(2, 0), (0, 2)]),
+            Point(0, 1),
+        ],
+    )
+    result = s.explain_validity()
+    assert result[1] != 'Valid Geometry'
+
+
+def test_make_valid():
+    s = geopandas.GeoSeries(
+        [
+            Polygon([(0, 0), (2, 2), (0, 2)]),
+            Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
+            LineString([(0, 0), (2, 2)]),
+            LineString([(2, 0), (0, 2)]),
+            Point(0, 1),
+        ],
+    )
+    sn = s.make_valid()
+    result = sn.explain_validity()
+    assert result[1] == 'Valid Geometry'

--- a/geopandas/tests/test_make_valid_and_explain.py
+++ b/geopandas/tests/test_make_valid_and_explain.py
@@ -12,8 +12,11 @@ def test_explain():
             Point(0, 1),
         ],
     )
-    result = s.explain_validity()
-    assert result[1] != "Valid Geometry"
+    try:
+        result = s.explain_validity()
+        assert result[1] != "Valid Geometry"
+    except ImportError:
+        print("shapely version must great than 1.8.0")
 
 
 def test_make_valid():
@@ -26,6 +29,9 @@ def test_make_valid():
             Point(0, 1),
         ],
     )
-    sn = s.make_valid()
-    result = sn.explain_validity()
-    assert result[1] == "Valid Geometry"
+    try:
+        sn = s.make_valid()
+        result = sn.explain_validity()
+        assert result[1] == "Valid Geometry"
+    except ImportError:
+        print("shapely version must great than 1.8.0")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 fiona>=1.8
 pandas>=0.25
 pyproj>=2.2.0
-shapely>=1.6
+shapely>=1.8
 
 # geodatabase access
 psycopg2>=2.5.1


### PR DESCRIPTION
feature 1:
    Returns a string explaining the validity or invalidity of the object.
example:
  >>> from shapely.geometry import Polygon,LineString,Point
  >>> s = geopandas.GeoSeries(
  ...                 [
  ...                     Polygon([(0, 0), (2, 2), (0, 2)]),
  ...                     Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
  ...                     LineString([(0, 0), (2, 2)]),
  ...                     LineString([(2, 0), (0, 2)]),
  ...                     Point(0, 1),
  ...                 ],
  ...             )
  >>> s.explain_validity()
  0            Valid Geometry
  1    Self-intersection[0 0]
  2            Valid Geometry
  3            Valid Geometry
  4            Valid Geometry
  dtype: object

feature 2:
    Returns a valid representation of the GeoSeries, if it is invalid. If it is valid, the raw GeoSeries will be returned.
example:
  >>> from shapely.geometry import Polygon,LineString,Point
  >>> s = geopandas.GeoSeries(
  ...                 [
  ...                     Polygon([(0, 0), (2, 2), (0, 2)]),
  ...                     Polygon([(0, 0), (2, 2), (0, 2), (2, 2)]),
  ...                     LineString([(0, 0), (2, 2)]),
  ...                     LineString([(2, 0), (0, 2)]),
  ...                     Point(0, 1),
  ...                 ],
  ...             )
>>> s.make_valid()
0    POLYGON ((0.00000 0.00000, 2.00000 2.00000, 0....
1    MULTILINESTRING ((0.00000 0.00000, 2.00000 2.0...
2        LINESTRING (0.00000 0.00000, 2.00000 2.00000)
3        LINESTRING (2.00000 0.00000, 0.00000 2.00000)
4                              POINT (0.00000 1.00000)
dtype: geometry
>>> s.make_valid().explain_validity()
0    Valid Geometry
1    Valid Geometry
2    Valid Geometry
3    Valid Geometry
4    Valid Geometry
dtype: object

