### PR TITLE
CI: diversify pandas versions in the test environments

### DIFF
--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   # required
-  - pandas=1.3.2  # temporary pin because 1.3.3 has regression for overlay (GH2101)
+  - pandas=1.2
   - shapely
   - fiona
   - pyproj

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.9
   # required
-  - pandas
+  - pandas=1.3
   - shapely
   - fiona
   - pyproj


### PR DESCRIPTION
In all the "latest-conda-forge" ci envs, we are not pinning pandas and thus getting the latest (except for an outdated pin in the 38 env), so all were using pandas 1.3.x. 
I added pins for pandas 1.2 and 1.3 for the py-38 and 39 envs (and then the py-310 env will get the latest pandas 1.4 once that is out). And we already have a specific env that pins to 1.0 and 0.25 (that last one we could probably remove if we bump the minimum required version)