### PR TITLE
ENH: support GeoParquet v0.2.0

### DIFF
--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -55,13 +55,17 @@ def test_create_metadata():
     metadata = _create_metadata(df)
 
     assert isinstance(metadata, dict)
-    assert metadata["schema_version"] == METADATA_VERSION
+    assert metadata["version"] == METADATA_VERSION
     assert metadata["creator"]["library"] == "geopandas"
     assert metadata["creator"]["version"] == geopandas.__version__
     assert metadata["primary_column"] == "geometry"
     assert "geometry" in metadata["columns"]
     assert metadata["columns"]["geometry"]["crs"] == df.geometry.crs.to_wkt()
     assert metadata["columns"]["geometry"]["encoding"] == "WKB"
+    assert metadata["columns"]["geometry"]["geometry_type"] == [
+        "MultiPolygon",
+        "Polygon",
+    ]
 
     assert np.array_equal(
         metadata["columns"]["geometry"]["bbox"], df.geometry.total_bounds
@@ -140,16 +144,12 @@ def test_validate_metadata_valid():
         (
             {"primary_column": "foo", "columns": {"foo": {}}},
             (
-                "'geo' metadata in Parquet/Feather file is missing required key 'crs' "
-                "for column 'foo'"
+                "'geo' metadata in Parquet/Feather file is missing required key "
+                "'encoding' for column 'foo'"
             ),
         ),
         (
             {"primary_column": "foo", "columns": {"foo": {"crs": None}}},
-            "'geo' metadata in Parquet/Feather file is missing required key",
-        ),
-        (
-            {"primary_column": "foo", "columns": {"foo": {"encoding": None}}},
             "'geo' metadata in Parquet/Feather file is missing required key",
         ),
         (


### PR DESCRIPTION
Addresses part of https://github.com/geopandas/geopandas/issues/2376

This PR already does:

- update the version from 0.1.0 to 0.2.0
- renames "schema_version" to "version" to follow upstream geoparquet spec
- makes the "crs" key optional, not using `null` if the crs is not defined
- adds the "geometry_type" field

What this PR does not yet do:

- we should add some dummy v0.1.0 files to ensure we keep forward compatibility (to ensure we can still read files created by older geopandas correctly)
- we should add explicit support for 3D geometries (and also update "geometry_type" for this)
- this does not yet map an unspecified "crs" field to OGC:CRS84 (but keeping it as None)
- this does not yet check/correct the winding order (this is still under discussion for 0.3.0, see https://github.com/opengeospatial/geoparquet/issues/46), so strictly speaking we are still generating incorrect files

I also didn't include an "epoch" field because we basically don't support spherical coordinates at the moment (we could add a way to let users override this, if they know their data has spherical edges).