### PR TITLE
DOC: add changelog for main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Development version
+-------------------
+
+New features and improvements:
+
+Deprecations and compatibility notes:
+
+Bug fixes:
+
+Notes on (optional) dependencies:
+
 Version 0.11 (June 20, 2022)
 ----------------------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ In particular, when submitting a pull request:
   line of a docstring should be a standalone summary. Parameters and
   return values should be documented explicitly.
 
+- Unless your PR implements minor changes or internal work only, make sure
+  it contains a note describing the changes in the `CHANGELOG.md` file.
+
 Improving the documentation and testing for code already in GeoPandas
 is a great way to get started if you'd like to make a contribution.
 

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -47,6 +47,9 @@ In particular, when submitting a pull request:
 - GeoPandas supports Python 3.8+ only. The last version of GeoPandas
   supporting Python 2 is 0.6.
 
+- Unless your PR implements minor changes or internal work only, make sure
+  it contains a note describing the changes in the `CHANGELOG.md` file.
+
 
 Seven Steps for Contributing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We recently agreed that we should change the way we collect changelog notes. Instead of doing one massive work skimming through all commits ahead of a release, the idea is that each PR will include a change log note, unless it covers only CI, tests or some other internal work.

(I also noticed that contributing guide in docs and the one in root are a bit out of sync, will have a look at it later).