### PR TITLE
REGR: Fix df.apply NaN to None regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Bug fixes:
 
 Notes on (optional) dependencies:
 
+Version 0.11.1 (July xx, 2022)
+---------------------------------
+
+Small bug-fix release:
+
+- Fix regression in ``apply()`` causing row-wise all nan float columns to be 
+  casted to GeometryDtype (#2482). 
+
+
 Version 0.11 (June 20, 2022)
 ----------------------------
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1509,16 +1509,16 @@ individually so that features may have different properties
                 if self.crs is not None and result.crs is None:
                     result.set_crs(self.crs, inplace=True)
         elif isinstance(result, Series) and result.dtype == "object":
-            # Reconstruct series GeometryDtype if lost by apply
-            try:
-                # if all none, assert list of nones is more likely than list of
-                # null geometry.
-                if not result.isna().all():
+            # Try reconstruct series GeometryDtype if lost by apply
+            # If all none and object dtype assert list of nones is more likely
+            # intended than list of null geometry.
+            if not result.isna().all():
+                try:    
                     # not enough info about func to preserve CRS
                     result = _ensure_geometry(result)
 
-            except TypeError:
-                pass
+                except TypeError:
+                    pass
 
         return result
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1509,7 +1509,6 @@ individually so that features may have different properties
                 if self.crs is not None and result.crs is None:
                     result.set_crs(self.crs, inplace=True)
         elif isinstance(result, Series) and result.dtype == "object":
-            print(result.dtype)
             # Reconstruct series GeometryDtype if lost by apply
             try:
                 # if all none, assert list of nones is more likely than list of

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1513,7 +1513,7 @@ individually so that features may have different properties
             # If all none and object dtype assert list of nones is more likely
             # intended than list of null geometry.
             if not result.isna().all():
-                try:    
+                try:
                     # not enough info about func to preserve CRS
                     result = _ensure_geometry(result)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1508,12 +1508,16 @@ individually so that features may have different properties
             else:
                 if self.crs is not None and result.crs is None:
                     result.set_crs(self.crs, inplace=True)
-        elif isinstance(result, Series):
+        elif isinstance(result, Series) and result.dtype == "object":
+            print(result.dtype)
             # Reconstruct series GeometryDtype if lost by apply
             try:
-                # Note CRS cannot be preserved in this case as func could refer
-                # to any column
-                result = _ensure_geometry(result)
+                # if all none, assert list of nones is more likely than list of
+                # null geometry.
+                if not result.isna().all():
+                    # not enough info about func to preserve CRS
+                    result = _ensure_geometry(result)
+
             except TypeError:
                 pass
 

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -655,11 +655,12 @@ def test_df_apply_returning_series(df):
 
     result = df.apply(lambda row: row.value1, axis=1)
     assert_series_equal(result, df["value1"].rename(None))
-
-
-def test_df_apply_all_nan_dtype(df):
+    # https://github.com/geopandas/geopandas/issues/2480
     result = df.apply(lambda x: float("NaN"), axis=1)
     assert result.dtype == "float64"
+    # assert list of nones is not promoted to GeometryDtype
+    result = df.apply(lambda x: None, axis=1)
+    assert result.dtype == "object"
 
 
 def test_preserve_attrs(df):

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -657,6 +657,11 @@ def test_df_apply_returning_series(df):
     assert_series_equal(result, df["value1"].rename(None))
 
 
+def test_df_apply_all_nan_dtype(df):
+    result = df.apply(lambda x: float("NaN"), axis=1)
+    assert result.dtype == "float64"
+
+
 def test_preserve_attrs(df):
     # https://github.com/geopandas/geopandas/issues/1654
     df.attrs["name"] = "my_name"


### PR DESCRIPTION
This resolves #2480, which was introduced by #2286.

Within there I added the check that `df.apply` producing geometry should return a geoseries
```python
result = df.apply(lambda row: row.geometry, axis=1)
assert_geoseries_equal(result, df.geometry, check_crs=False)
```
This conflicts in the case of columns which are all  NaN as null is a legal value in a geometry array and cast by preserve geometry.

To resolve, this casting to a GeoSeries is more strict - it only happens for object dtypes now, rather than being attempted for any dtype.

This leaves the additional (slightly pathological) case of how a list of how an object dtype of all None's is handled. I've opted that this should stays as all Nones rather than becoming a geometry array - it seems hoping for these to be geometrydtype and finding they're not is preferable to expecting them to stay object dtype and having them promoted to geometry - especially since apply may not even interact with geometry data at all.

