### PR TITLE
REF: use composition instead of sublcassing pygeos.STRtree for SpatialIndex

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -633,7 +633,7 @@ if compat.HAS_PYGEOS:
 
     _PYGEOS_PREDICATES = {p.name for p in pygeos.strtree.BinaryPredicate} | set([None])
 
-    class PyGEOSSTRTreeIndex(pygeos.STRtree):
+    class PyGEOSSTRTreeIndex(BaseSpatialIndex):
         """A simple wrapper around pygeos's STRTree.
 
 
@@ -651,7 +651,7 @@ if compat.HAS_PYGEOS:
             non_empty = geometry.copy()
             non_empty[pygeos.is_empty(non_empty)] = None
             # set empty geometries to None to maintain indexing
-            super().__init__(non_empty)
+            self._tree = pygeos.STRtree(non_empty)
             # store geometries, including empty geometries for user access
             self.geometries = geometry.copy()
 
@@ -687,7 +687,7 @@ if compat.HAS_PYGEOS:
             if isinstance(geometry, BaseGeometry):
                 geometry = array._shapely_to_geom(geometry)
 
-            matches = super().query(geometry=geometry, predicate=predicate)
+            matches = self._tree.query(geometry=geometry, predicate=predicate)
 
             if sort:
                 return np.sort(matches)
@@ -740,7 +740,7 @@ if compat.HAS_PYGEOS:
 
             geometry = self._as_geometry_array(geometry)
 
-            res = super().query_bulk(geometry, predicate)
+            res = self._tree.query_bulk(geometry, predicate)
 
             if sort:
                 # sort by first array (geometry) and then second (tree)
@@ -760,9 +760,9 @@ if compat.HAS_PYGEOS:
             geometry = self._as_geometry_array(geometry)
 
             if not return_all and max_distance is None and not return_distance:
-                return super().nearest(geometry)
+                return self._tree.nearest(geometry)
 
-            result = super().nearest_all(
+            result = self._tree.nearest_all(
                 geometry, max_distance=max_distance, return_distance=return_distance
             )
             if return_distance:
@@ -804,9 +804,9 @@ if compat.HAS_PYGEOS:
 
             # need to convert tuple of bounds to a geometry object
             if len(coordinates) == 4:
-                indexes = super().query(pygeos.box(*coordinates))
+                indexes = self._tree.query(pygeos.box(*coordinates))
             elif len(coordinates) == 2:
-                indexes = super().query(pygeos.points(*coordinates))
+                indexes = self._tree.query(pygeos.points(*coordinates))
             else:
                 raise TypeError(
                     "Invalid coordinates, must be iterable in format "
@@ -819,9 +819,12 @@ if compat.HAS_PYGEOS:
         @property
         @doc(BaseSpatialIndex.size)
         def size(self):
-            return len(self)
+            return len(self._tree)
 
         @property
         @doc(BaseSpatialIndex.is_empty)
         def is_empty(self):
-            return len(self) == 0
+            return len(self._tree) == 0
+
+        def __len__(self):
+            return len(self._tree)


### PR DESCRIPTION
The current `sindex` that is used when pygeos is installed, `PyGEOSSTRTreeIndex`, subclasses the pygeos.STRtree. But we also have a `BaseSpatialIndex` class ourselves that defines the interface. 

Considering that the STRtree migrated from pygeos to shapely will change its API a bit, I was thinking that in general it seems better and more robust that we don't subclass here, but rather use composition (something we will need to do for `shapely.STRtree` anyway, if we want to keep the `.sindex` interface stable). 
In general this seems the better way to do this if we would allow for multiple SpatialIndex classes backed by different implementations (xref https://github.com/geopandas/geopandas/issues/1344)

cc @adriangb