### PR TITLE
DEP: bump minimal Python version to 3.8+

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3
 
   Test:
@@ -35,28 +35,28 @@ jobs:
         postgis: [false]
         dev: [false]
         env:
-          - ci/envs/37-minimal.yaml
-          - ci/envs/38-no-optional-deps.yaml
-          - ci/envs/37-pd11.yaml
-          - ci/envs/37-latest-defaults.yaml
-          - ci/envs/37-latest-conda-forge.yaml
+          - ci/envs/38-minimal.yaml
+          - ci/envs/39-no-optional-deps.yaml
+          - ci/envs/38-pd11-defaults.yaml
+          - ci/envs/38-latest-defaults.yaml
           - ci/envs/38-latest-conda-forge.yaml
+          - ci/envs/39-pd12-conda-forge.yaml
           - ci/envs/39-latest-conda-forge.yaml
           - ci/envs/310-latest-conda-forge.yaml
         include:
-          - env: ci/envs/37-latest-conda-forge.yaml
-            os: macos-latest
-            postgis: false
-            dev: false
           - env: ci/envs/38-latest-conda-forge.yaml
             os: macos-latest
             postgis: false
             dev: false
-          - env: ci/envs/37-latest-conda-forge.yaml
+          - env: ci/envs/39-latest-conda-forge.yaml
+            os: macos-latest
+            postgis: false
+            dev: false
+          - env: ci/envs/38-latest-conda-forge.yaml
             os: windows-latest
             postgis: false
             dev: false
-          - env: ci/envs/38-latest-conda-forge.yaml
+          - env: ci/envs/39-latest-conda-forge.yaml
             os: windows-latest
             postgis: false
             dev: false
@@ -65,7 +65,7 @@ jobs:
             dev: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v2
@@ -106,7 +106,7 @@ jobs:
           pytest -v -r s -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with PostGIS
-        if: contains(matrix.env, '38-latest-conda-forge.yaml') && contains(matrix.os, 'ubuntu')
+        if: contains(matrix.env, '39-pd12-conda-forge.yaml') && contains(matrix.os, 'ubuntu')
         env:
           PGUSER: postgres
           PGPASSWORD: postgres
@@ -118,7 +118,7 @@ jobs:
           pytest -v -r s --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
       - name: Test docstrings
-        if: contains(matrix.env, '38-latest-conda-forge.yaml') && contains(matrix.os, 'ubuntu')
+        if: contains(matrix.env, '39-pd12-conda-forge.yaml') && contains(matrix.os, 'ubuntu')
         env:
           USE_PYGEOS: 1
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ In general, GeoPandas follows the conventions of the pandas project
 where applicable. Please read the [contributing
 guidelines](https://geopandas.readthedocs.io/en/latest/community/contributing.html).
 
-
 In particular, when submitting a pull request:
 
 - Install the requirements for the development environment (one can do this
@@ -39,7 +38,7 @@ is a great way to get started if you'd like to make a contribution.
 Style
 -----
 
-- GeoPandas supports Python 3.7+ only. The last version of GeoPandas
+- GeoPandas supports Python 3.8+ only. The last version of GeoPandas
   supporting Python 2 is 0.6.
 
 - GeoPandas follows [the PEP 8

--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   # required
-  - pandas=1.2
+  - pandas
   - shapely
   - fiona
   - pyproj
@@ -23,12 +23,6 @@ dependencies:
   - xyzservices
   - scipy
   - geopy
-  # installed in tests.yaml, because not available on windows
-  # - postgis
   - SQLalchemy
-  - psycopg2
   - libspatialite
-  - geoalchemy2
   - pyarrow
-  # doctest testing
-  - pytest-doctestplus

--- a/ci/envs/38-latest-defaults.yaml
+++ b/ci/envs/38-latest-defaults.yaml
@@ -2,7 +2,7 @@ name: test
 channels:
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   # required
   - pandas
   - shapely

--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   # required
   - numpy=1.18
   - pandas==1.0.5

--- a/ci/envs/38-pd11-defaults.yaml
+++ b/ci/envs/38-pd11-defaults.yaml
@@ -2,7 +2,7 @@ name: test
 channels:
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   # required
   - pandas=1.1
   - shapely

--- a/ci/envs/39-no-optional-deps.yaml
+++ b/ci/envs/39-no-optional-deps.yaml
@@ -2,7 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.9
   # required
   - pandas
   - shapely

--- a/ci/envs/39-pd12-conda-forge.yaml
+++ b/ci/envs/39-pd12-conda-forge.yaml
@@ -2,9 +2,9 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   # required
-  - pandas
+  - pandas=1.2
   - shapely
   - fiona
   - pyproj
@@ -23,6 +23,12 @@ dependencies:
   - xyzservices
   - scipy
   - geopy
+  # installed in tests.yaml, because not available on windows
+  # - postgis
   - SQLalchemy
+  - psycopg2
   - libspatialite
+  - geoalchemy2
   - pyarrow
+  # doctest testing
+  - pytest-doctestplus

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -44,7 +44,7 @@ In particular, when submitting a pull request:
   imports when possible, and explicit relative imports for local
   imports when necessary in tests.
 
-- GeoPandas supports Python 3.7+ only. The last version of GeoPandas
+- GeoPandas supports Python 3.8+ only. The last version of GeoPandas
   supporting Python 2 is 0.6.
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         "geopandas.tools.tests",
     ],
     package_data={"geopandas": data_files},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=INSTALL_REQUIRES,
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
Closes #2391 

I tried to keep the same logic of the CI matrix, just on higher Python versions. Since I had to bump yaml names at the same time, the diff is a bit broken. The only thing I did was to change the Python versions.