### PR TITLE
BUG: preserve column order inside iterfeatures

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -865,7 +865,7 @@ individually so that features may have different properties
         if not self.columns.is_unique:
             raise ValueError("GeoDataFrame cannot contain duplicated column names.")
 
-        properties_cols = self.columns.difference([self._geometry_column_name])
+        properties_cols = [c for c in self.columns if c != self._geometry_column_name]
 
         if len(properties_cols) > 0:
             # convert to object to get python scalars.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -865,7 +865,7 @@ individually so that features may have different properties
         if not self.columns.is_unique:
             raise ValueError("GeoDataFrame cannot contain duplicated column names.")
 
-        properties_cols = self.columns.drop(self.geometry.name)
+        properties_cols = self.columns.drop(self._geometry_column_name)
 
         if len(properties_cols) > 0:
             # convert to object to get python scalars.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -865,7 +865,7 @@ individually so that features may have different properties
         if not self.columns.is_unique:
             raise ValueError("GeoDataFrame cannot contain duplicated column names.")
 
-        properties_cols = [c for c in self.columns if c != self._geometry_column_name]
+        properties_cols = self.columns.drop(self.geometry.name)
 
         if len(properties_cols) > 0:
             # convert to object to get python scalars.

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -659,7 +659,7 @@ class TestDataFrame:
         geometry = [Point(xy) for xy in zip(df["lon"], df["lat"])]
         gdf = GeoDataFrame(df, geometry=geometry)
         # from_features returns sorted columns
-        expected = gdf[["geometry", "lat", "lon", "name"]]
+        expected = gdf[["geometry", "name", "lat", "lon"]]
 
         # test FeatureCollection
         res = GeoDataFrame.from_features(gdf.__geo_interface__)


### PR DESCRIPTION
I have implemented the fix for the issue in https://github.com/geopandas/geopandas/issues/2394#issuecomment-1083426801

Unfortunately I had to change the test as well, because the `from_features()` method, used in the test calls `iter_features()` itself, so that the expected order of columns had to be changed. 
However, after the fix, the order of columns is predictable and corresponds to `geometry`  and the ordered `keys` of the dict to greate the GeoDataFrame.

If there are issues with this PR let me know and I'll try to improve

Closes https://github.com/geopandas/geopandas/issues/2394