### PR TITLE
CI: update use of deprecated iteritems to avoid warnings

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -913,7 +913,7 @@ class GeoSeries(GeoPandasBase, Series):
 
         index = []
         geometries = []
-        for idx, s in self.geometry.iteritems():
+        for idx, s in self.geometry.items():
             if s.type.startswith("Multi") or s.type == "GeometryCollection":
                 geoms = s.geoms
                 idxs = [(idx, i) for i in range(len(geoms))]

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -316,7 +316,7 @@ def assert_geodataframe_equal(
     )
 
     # geometry comparison
-    for col, dtype in left.dtypes.iteritems():
+    for col, dtype in left.dtypes.items():
         if isinstance(dtype, GeometryDtype):
             assert_geoseries_equal(
                 left[col],


### PR DESCRIPTION
Should fix the failing 310-dev environment, we're just now getting warnings from https://github.com/pandas-dev/pandas/pull/45321

(the change in geoseries is not required to fix CI, but seemed sensible to get all at once)

I also noticed setting up a local environment that this environment doesn't actually seem to use numpy main, despite in being in the yaml:
https://github.com/geopandas/geopandas/blob/cebb5873d04a81bf37376dfb5d4b2adcfe9d87af/ci/envs/310-dev.yaml#L29

I'll make that a separate issue though.