### PR TITLE
MAINT: move static metadata to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,57 @@
+[metadata]
+name = geopandas
+description = Geographic pandas extensions
+long_description =
+    GeoPandas is a project to add support for geographic data to
+    `pandas`_ objects.
+
+    The goal of GeoPandas is to make working with geospatial data in
+    python easier. It combines the capabilities of `pandas`_ and `shapely`_,
+    providing geospatial operations in pandas and a high-level interface
+    to multiple geometries to shapely. GeoPandas enables you to easily do
+    operations in python that would otherwise require a spatial database
+    such as PostGIS.
+
+    .. _pandas: http://pandas.pydata.org
+    .. _shapely: http://shapely.readthedocs.io/en/latest/
+long_description_content_type = text/x-rst
+author = GeoPandas contributors
+author_email = kjordahl@alum.mit.edu
+url = http://geopandas.org
+project_urls =
+    Source = https://github.com/geopandas/geopandas
+license = BSD
+license_files = LICENSE.txt
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Scientific/Engineering :: GIS
+
+[options]
+packages = find:
+python_requires = >=3.8
+install_requires =
+    pandas >= 1.0.0
+    shapely >= 1.7
+    fiona >= 1.8
+    pyproj >= 2.6.1.post1
+    packaging
+
+[options.packages.find]
+exclude = benchmarks
+
+[options.package_data]
+geopandas =
+    datasets/nybb_16a.zip
+    datasets/naturalearth_cities/*
+    datasets/naturalearth_lowres/*
+    tests/data/*
+
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env/python
 """Installation script
 
+See setup.cfg for static metadata.
 """
 
 import os
@@ -15,67 +16,7 @@ sys.path.append(os.path.dirname(__file__))
 
 import versioneer  # noqa: E402
 
-LONG_DESCRIPTION = """GeoPandas is a project to add support for geographic data to
-`pandas`_ objects.
-
-The goal of GeoPandas is to make working with geospatial data in
-python easier. It combines the capabilities of `pandas`_ and `shapely`_,
-providing geospatial operations in pandas and a high-level interface
-to multiple geometries to shapely. GeoPandas enables you to easily do
-operations in python that would otherwise require a spatial database
-such as PostGIS.
-
-.. _pandas: http://pandas.pydata.org
-.. _shapely: http://shapely.readthedocs.io/en/latest/
-"""
-
-if os.environ.get("READTHEDOCS", False) == "True":
-    INSTALL_REQUIRES = []
-else:
-    INSTALL_REQUIRES = [
-        "pandas >= 1.0.0",
-        "shapely >= 1.7",
-        "fiona >= 1.8",
-        "pyproj >= 2.6.1.post1",
-        "packaging",
-    ]
-
-# get all data dirs in the datasets module
-data_files = []
-
-for item in os.listdir("geopandas/datasets"):
-    if not item.startswith("__"):
-        if os.path.isdir(os.path.join("geopandas/datasets/", item)):
-            data_files.append(os.path.join("datasets", item, "*"))
-        elif item.endswith(".zip"):
-            data_files.append(os.path.join("datasets", item))
-
-data_files.append("tests/data/*")
-
-
 setup(
-    name="geopandas",
     version=versioneer.get_version(),
-    description="Geographic pandas extensions",
-    license="BSD",
-    author="GeoPandas contributors",
-    author_email="kjordahl@alum.mit.edu",
-    url="http://geopandas.org",
-    project_urls={
-        "Source": "https://github.com/geopandas/geopandas",
-    },
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/x-rst",
-    packages=[
-        "geopandas",
-        "geopandas.io",
-        "geopandas.tools",
-        "geopandas.datasets",
-        "geopandas.tests",
-        "geopandas.tools.tests",
-    ],
-    package_data={"geopandas": data_files},
-    python_requires=">=3.8",
-    install_requires=INSTALL_REQUIRES,
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
This PR is a follow-up from #2419, and moves the project metatdata from `setup.py` to a [declarative configuration](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) `setup.cfg` file.

- New metadata are `license_files` and `classifiers`
- Option `packages` is changed from explicit to `find:`, which adds `geopandas.io.tests`. Was this intentionally excluded, or was it missed?
- Option `package_data` is changed from custom-generated to an equivalent list of datasets
- Option `install_requires` is moved to `setup.cfg`. It was not clear why this would be empty for ReadTheDocs, which has these dependencies met with `doc/environment.yml`. However, if there is a good reason, this dynamic option can be moved back to `setup.py`.
- Most of `setup.py` is there to support versioneer or anyone that expects to see this file.