### PR TITLE
DOC: fixup rst formatting in dissolve docstring

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1477,6 +1477,7 @@ individually so that features may have different properties
             Aggregation function for manipulation of data associated
             with each group. Passed to pandas `groupby.agg` method.
             Accepted combinations are:
+
             - function
             - string function name
             - list of functions and/or function names, e.g. [np.sum, 'mean']


### PR DESCRIPTION
Tiny follow-up on https://github.com/geopandas/geopandas/pull/2303, restructuredtext is picky about having a whitespace line before a list