### PR TITLE
REGR: fix bug in apply when returning a series

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1408,7 +1408,10 @@ individually so that features may have different properties
             func, axis=axis, raw=raw, result_type=result_type, args=args, **kwargs
         )
         # Reconstruct gdf if it was lost by apply
-        if self._geometry_column_name in result.columns:
+        if (
+            isinstance(result, DataFrame)
+            and self._geometry_column_name in result.columns
+        ):
             # axis=1 apply will split GeometryDType to object, try and cast back
             try:
                 result = result.set_geometry(self._geometry_column_name)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -607,6 +607,9 @@ def test_df_apply_returning_series(df):
     # https://github.com/geopandas/geopandas/issues/2283
     result = df.apply(lambda row: row.geometry, axis=1)
     assert_geoseries_equal(result, df.geometry, check_crs=False)
+    
+    result = df.apply(lambda row: row.value1, axis=1)
+    assert_series_equal(result, df["value1"])
 
 
 @pytest.mark.skipif(not compat.PANDAS_GE_10, reason="attrs introduced in pandas 1.0")

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -605,7 +605,8 @@ def test_apply_preserves_geom_col_name(df):
 
 def test_df_apply_returning_series(df):
     # https://github.com/geopandas/geopandas/issues/2283
-    df.apply(lambda row: row.geometry, axis=1)
+    result = df.apply(lambda row: row.geometry, axis=1)
+    assert_geoseries_equal(result, df.geometry, check_crs=False)
 
 
 @pytest.mark.skipif(not compat.PANDAS_GE_10, reason="attrs introduced in pandas 1.0")

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -607,7 +607,7 @@ def test_df_apply_returning_series(df):
     # https://github.com/geopandas/geopandas/issues/2283
     result = df.apply(lambda row: row.geometry, axis=1)
     assert_geoseries_equal(result, df.geometry, check_crs=False)
-    
+
     result = df.apply(lambda row: row.value1, axis=1)
     assert_series_equal(result, df["value1"])
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -603,6 +603,11 @@ def test_apply_preserves_geom_col_name(df):
     assert result.geometry.name == "geom"
 
 
+def test_df_apply_returning_series(df):
+    # https://github.com/geopandas/geopandas/issues/2283
+    df.apply(lambda row: row.geometry, axis=1)
+
+
 @pytest.mark.skipif(not compat.PANDAS_GE_10, reason="attrs introduced in pandas 1.0")
 def test_preserve_attrs(df):
     # https://github.com/geopandas/geopandas/issues/1654

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -609,7 +609,7 @@ def test_df_apply_returning_series(df):
     assert_geoseries_equal(result, df.geometry, check_crs=False)
 
     result = df.apply(lambda row: row.value1, axis=1)
-    assert_series_equal(result, df["value1"])
+    assert_series_equal(result, df["value1"].rename(None))
 
 
 @pytest.mark.skipif(not compat.PANDAS_GE_10, reason="attrs introduced in pandas 1.0")


### PR DESCRIPTION
Closes #2283 
> it's good that we didn't end up merging that just before the 0.10 release :)

Sorry about this and the other bug, hopefully there's not more.

This one at least is easy to fix, basically exactly what @jorisvandenbossche suggested. The one change is doing an isinstance check on `DataFrame` rather than `GeoDataFrame` -  to get `test_crs.py::test_apply_geodataframe` to work. I suppose this was probably why that check got taken out when I did #2060, it's still a pretty big oversight by me. 

I'm now looking into why that GeoDataFrame -> DataFrame change is neccessary - it means the raw results of apply in pandas aren't preserving the GeoDataFrame although it used to, which probably isn't great because it means the geometry column is becoming an object type column as an intermediate step.
