### PR TITLE
BUG: fix incorrect colors with mixed geometry types and list of colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ doc/source/docs/reference/api/*.rst
 
 geopandas.egg-info
 geopandas/version.py
-geopandas/datasets/ne_110m_admin_0_countries.zip
 
 .asv
 doc/source/getting_started/my_file.geojson

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ doc/source/docs/reference/api/*.rst
 
 geopandas.egg-info
 geopandas/version.py
+geopandas/datasets/ne_110m_admin_0_countries.zip
 
 .asv
 doc/source/getting_started/my_file.geojson

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -325,7 +325,7 @@ def plot_series(
     ----------
     s : Series
         The GeoSeries to be plotted. Currently Polygon,
-        MultiPolygon, LineString, MultiLineString and Point
+        MultiPolygon, LineString, MultiLineString, Point and MultiPoint
         geometries can be plotted.
     cmap : str (default None)
         The name of a colormap recognized by matplotlib. Any
@@ -335,7 +335,7 @@ def plot_series(
 
             tab10, tab20, Accent, Dark2, Paired, Pastel1, Set1, Set2
 
-    color : str (default None)
+    color : str, np.array, pd.Series, List (default None)
         If specified, all objects will be colored uniformly.
     ax : matplotlib.pyplot.Artist (default None)
         axes on which to draw the plot
@@ -414,6 +414,11 @@ def plot_series(
         )
         return ax
 
+    # have colors been given for all geometries?
+    color_given = isinstance(color, (list, pd.core.series.Series, np.ndarray)) and len(
+        color
+    ) == len(s)
+
     # if cmap is specified, create range of colors based on cmap
     values = None
     if cmap is not None:
@@ -426,6 +431,10 @@ def plot_series(
     # decompose GeometryCollections
     geoms, multiindex = _flatten_multi_geoms(s.geometry, prefix="Geom")
     values = np.take(values, multiindex, axis=0) if cmap else None
+    # ensure indexes are consistent
+    if color_given and isinstance(color, pd.Series):
+        color = color.reindex(s.index)
+    expl_color = np.take(color, multiindex, axis=0) if color_given else color
     expl_series = geopandas.GeoSeries(geoms)
 
     geom_types = expl_series.type
@@ -443,8 +452,9 @@ def plot_series(
         # color overrides both face and edgecolor. As we want people to be
         # able to use edgecolor as well, pass color to facecolor
         facecolor = style_kwds.pop("facecolor", None)
+        color_ = expl_color[poly_idx] if color_given else color
         if color is not None:
-            facecolor = color
+            facecolor = color_
 
         values_ = values[poly_idx] if cmap else None
         _plot_polygon_collection(
@@ -455,16 +465,20 @@ def plot_series(
     lines = expl_series[line_idx]
     if not lines.empty:
         values_ = values[line_idx] if cmap else None
+        color_ = expl_color[line_idx] if color_given else color
+
         _plot_linestring_collection(
-            ax, lines, values_, color=color, cmap=cmap, **style_kwds
+            ax, lines, values_, color=color_, cmap=cmap, **style_kwds
         )
 
     # plot all Points in the same collection
     points = expl_series[point_idx]
     if not points.empty:
         values_ = values[point_idx] if cmap else None
+        color_ = expl_color[point_idx] if color_given else color
+
         _plot_point_collection(
-            ax, points, values_, color=color, cmap=cmap, **style_kwds
+            ax, points, values_, color=color_, cmap=cmap, **style_kwds
         )
 
     plt.draw()
@@ -524,7 +538,7 @@ def plot_dataframe(
          - 'hexbin' : hexbin plot.
     cmap : str (default None)
         The name of a colormap recognized by matplotlib.
-    color : str (default None)
+    color : str, np.array, pd.Series (default None)
         If specified, all objects will be colored uniformly.
     ax : matplotlib.pyplot.Artist (default None)
         axes on which to draw the plot

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -415,9 +415,7 @@ def plot_series(
         return ax
 
     # have colors been given for all geometries?
-    color_given = isinstance(color, (list, pd.core.series.Series, np.ndarray)) and len(
-        color
-    ) == len(s)
+    color_given = pd.api.types.is_list_like(color) and len(color) == len(s)
 
     # if cmap is specified, create range of colors based on cmap
     values = None

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -876,7 +876,7 @@ class TestColorParamArray:
     def setup_method(self):
         geom = []
         color = []
-        for a, b in zip(np.linspace(0, 10, 4)[::2], np.linspace(0, 10, 4)[1::2]):
+        for a, b in [(0, 2), (4, 6)]:
             b = box(a, a, b, b)
             geom += [b, b.buffer(0.8).exterior, b.centroid]
             color += ["red", "green", "blue"]

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -16,6 +16,7 @@ from shapely.geometry import (
     MultiPoint,
     MultiLineString,
     GeometryCollection,
+    box,
 )
 
 
@@ -869,6 +870,47 @@ class TestPolygonZPlotting:
     def test_plot(self):
         # basic test that points with z coords don't break plotting
         self.df.plot()
+
+
+class TestColorParamArray:
+    def setup_method(self):
+        geom = []
+        color = []
+        for a, b in zip(np.linspace(0, 10, 4)[::2], np.linspace(0, 10, 4)[1::2]):
+            b = box(a, a, b, b)
+            geom += [b, b.buffer(0.8).exterior, b.centroid]
+            color += ["red", "green", "blue"]
+
+        self.gdf = GeoDataFrame({"geometry": geom, "color_rgba": color})
+        self.mgdf = self.gdf.dissolve(self.gdf.type)
+
+    def test_color_single(self):
+        ax = self.gdf.plot(color=self.gdf["color_rgba"])
+
+        _check_colors(
+            4,
+            np.concatenate([c.get_edgecolor() for c in ax.collections]),
+            ["green"] * 2 + ["blue"] * 2,
+        )
+        _check_colors(
+            4,
+            np.concatenate([c.get_facecolor() for c in ax.collections]),
+            ["red"] * 2 + ["blue"] * 2,
+        )
+
+    def test_color_multi(self):
+        ax = self.mgdf.plot(color=self.mgdf["color_rgba"])
+
+        _check_colors(
+            4,
+            np.concatenate([c.get_edgecolor() for c in ax.collections]),
+            ["green"] * 2 + ["blue"] * 2,
+        )
+        _check_colors(
+            4,
+            np.concatenate([c.get_facecolor() for c in ax.collections]),
+            ["red"] * 2 + ["blue"] * 2,
+        )
 
 
 class TestGeometryCollectionPlotting:


### PR DESCRIPTION
Closes #1379 

Fixes this referenced example in issue
```
import geopandas as gpd
import pandas as pd
from shapely.geometry import Point, box
import matplotlib.pyplot as plt
from matplotlib.colors import LinearSegmentedColormap

# fmt: off
gdf = gpd.GeoDataFrame({
    "geometry": [box(0,0,1,1), box(1,1,2,2), box(2,2,3,3), Point(0, 0), Point(1,1), Point(2,2), Point(3,3)],
    "color_rgba": [(0.0, 0.0, 0.0, 0.5), (0.0, 0.0, 0.0, 0.2), (0.0, 0.0, 0.0, 0.1), (1.0, 1.0, 1.0, 1.0), (1.0, 1.0, 1.0, 1.0), (1.0, 1.0, 1.0, 1.0), (1.0, 1.0, 1.0, 1.0)],
})
# fmt: on

gdf.plot(markersize=1000, edgecolor="k", color=gdf["color_rgba"])
```
<img width="269" alt="image" src="https://user-images.githubusercontent.com/42769112/164934462-e17b432e-ad58-4bbd-ad14-2354e0b4803c.png">

Also
```
from shapely.geometry import LineString, Point, Polygon
import geopandas as gpd
import numpy as np

gdf = gpd.GeoDataFrame(geometry=[Polygon([(1, 1), (1, 2), (2, 2), (2, 1)]),
                                LineString([(2, 0), (4, 2)]),
                                Point(3, 2),
                                Point(1, 0)])

colors = ['red', 'green', 'blue', 'blue']

gdf.plot(color=colors)
```
<img width="388" alt="image" src="https://user-images.githubusercontent.com/42769112/164934503-e9ed2b16-ddb9-4196-8bed-84843e4c8d2a.png">

Plus geometry used in test cases:
```
import numpy as np
from shapely.geometry import box
import geopandas as gpd

geom = []
color = []
for a, b in zip(np.linspace(0, 10, 4)[::2], np.linspace(0, 10, 4)[1::2]):
    b = box(a,a,b,b)
    geom += [b, b.buffer(.8).exterior, b.centroid]
    color += ["red","green","blue"]
    
gdf = gpd.GeoDataFrame({"geometry":geom, "color_rgba":color})

gdf.plot(color=gdf["color_rgba"])
```
<img width="273" alt="image" src="https://user-images.githubusercontent.com/42769112/164934642-424eb99a-0436-44eb-af02-5a2c623eda61.png">
