### PR TITLE
ENH: matplotlib color abbreviations in explore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- #2471 Enable **matplotlib** color abbreviations to be passed as `color`, `style_kwds` and `missing_kwds` paramters to `explore()`.  For example `r` for `red`.   [matplotlib colors](https://matplotlib.org/2.0.1/api/colors_api.html#matplotlib.colors.is_color_like)
+
 Version 0.11 (June 20, 2022)
 ----------------------------
 

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -80,7 +80,7 @@ However it also accepts other summary statistic options as allowed by :meth:`pan
 * list of functions and/or function names, e.g. [np.sum, 'mean']
 * dict of axis labels -> functions, function names or list of such.
 
-For example, to get the number of contries on each continent, 
+For example, to get the number of countries on each continent, 
 as well as the populations of the largest and smallest country of each,
 we can aggregate the ``'name'`` column using ``'count'``,
 and the ``'pop_est'`` column using ``'min'`` and ``'max'``:

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -471,6 +471,31 @@ GON (((180.00000 -16.06713, 180.00000...
 
         style_kwds_function = _no_style
 
+    # allow for matplotlib color abbreviations, e.g. "r" for "red"
+    # plus allow colors to be defined as RGB(A) tuples e.g. (1,0,0)
+    def plt_color(c):
+        def hex_c(c):
+            # if color is a tuple or RGBA string include alpha
+            alpha = isinstance(c, tuple) or (
+                isinstance(c, str)
+                and c[0] == "#"
+                and len(c) == 9
+                and colors.is_color_like(c)
+            )
+            return colors.to_hex(c, keep_alpha=alpha) if colors.is_color_like(c) else c
+
+        return (
+            [hex_c(c_) for c_ in c]
+            if pd.api.types.is_list_like(c)
+            and not (isinstance(c, tuple) and colors.is_color_like(c))
+            else hex_c(c)
+        )
+
+    if "fillColor" in style_kwds:
+        style_kwds["fillColor"] = plt_color(style_kwds["fillColor"])
+    if "color" in style_kwds:
+        style_kwds["color"] = plt_color(style_kwds["color"])
+
     # specify color
     if color is not None:
         if (
@@ -491,30 +516,6 @@ GON (((180.00000 -16.06713, 180.00000...
 
             style_function = _style_color
         else:  # assign new column
-            # allow for matplotlib color abbreviations, e.g. "r" for "red"
-            # plus allow colors to be defined as RGB(A) tuples e.g. (1,0,0)
-            def plt_color(c):
-                def hex_c(c):
-                    # if color is a tuple or RGBA string include alpha
-                    alpha = isinstance(c, tuple) or (
-                        isinstance(c, str)
-                        and c[0] == "#"
-                        and len(c) == 9
-                        and colors.is_color_like(c)
-                    )
-                    return (
-                        colors.to_hex(c, keep_alpha=alpha)
-                        if colors.is_color_like(c)
-                        else c
-                    )
-
-                return (
-                    [hex_c(c_) for c_ in c]
-                    if pd.api.types.is_list_like(c)
-                    and not (isinstance(c, tuple) and colors.is_color_like(c))
-                    else hex_c(c)
-                )
-
             if isinstance(gdf, geopandas.GeoSeries):
                 gdf = geopandas.GeoDataFrame(geometry=gdf)
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -1,7 +1,5 @@
 from statistics import mean
 
-from matplotlib.colors import is_color_like
-
 import geopandas
 from shapely.geometry import LineString
 import numpy as np

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -81,8 +81,9 @@ def _explore(
                     return "green"
                 return "red"
 
-    color : `color <https://matplotlib.org/stable/tutorials/colors/colors.html>`_, array-like (default None)
-        `matplotlib` compatible color, or list-like of colors 
+    color : `color <https://matplotlib.org/stable/tutorials/colors/colors.html>`_,
+        array-like (default None)
+            `matplotlib` compatible color, or list-like of colors
     m : folium.Map (default None)
         Existing map instance on which to draw the plot.
     tiles : str, xyzservices.TileProvider (default 'OpenStreetMap Mapnik')
