### PR TITLE
BUG: GeoDataFrame constructor set `copy=true` if `copy` is not set and `data` is a `DataFrame`.

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -133,7 +133,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
         with compat.ignore_shapely2_warnings():
-            if kwargs.get("copy") is None and not isinstance(data, GeoDataFrame):
+            if kwargs.get("copy") is None and type(data) == DataFrame:
                 kwargs.update(copy=True)
             super().__init__(data, *args, **kwargs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -133,7 +133,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
         with compat.ignore_shapely2_warnings():
-            if kwargs.get("copy") is None and isinstance(data, DataFrame):
+            if kwargs.get("copy") is None and not isinstance(data, GeoDataFrame):
                 kwargs.update(copy=True)
             super().__init__(data, *args, **kwargs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -133,7 +133,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
         with compat.ignore_shapely2_warnings():
-            if kwargs.get("copy") is None and type(data) == DataFrame:
+            if (
+                kwargs.get("copy") is None
+                and isinstance(data, DataFrame)
+                and not isinstance(data, GeoDataFrame)
+            ):
                 kwargs.update(copy=True)
             super().__init__(data, *args, **kwargs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -133,6 +133,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
         with compat.ignore_shapely2_warnings():
+            if kwargs.get('copy') is None and isinstance(data, DataFrame):
+                kwargs.update(copy=True)
             super().__init__(data, *args, **kwargs)
 
         # need to set this before calling self['geometry'], because

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -133,7 +133,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
         with compat.ignore_shapely2_warnings():
-            if kwargs.get('copy') is None and isinstance(data, DataFrame):
+            if kwargs.get("copy") is None and isinstance(data, DataFrame):
                 kwargs.update(copy=True)
             super().__init__(data, *args, **kwargs)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -676,6 +676,27 @@ class TestDataFrame:
         with pytest.raises(ValueError):
             df.set_geometry("location", inplace=True)
 
+    def test_dataframe_not_manipulated(self):
+        df = pd.DataFrame(
+            {
+                "A": range(len(self.df)),
+                "latitude": self.df.geometry.centroid.y,
+                "longitude": self.df.geometry.centroid.x,
+            },
+            index=self.df.index,
+        )
+        df_copy = df.copy()
+        gf = GeoDataFrame(
+            df,
+            geometry=points_from_xy(df["longitude"], df["latitude"]),
+            crs=self.df.crs,
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert "geometry" not in df
+        pd.testing.assert_frame_equal(df, df_copy)
+        assert isinstance(gf, GeoDataFrame)
+        assert hasattr(gf, "geometry")
+
     def test_geodataframe_geointerface(self):
         assert self.df.__geo_interface__["type"] == "FeatureCollection"
         assert len(self.df.__geo_interface__["features"]) == self.df.shape[0]


### PR DESCRIPTION
This PR is very similar to https://github.com/geopandas/geopandas/pull/1324 and fixes https://github.com/geopandas/geopandas/issues/2301 (as well as duplicates https://github.com/geopandas/geopandas/issues/1804, https://github.com/geopandas/geopandas/issues/2017, https://github.com/geopandas/geopandas/issues/2186, and https://github.com/geopandas/geopandas/issues/2301).

In the spirit of [this logic](https://github.com/pandas-dev/pandas/blob/ab42f85f192ab054a18f94825ced1bb4c1ab7d3f/pandas/core/frame.py#L616-L629), if  a  `DataFrame` is passed to the `GeoDataFrame` constructor, and the `copy` kwarg is not explicitly set by the user, then `copy=True` is set so that the input is not modified.