### PR TITLE
CI: temporarily use released Shapely in the dev build

### DIFF
--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -25,8 +25,8 @@ dependencies:
     - geopy
     - mapclassify>=2.4.0
     # dev versions of packages
-    - --pre --upgrade --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-    - --pre --upgrade --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
+    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
     - git+https://github.com/matplotlib/matplotlib.git@main
     # - git+https://github.com/Toblerity/Shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master

--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.8
   - cython
   # required
+  - shapely
   - fiona
   - pyproj
   - geos
@@ -27,7 +28,7 @@ dependencies:
     - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
     - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
     - git+https://github.com/matplotlib/matplotlib.git@main
-    - git+https://github.com/Toblerity/Shapely.git@main
+    # - git+https://github.com/Toblerity/Shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@main
     - git+https://github.com/geopandas/xyzservices.git@main

--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -25,8 +25,8 @@ dependencies:
     - geopy
     - mapclassify>=2.4.0
     # dev versions of packages
-    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
-    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
+    - --pre --upgrade --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy
+    - --pre --upgrade --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas
     - git+https://github.com/matplotlib/matplotlib.git@main
     # - git+https://github.com/Toblerity/Shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master


### PR DESCRIPTION
Until https://github.com/geopandas/geopandas/pull/2275 is done, this will otherwise always fail the dev build, which makes we don't really easily notice any other failure.