### PR TITLE
TST: read_parquet supports partitioned datasets

### DIFF
--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -594,6 +594,11 @@ def test_fsspec_url():
     result = read_parquet("memory://data.parquet", filesystem=memfs)
     assert_geodataframe_equal(result, df)
 
+    # reset fsspec registry
+    fsspec.register_implementation(
+        "memory", fsspec.implementations.memory.MemoryFileSystem, clobber=True
+    )
+
 
 def test_non_fsspec_url_with_storage_options_raises():
     with pytest.raises(ValueError, match="storage_options"):
@@ -706,3 +711,35 @@ def test_read_versioned_file(version):
         DATA_PATH / "arrow" / f"naturalearth_lowres_top2_v{version}.parquet"
     )
     assert_geodataframe_equal(df, expected, check_crs=check_crs)
+
+
+def test_parquet_read_partitioned_dataset(tmpdir):
+    # we don't yet explicitly support this (in writing), but for Parquet it
+    # works for reading (by relying on pyarrow.read_table)
+    df = read_file(get_path("naturalearth_lowres"))
+
+    # manually create partitioned dataset
+    basedir = tmpdir / "partitioned_dataset"
+    basedir.mkdir()
+    df[:100].to_parquet(basedir / "data1.parquet")
+    df[100:].to_parquet(basedir / "data2.parquet")
+
+    result = read_parquet(basedir)
+    assert_geodataframe_equal(result, df)
+
+
+def test_parquet_read_partitioned_dataset_fsspec(tmpdir):
+    fsspec = pytest.importorskip("fsspec")
+
+    df = read_file(get_path("naturalearth_lowres"))
+
+    # manually create partitioned dataset
+    memfs = fsspec.filesystem("memory")
+    memfs.mkdir("partitioned_dataset")
+    with memfs.open("partitioned_dataset/data1.parquet", "wb") as f:
+        df[:100].to_parquet(f)
+    with memfs.open("partitioned_dataset/data2.parquet", "wb") as f:
+        df[100:].to_parquet(f)
+
+    result = read_parquet("memory://partitioned_dataset")
+    assert_geodataframe_equal(result, df)


### PR DESCRIPTION
We don't yet support writing partitioned datasets (xref https://github.com/geopandas/geopandas/issues/1382), but for parquet we actually do support reading them by using `pyarrow.parquet.read_table` (for feather this is not supported, see https://github.com/geopandas/geopandas/issues/2348). 
But, I don't think we actually explicitly test this capability (`read_table` will do it automatically for us, but some of the surrounding handling of eg metadata could in theory break it). So this PR is adding a basic test.
