### PR TITLE
TST: allow TypeError in fillna() with pandas main

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -384,7 +384,7 @@ def test_fillna(s, df):
     df2["geometry"] = s2
     res = df2.fillna(Point(1, 1))
     assert_geodataframe_equal(res, df)
-    with pytest.raises((NotImplementedError, TypeError)):
+    with pytest.raises((NotImplementedError, TypeError)):  # GH2351
         df2.fillna(0)
 
     # allow non-geometry fill value if there are no missing values

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -384,7 +384,7 @@ def test_fillna(s, df):
     df2["geometry"] = s2
     res = df2.fillna(Point(1, 1))
     assert_geodataframe_equal(res, df)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises((NotImplementedError, TypeError)):
         df2.fillna(0)
 
     # allow non-geometry fill value if there are no missing values


### PR DESCRIPTION
I have to admit I am not fully sure what has changed in https://github.com/pandas-dev/pandas/pull/45911 but as a result, `GeoDataFrame.fillna` completely circumvents our custom `GeometryArray.fillna`. But it still seem to work as before, just raising a different error (from `GeometryArray.__setitem__`), so I guess this is fine?

