### PR TITLE
DOC: how to access unexposed drivers from fiona

### DIFF
--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -29,7 +29,17 @@ the ``driver`` keyword, or pick a single layer from a multi-layered file with
 the ``layer`` keyword::
 
     countries_gdf = geopandas.read_file("package.gpkg", layer='countries')
+    
+Currently fiona only exposes the default drivers. To display those, type::
 
+    import fiona; fiona.supported_drivers 
+
+There is an `array <https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py>`_
+of unexposed but supported (depending on the GDAL-build) drivers. One can activate 
+these on runtime by updating the `supported_drivers` dictionary like::
+
+    fiona.supported_drivers["NAS"] = "raw"
+    
 Where supported in :mod:`fiona`, *geopandas* can also load resources directly from
 a web URL, for example for GeoJSON files from `geojson.xyz <http://geojson.xyz/>`_::
 


### PR DESCRIPTION
Closes #2336 

Following the gitter thread of @jorisvandenbossche & @RadMagnus from February, 2.
Added a section on the [io-page ](https://geopandas.org/en/stable/docs/user_guide/io.html) that explains in more detail how to check which formats are supported by geopandas.read_file by investigating the fiona library.
Explained how to change fiona/drvsupport.py on runtime to include supported drivers that are unexposed (commented out)