@@ -880,8 +881,9 @@ def _explore_geoseries(
 
     Parameters
     ----------
-    color : str, array-like (default None)
-        Named color or a list-like of colors (named or hex).
+    color : `color <https://matplotlib.org/stable/tutorials/colors/colors.html>`_,
+        array-like (default None)
+            `matplotlib` compatible color, or list-like of colors
     m : folium.Map (default None)
         Existing map instance on which to draw the plot.
     tiles : str, xyzservices.TileProvider (default 'OpenStreetMap Mapnik')

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -491,19 +491,23 @@ GON (((180.00000 -16.06713, 180.00000...
             style_function = _style_color
         else:  # assign new column
             # allow for matplotlib color abbreviations, e.g. "r" for "red"
+            # plus allow colors to be defined as RGB(A) tuples e.g. (1,0,0)
             def plt_color(c):
                 def hex_c(c):
                     return (
                         colors.to_hex(c)
-                        if isinstance(c, str)
+                        if (
+                            (isinstance(c, str) and not c[0] == "#")
+                            or isinstance(c, tuple)
+                        )
                         and colors.is_color_like(c)
-                        and not c[0] == "#"
                         else c
                     )
 
                 return (
                     [hex_c(c_) for c_ in c]
                     if pd.api.types.is_list_like(c)
+                    and not (isinstance(c, tuple) and len(c) in (3, 4))
                     else hex_c(c)
                 )
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -1,5 +1,7 @@
 from statistics import mean
 
+from matplotlib.colors import is_color_like
+
 import geopandas
 from shapely.geometry import LineString
 import numpy as np
@@ -81,8 +83,8 @@ def _explore(
                     return "green"
                 return "red"
 
-    color : str, array-like (default None)
-        Named color or a list-like of colors (named or hex).
+    color : `color <https://matplotlib.org/stable/tutorials/colors/colors.html>`_, array-like (default None)
+        `matplotlib` compatible color, or list-like of colors 
     m : folium.Map (default None)
         Existing map instance on which to draw the plot.
     tiles : str, xyzservices.TileProvider (default 'OpenStreetMap Mapnik')
@@ -170,7 +172,7 @@ def _explore(
         stroke : bool (default True)
             Whether to draw stroke along the path. Set it to ``False`` to
             disable borders on polygons or circles.
-        color : str
+        color : `color <https://matplotlib.org/stable/tutorials/colors/colors.html>`_
             Stroke color
         weight : int
             Stroke width in pixels
@@ -494,20 +496,23 @@ GON (((180.00000 -16.06713, 180.00000...
             # plus allow colors to be defined as RGB(A) tuples e.g. (1,0,0)
             def plt_color(c):
                 def hex_c(c):
-                    return (
-                        colors.to_hex(c)
-                        if (
-                            (isinstance(c, str) and not c[0] == "#")
-                            or isinstance(c, tuple)
-                        )
+                    # if color is a tuple or RGBA string include alpha
+                    alpha = isinstance(c, tuple) or (
+                        isinstance(c, str)
+                        and c[0] == "#"
+                        and len(c) == 9
                         and colors.is_color_like(c)
+                    )
+                    return (
+                        colors.to_hex(c, keep_alpha=alpha)
+                        if colors.is_color_like(c)
                         else c
                     )
 
                 return (
                     [hex_c(c_) for c_ in c]
                     if pd.api.types.is_list_like(c)
-                    and not (isinstance(c, tuple) and len(c) in (3, 4))
+                    and not (isinstance(c, tuple) and colors.is_color_like(c))
                     else hex_c(c)
                 )
 

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -111,7 +111,11 @@ class TestExplore:
         # single named color
         m = self.nybb.explore(color="red")
         out_str = self._fetch_map_string(m)
-        assert '"fillColor":"red"' in out_str
+        assert '"fillColor":"#ff0000"' in out_str
+        # abbreviated color
+        m = self.nybb.explore(color="r")
+        out_str = self._fetch_map_string(m)
+        assert '"fillColor":"#ff0000"' in out_str
 
         # list of colors
         colors = ["#333333", "#367324", "#95824f", "#fcaa00", "#ffcc33"]
@@ -131,7 +135,7 @@ class TestExplore:
         # line GeoSeries
         m4 = self.nybb.boundary.explore(color="red")
         out_str = self._fetch_map_string(m4)
-        assert '"fillColor":"red"' in out_str
+        assert '"fillColor":"#ff0000"' in out_str
 
     def test_choropleth_linear(self):
         """Check choropleth colors"""
@@ -315,7 +319,7 @@ class TestExplore:
         out_str = self._fetch_map_string(m)
         assert '"fillColor":"orange","fillOpacity":0.1,"weight":0.5' in out_str
         m = self.world.explore(column="pop_est", style_kwds=dict(color="black"))
-        assert '"color":"black"' in self._fetch_map_string(m)
+        assert '"color":"#000000"' in self._fetch_map_string(m)
 
         # custom style_function - geopandas/issues/2350
         m = self.world.explore(
@@ -527,10 +531,10 @@ class TestExplore:
         assert '"fillColor":null' in self._fetch_map_string(m)
 
         m = self.missing.explore("pop_est", missing_kwds=dict(color="red"))
-        assert '"fillColor":"red"' in self._fetch_map_string(m)
+        assert '"fillColor":"#ff0000"' in self._fetch_map_string(m)
 
         m = self.missing.explore("continent", missing_kwds=dict(color="red"))
-        assert '"fillColor":"red"' in self._fetch_map_string(m)
+        assert '"fillColor":"#ff0000"' in self._fetch_map_string(m)
 
     def test_categorical_legend(self):
         m = self.world.explore("continent", legend=True)

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -326,7 +326,8 @@ class TestExplore:
             style_kwds=dict(fillOpacity=0.1, weight=0.5, fillColor="orange")
         )
         out_str = self._fetch_map_string(m)
-        assert '"fillColor":"orange","fillOpacity":0.1,"weight":0.5' in out_str
+        # color is transformed to RGB string
+        assert '"fillColor":"#ffa500","fillOpacity":0.1,"weight":0.5' in out_str
         m = self.world.explore(column="pop_est", style_kwds=dict(color="black"))
         assert '"color":"#000000"' in self._fetch_map_string(m)
 

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -109,10 +109,22 @@ class TestExplore:
     def test_simple_color(self):
         """Check color settings"""
         # multiple ways to define red
-        for c in ["r", "red", "#ff0000", (1, 0, 0), (1, 0, 0, 1)]:
+        for c, expected in zip(
+            [
+                "r",
+                "red",
+                "#ff0000",
+                "#f00",
+                "#ff0000ff",
+                (1, 0, 0, 1),
+                (1, 0, 0),
+                "xkcd:red",
+            ],
+            ["#ff0000"] * 4 + ["#ff0000ff"] * 3 + ["#e50000"],
+        ):
             m = self.nybb.explore(color=c)
             out_str = self._fetch_map_string(m)
-            assert '"fillColor":"#ff0000"' in out_str
+            assert f'"fillColor":"{expected}"' in out_str
 
         # list of colors
         colors = ["#333333", "#367324", "#95824f", "#fcaa00", "#ffcc33"]

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -108,14 +108,11 @@ class TestExplore:
 
     def test_simple_color(self):
         """Check color settings"""
-        # single named color
-        m = self.nybb.explore(color="red")
-        out_str = self._fetch_map_string(m)
-        assert '"fillColor":"#ff0000"' in out_str
-        # abbreviated color
-        m = self.nybb.explore(color="r")
-        out_str = self._fetch_map_string(m)
-        assert '"fillColor":"#ff0000"' in out_str
+        # multiple ways to define red
+        for c in ["r", "red", "#ff0000", (1, 0, 0), (1, 0, 0, 1)]:
+            m = self.nybb.explore(color=c)
+            out_str = self._fetch_map_string(m)
+            assert '"fillColor":"#ff0000"' in out_str
 
         # list of colors
         colors = ["#333333", "#367324", "#95824f", "#fcaa00", "#ffcc33"]


### PR DESCRIPTION
Enhance `explore()` to be able to accept **matplotlib** color abbreviations
- b: blue
- g: green
- r: red
- c: cyan
- m: magenta
- y: yellow
- k: black
- w: white

```
import geopandas as gpd
import numpy as np

df = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
df.explore(color="b", style_kwds={"color":"r"}, height=300, width=300)
```

<img width="308" alt="image" src="https://user-images.githubusercontent.com/42769112/175830312-034c64b6-8158-4835-a1f2-afc65e57f8b1.png">

```
df.loc[df.sample(50).index, "gdp_md_est"] = np.nan
df.explore(column="gdp_md_est", missing_kwds={"color":"g"}, height=300, width=300, legend=False)
```
<img width="318" alt="image" src="https://user-images.githubusercontent.com/42769112/175830366-a1280a3c-139e-4ade-bbe9-09ac97af96b3.png">

```
df.boundary.explore(color=np.random.choice(["r","g","b"], len(df)), height=300,width=300)
```
<img width="312" alt="image" src="https://user-images.githubusercontent.com/42769112/175830431-03c7ea25-71fd-4429-8326-b6804719b492.png">
