### PR TITLE
TST: fix test_value_counts test for pandas 1.4

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -19,6 +19,7 @@ PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("1.0.0")
 PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0")
 PANDAS_GE_115 = str(pd.__version__) >= LooseVersion("1.1.5")
 PANDAS_GE_12 = str(pd.__version__) >= LooseVersion("1.2.0")
+PANDAS_GE_20 = str(pd.__version__) > LooseVersion("1.4.0.dev")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -19,7 +19,7 @@ PANDAS_GE_10 = str(pd.__version__) >= LooseVersion("1.0.0")
 PANDAS_GE_11 = str(pd.__version__) >= LooseVersion("1.1.0")
 PANDAS_GE_115 = str(pd.__version__) >= LooseVersion("1.1.5")
 PANDAS_GE_12 = str(pd.__version__) >= LooseVersion("1.2.0")
-PANDAS_GE_20 = str(pd.__version__) > LooseVersion("1.4.0.dev")
+PANDAS_GE_14 = str(pd.__version__) >= LooseVersion("1.4.0")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -463,7 +463,7 @@ def test_value_counts():
     s2 = GeoSeries([Point(0, 0), Point(1, 1), Point(0, 0)], crs="EPSG:4326")
     res2 = s2.value_counts()
     assert_series_equal(res2, exp)
-    if compat.PANDAS_GE_20:
+    if compat.PANDAS_GE_14:
         # TODO should/ can we fix CRS being lost
         assert s2.value_counts().index.array.crs is None
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -446,7 +446,7 @@ def test_unique():
 
 
 def pd20_compat_index(index):
-    if compat.PANDAS_GE_20:
+    if compat.PANDAS_GE_14:
         return from_shapely(index)
     else:
         return index

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -445,7 +445,7 @@ def test_unique():
     assert_array_equal(s.unique(), exp)
 
 
-def pd20_compat_index(index):
+def pd14_compat_index(index):
     if compat.PANDAS_GE_14:
         return from_shapely(index)
     else:
@@ -457,7 +457,7 @@ def test_value_counts():
     s = GeoSeries([Point(0, 0), Point(1, 1), Point(0, 0)])
     res = s.value_counts()
     with compat.ignore_shapely2_warnings():
-        exp = pd.Series([2, 1], index=pd20_compat_index([Point(0, 0), Point(1, 1)]))
+        exp = pd.Series([2, 1], index=pd14_compat_index([Point(0, 0), Point(1, 1)]))
     assert_series_equal(res, exp)
     # Check crs doesn't make a difference - note it is not kept in output index anyway
     s2 = GeoSeries([Point(0, 0), Point(1, 1), Point(0, 0)], crs="EPSG:4326")
@@ -470,7 +470,7 @@ def test_value_counts():
     # check mixed geometry
     s3 = GeoSeries([Point(0, 0), LineString([[1, 1], [2, 2]]), Point(0, 0)])
     res3 = s3.value_counts()
-    index = pd20_compat_index([Point(0, 0), LineString([[1, 1], [2, 2]])])
+    index = pd14_compat_index([Point(0, 0), LineString([[1, 1], [2, 2]])])
     with compat.ignore_shapely2_warnings():
         exp3 = pd.Series([2, 1], index=index)
     assert_series_equal(res3, exp3)
@@ -479,10 +479,10 @@ def test_value_counts():
     s4 = GeoSeries([Point(0, 0), None, Point(0, 0)])
     res4 = s4.value_counts(dropna=True)
     with compat.ignore_shapely2_warnings():
-        exp4_dropna = pd.Series([2], index=pd20_compat_index([Point(0, 0)]))
+        exp4_dropna = pd.Series([2], index=pd14_compat_index([Point(0, 0)]))
     assert_series_equal(res4, exp4_dropna)
     with compat.ignore_shapely2_warnings():
-        exp4_keepna = pd.Series([2, 1], index=pd20_compat_index([Point(0, 0), None]))
+        exp4_keepna = pd.Series([2, 1], index=pd14_compat_index([Point(0, 0), None]))
     res4_keepna = s4.value_counts(dropna=False)
     assert_series_equal(res4_keepna, exp4_keepna)
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -445,33 +445,44 @@ def test_unique():
     assert_array_equal(s.unique(), exp)
 
 
+def pd20_compat_index(index):
+    if compat.PANDAS_GE_20:
+        return from_shapely(index)
+    else:
+        return index
+
+
 def test_value_counts():
     # each object is considered unique
     s = GeoSeries([Point(0, 0), Point(1, 1), Point(0, 0)])
     res = s.value_counts()
     with compat.ignore_shapely2_warnings():
-        exp = pd.Series([2, 1], index=[Point(0, 0), Point(1, 1)])
+        exp = pd.Series([2, 1], index=pd20_compat_index([Point(0, 0), Point(1, 1)]))
     assert_series_equal(res, exp)
     # Check crs doesn't make a difference - note it is not kept in output index anyway
     s2 = GeoSeries([Point(0, 0), Point(1, 1), Point(0, 0)], crs="EPSG:4326")
     res2 = s2.value_counts()
     assert_series_equal(res2, exp)
+    if compat.PANDAS_GE_20:
+        # TODO should/ can we fix CRS being lost
+        assert s2.value_counts().index.array.crs is None
 
     # check mixed geometry
     s3 = GeoSeries([Point(0, 0), LineString([[1, 1], [2, 2]]), Point(0, 0)])
     res3 = s3.value_counts()
+    index = pd20_compat_index([Point(0, 0), LineString([[1, 1], [2, 2]])])
     with compat.ignore_shapely2_warnings():
-        exp3 = pd.Series([2, 1], index=[Point(0, 0), LineString([[1, 1], [2, 2]])])
+        exp3 = pd.Series([2, 1], index=index)
     assert_series_equal(res3, exp3)
 
     # check None is handled
     s4 = GeoSeries([Point(0, 0), None, Point(0, 0)])
     res4 = s4.value_counts(dropna=True)
     with compat.ignore_shapely2_warnings():
-        exp4_dropna = pd.Series([2], index=[Point(0, 0)])
+        exp4_dropna = pd.Series([2], index=pd20_compat_index([Point(0, 0)]))
     assert_series_equal(res4, exp4_dropna)
     with compat.ignore_shapely2_warnings():
-        exp4_keepna = pd.Series([2, 1], index=[Point(0, 0), None])
+        exp4_keepna = pd.Series([2, 1], index=pd20_compat_index([Point(0, 0), None]))
     res4_keepna = s4.value_counts(dropna=False)
     assert_series_equal(res4_keepna, exp4_keepna)
 


### PR DESCRIPTION
Fixes #2287.
Wasn't sure on the naming convention for the LooseVersion guard, so I've just copied the logic from https://github.com/geopandas/geopandas/pull/1658/files and hoped that's okay.

There is a separate issue that the geometryarray that is now stored in the index loses CRS info, but have kept this focused to fixing CI.