### PR TITLE
TST: skip pandas groupby test if no sindex available

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -558,6 +558,7 @@ def test_groupby_groups(df):
     assert_frame_equal(res, exp)
 
 
+@pytest.mark.skip_no_sindex
 @pytest.mark.skipif(
     compat.PANDAS_GE_13 and not compat.PANDAS_GE_14,
     reason="this was broken in pandas 1.3.5 (GH-2294)",


### PR DESCRIPTION
This should fix the CI (this test didn't run on pandas 1.3, and now pandas 1.4 is released the test started running on the minimal build, which doesn't have rtree or pygeos)