### PR TITLE
TST: Fix first_dissolve not picked up by pytest

### DIFF
--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -71,7 +71,7 @@ def test_dissolve_retains_nonexisting_crs(nybb_polydf):
     assert test.crs is None
 
 
-def first_dissolve(nybb_polydf, first):
+def test_first_dissolve(nybb_polydf, first):
     test = nybb_polydf.dissolve("manhattan_bronx")
     assert_frame_equal(first, test, check_column_type=False)
 


### PR DESCRIPTION
The test function name needs to start with `test_` to be recognized by `pytest`.

This test was originally named correctly, but was apparently renamed by accident in PR#654.