### PR TITLE
BUG: Fix error on .[xyz] on GeoSeries with empty points: return nan

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -879,10 +879,14 @@ class GeometryArray(ExtensionArray):
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            nonempty = ~self.is_empty
-            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
-            coords[nonempty] = vectorized.get_x(self.data[nonempty])
-            return coords
+            empty = self.is_empty
+            if empty.any():
+                nonempty = ~empty
+                coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+                coords[nonempty] = vectorized.get_x(self.data[nonempty])
+                return coords
+            else:
+                return vectorized.get_x(self.data)
         else:
             message = "x attribute access only provided for Point geometries"
             raise ValueError(message)
@@ -891,10 +895,14 @@ class GeometryArray(ExtensionArray):
     def y(self):
         """Return the y location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            nonempty = ~self.is_empty
-            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
-            coords[nonempty] = vectorized.get_y(self.data[nonempty])
-            return coords
+            empty = self.is_empty
+            if empty.any():
+                nonempty = ~empty
+                coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+                coords[nonempty] = vectorized.get_y(self.data[nonempty])
+                return coords
+            else:
+                return vectorized.get_y(self.data)
         else:
             message = "y attribute access only provided for Point geometries"
             raise ValueError(message)
@@ -903,10 +911,14 @@ class GeometryArray(ExtensionArray):
     def z(self):
         """Return the z location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            nonempty = ~self.is_empty
-            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
-            coords[nonempty] = vectorized.get_z(self.data[nonempty])
-            return coords
+            empty = self.is_empty
+            if empty.any():
+                nonempty = ~empty
+                coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+                coords[nonempty] = vectorized.get_z(self.data[nonempty])
+                return coords
+            else:
+                return vectorized.get_z(self.data)
         else:
             message = "z attribute access only provided for Point geometries"
             raise ValueError(message)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -879,7 +879,10 @@ class GeometryArray(ExtensionArray):
     def x(self):
         """Return the x location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            return vectorized.get_x(self.data)
+            nonempty = ~self.is_empty
+            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+            coords[nonempty] = vectorized.get_x(self.data[nonempty])
+            return coords
         else:
             message = "x attribute access only provided for Point geometries"
             raise ValueError(message)
@@ -888,7 +891,10 @@ class GeometryArray(ExtensionArray):
     def y(self):
         """Return the y location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            return vectorized.get_y(self.data)
+            nonempty = ~self.is_empty
+            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+            coords[nonempty] = vectorized.get_y(self.data[nonempty])
+            return coords
         else:
             message = "y attribute access only provided for Point geometries"
             raise ValueError(message)
@@ -897,7 +903,10 @@ class GeometryArray(ExtensionArray):
     def z(self):
         """Return the z location of point geometries in a GeoSeries"""
         if (self.geom_type[~self.isna()] == "Point").all():
-            return vectorized.get_z(self.data)
+            nonempty = ~self.is_empty
+            coords = np.full_like(nonempty, dtype=float, fill_value=np.nan)
+            coords[nonempty] = vectorized.get_z(self.data[nonempty])
+            return coords
         else:
             message = "z attribute access only provided for Point geometries"
             raise ValueError(message)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -74,9 +74,9 @@ class TestGeomMethods:
         self.pt2d = Point(-73.9847, 40.7484)
         self.landmarks_mixed = GeoSeries([self.esb, self.sol, self.pt2d], crs=4326)
         self.pt_empty = wkt.loads("POINT EMPTY")
-        self.landmarks_mixed_empty = GeoSeries([
-            self.esb, self.sol, self.pt2d, self.pt_empty
-        ], crs=4326)
+        self.landmarks_mixed_empty = GeoSeries(
+            [self.esb, self.sol, self.pt2d, self.pt_empty], crs=4326
+        )
         self.l1 = LineString([(0, 0), (0, 1), (1, 1)])
         self.l2 = LineString([(0, 0), (1, 0), (1, 1), (0, 1)])
         self.g5 = GeoSeries([self.l1, self.l2])

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -7,6 +7,7 @@ from pandas import DataFrame, Index, MultiIndex, Series
 from shapely.geometry import LinearRing, LineString, MultiPoint, Point, Polygon
 from shapely.geometry.collection import GeometryCollection
 from shapely.ops import unary_union
+from shapely import wkt
 
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.base import GeoPandasBase
@@ -72,6 +73,10 @@ class TestGeomMethods:
         self.landmarks = GeoSeries([self.esb, self.sol], crs="epsg:4326")
         self.pt2d = Point(-73.9847, 40.7484)
         self.landmarks_mixed = GeoSeries([self.esb, self.sol, self.pt2d], crs=4326)
+        self.pt_empty = wkt.loads("POINT EMPTY")
+        self.landmarks_mixed_empty = GeoSeries([
+            self.esb, self.sol, self.pt2d, self.pt_empty
+        ], crs=4326)
         self.l1 = LineString([(0, 0), (0, 1), (1, 1)])
         self.l2 = LineString([(0, 0), (1, 0), (1, 1), (0, 1)])
         self.g5 = GeoSeries([self.l1, self.l2])
@@ -616,6 +621,15 @@ class TestGeomMethods:
         # mixed dimensions
         expected_z = [30.3244, 31.2344, np.nan]
         assert_array_dtype_equal(expected_z, self.landmarks_mixed.geometry.z)
+
+    def test_xyz_points_empty(self):
+        expected_x = [-73.9847, -74.0446, -73.9847, np.nan]
+        expected_y = [40.7484, 40.6893, 40.7484, np.nan]
+        expected_z = [30.3244, 31.2344, np.nan, np.nan]
+
+        assert_array_dtype_equal(expected_x, self.landmarks_mixed_empty.geometry.x)
+        assert_array_dtype_equal(expected_y, self.landmarks_mixed_empty.geometry.y)
+        assert_array_dtype_equal(expected_z, self.landmarks_mixed_empty.geometry.z)
 
     def test_xyz_polygons(self):
         # accessing x attribute in polygon geoseries should raise an error


### PR DESCRIPTION
Close #2223

Done by explicit checking of emptiness and returning nan for empty points. Some performance degradation of `.[xyz]` methods may be expected due to the extra array being prepared and the nonempty check.