### PR TITLE
CLN: remove isna warning

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -665,21 +665,6 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.notna : inverse of isna
         GeoSeries.is_empty : detect empty geometries
         """
-        if self.is_empty.any():
-            warnings.warn(
-                "GeoSeries.isna() previously returned True for both missing (None) "
-                "and empty geometries. Now, it only returns True for missing values. "
-                "Since the calling GeoSeries contains empty geometries, the result "
-                "has changed compared to previous versions of GeoPandas.\n"
-                "Given a GeoSeries 's', you can use 's.is_empty | s.isna()' to get "
-                "back the old behaviour.\n\n"
-                "To further ignore this warning, you can do: \n"
-                "import warnings; warnings.filterwarnings('ignore', 'GeoSeries.isna', "
-                "UserWarning)",
-                UserWarning,
-                stacklevel=2,
-            )
-
         return super().isna()
 
     def isnull(self):

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -379,15 +379,6 @@ class TestSeries:
         assert_geoseries_equal(expected, GeoSeries.from_xy(x, y, z))
 
 
-def test_missing_values_empty_warning():
-    s = GeoSeries([Point(1, 1), None, np.nan, BaseGeometry(), Polygon()])
-    with pytest.warns(UserWarning):
-        s.isna()
-
-    with pytest.warns(UserWarning):
-        s.notna()
-
-
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_missing_values():
     s = GeoSeries([Point(1, 1), None, np.nan, BaseGeometry(), Polygon()])


### PR DESCRIPTION
This removes the warning we had since 0.6. 

At point, we may even remove `isna` and `isnull` we inherit from pandas (and call directly). Shall I go ahead or do we want to keep them around to have that note in the `isna` docstring about `isna` vs `is_empty`?