### PR TITLE
Remove warning about no stability promise in Parquet/Feather export

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -174,21 +174,6 @@ def _geopandas_to_arrow(df, index=None):
     """
     from pyarrow import Table
 
-    warnings.warn(
-        "this is an initial implementation of Parquet/Feather file support and "
-        "associated metadata.  This is tracking version 0.1.0 of the metadata "
-        "specification at "
-        "https://github.com/geopandas/geo-arrow-spec\n\n"
-        "This metadata specification does not yet make stability promises.  "
-        "We do not yet recommend using this in a production setting unless you "
-        "are able to rewrite your Parquet/Feather files.\n\n"
-        "To further ignore this warning, you can do: \n"
-        "import warnings; warnings.filterwarnings('ignore', "
-        "message='.*initial implementation of Parquet.*')",
-        UserWarning,
-        stacklevel=4,
-    )
-
     _validate_dataframe(df)
 
     # create geo metadata before altering incoming data frame

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -198,15 +198,10 @@ def _to_parquet(df, path, index=None, compression="snappy", **kwargs):
 
     Requires 'pyarrow'.
 
-    WARNING: this is an initial implementation of Parquet file support and
+    This is an initial implementation of Parquet file support and
     associated metadata.  This is tracking version 0.1.0 of the metadata
     specification at:
     https://github.com/geopandas/geo-arrow-spec
-
-    This metadata specification does not yet make stability promises.  As such,
-    we do not yet recommend using this in a production setting unless you are
-    able to rewrite your Parquet files.
-
 
     .. versionadded:: 0.8
 
@@ -241,14 +236,10 @@ def _to_feather(df, path, index=None, compression=None, **kwargs):
 
     Requires 'pyarrow' >= 0.17.
 
-    WARNING: this is an initial implementation of Feather file support and
+    This is an initial implementation of Feather file support and
     associated metadata.  This is tracking version 0.1.0 of the metadata
     specification at:
     https://github.com/geopandas/geo-arrow-spec
-
-    This metadata specification does not yet make stability promises.  As such,
-    we do not yet recommend using this in a production setting unless you are
-    able to rewrite your Feather files.
 
     .. versionadded:: 0.8
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -28,9 +28,6 @@ from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 # Skip all tests in this module if pyarrow is not available
 pyarrow = pytest.importorskip("pyarrow")
 
-# TEMPORARY: hide warning from to_parquet
-pytestmark = pytest.mark.filterwarnings("ignore:.*initial implementation of Parquet.*")
-
 
 @pytest.fixture(
     params=[
@@ -217,9 +214,7 @@ def test_roundtrip(tmpdir, file_format, test_dataset):
 
     filename = os.path.join(str(tmpdir), "test.pq")
 
-    # TEMP: Initial implementation should raise a UserWarning
-    with pytest.warns(UserWarning, match="initial implementation"):
-        writer(df, filename)
+    writer(df, filename)
 
     assert os.path.exists(filename)
 


### PR DESCRIPTION
This came up in https://github.com/geopandas/dask-geopandas/issues/138

While I wouldn't consider the spec stable (there are some discussions in https://github.com/opengeospatial/cdw-geo/ as well), I think at this point it is already used enough to say that we will keep some back-compat layer in geopandas to be able to read files written with the current pandas, even if the metadata spec would still change? (after all, the spec is versioned, and should allow this). 
If we want to make this guarantee, I think it should be OK to remove the warning? 

cc @brendan-ward 