### PR TITLE
Fix: Deprecate version for to_feather / to_parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Deprecations and compatibility notes:
 -   The `version` parameter for the `to_feather` and `to_parquet` methods has
     been replaced with `schema_version`.  `version` will be passed directly to
     underlying feather or parquet writer. `version` will only be used to set
-    `schema_version` if `version is one of 0.1.0 or 0.4.0 (#2496).
+    `schema_version` if `version` is one of 0.1.0 or 0.4.0 (#2496).
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ New features and improvements:
 Deprecations and compatibility notes:
 
 -   The `version` parameter for the `to_feather` and `to_parquet` methods has
-    been replaced with `schema_version` because `version` is a parameter to the
-    underlying parquet writer. It will no longer be used by GeoPandas in a
-    future version. In the interim, `version` will be passed to the parquet
-    writer unless it is one of 0.1.0 or 0.4.0.
+    been replaced with `schema_version`.  `version` will be passed directly to
+    underlying feather or parquet writer. `version` will only be used to set
+    `schema_version` if `version is one of 0.1.0 or 0.4.0 (#2496).
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ New features and improvements:
 
 Deprecations and compatibility notes:
 
+-   The `version` parameter for the `to_feather` and `to_parquet` methods has
+    been replaced with `schema_version` because `version` is a parameter to the
+    underlying parquet writer. It will no longer be used by GeoPandas in a
+    future version. In the interim, `version` will be passed to the parquet
+    writer unless it is one of 0.1.0 or 0.4.0.
+
 Bug fixes:
 
 Notes on (optional) dependencies:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -996,7 +996,7 @@ individually so that features may have different properties
         return df
 
     def to_parquet(
-        self, path, index=None, compression="snappy", version=None, **kwargs
+        self, path, index=None, compression="snappy", schema_version=None, **kwargs
     ):
         """Write a GeoDataFrame to the Parquet format.
 
@@ -1026,7 +1026,7 @@ individually so that features may have different properties
             output except `RangeIndex` which is stored as metadata only.
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        version : {'0.1.0', '0.4.0', None}
+        schema_version : {'0.1.0', '0.4.0', None}
             GeoParquet specification version; if not provided will default to
             latest supported version.
         kwargs
@@ -1056,10 +1056,17 @@ individually so that features may have different properties
         from geopandas.io.arrow import _to_parquet
 
         _to_parquet(
-            self, path, compression=compression, index=index, version=version, **kwargs
+            self,
+            path,
+            compression=compression,
+            index=index,
+            schema_version=schema_version,
+            **kwargs,
         )
 
-    def to_feather(self, path, index=None, compression=None, version=None, **kwargs):
+    def to_feather(
+        self, path, index=None, compression=None, schema_version=None, **kwargs
+    ):
         """Write a GeoDataFrame to the Feather format.
 
         Any geometry columns present are serialized to WKB format in the file.
@@ -1089,7 +1096,7 @@ individually so that features may have different properties
         compression : {'zstd', 'lz4', 'uncompressed'}, optional
             Name of the compression to use. Use ``"uncompressed"`` for no
             compression. By default uses LZ4 if available, otherwise uncompressed.
-        version : {'0.1.0', '0.4.0', None}
+        schema_version : {'0.1.0', '0.4.0', None}
             GeoParquet specification version; if not provided will default to
             latest supported version.
         kwargs
@@ -1110,7 +1117,12 @@ individually so that features may have different properties
         from geopandas.io.arrow import _to_feather
 
         _to_feather(
-            self, path, index=index, compression=compression, version=version, **kwargs
+            self,
+            path,
+            index=index,
+            compression=compression,
+            schema_version=schema_version,
+            **kwargs,
         )
 
     def to_file(self, filename, driver=None, schema=None, index=None, **kwargs):

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -66,13 +66,13 @@ def _remove_id_from_member_of_ensembles(json_dict):
                 member.pop("id", None)
 
 
-def _create_metadata(df, version=None):
+def _create_metadata(df, schema_version=None):
     """Create and encode geo metadata dict.
 
     Parameters
     ----------
     df : GeoDataFrame
-    version : {'0.1.0', '0.4.0', None}
+    schema_version : {'0.1.0', '0.4.0', None}
         GeoParquet specification version; if not provided will default to
         latest supported version.
 
@@ -81,10 +81,12 @@ def _create_metadata(df, version=None):
     dict
     """
 
-    version = version or METADATA_VERSION
+    schema_version = schema_version or METADATA_VERSION
 
-    if version not in SUPPORTED_VERSIONS:
-        raise ValueError(f"version must be one of: {', '.join(SUPPORTED_VERSIONS)}")
+    if schema_version not in SUPPORTED_VERSIONS:
+        raise ValueError(
+            f"schema_version must be one of: {', '.join(SUPPORTED_VERSIONS)}"
+        )
 
     # Construct metadata for each geometry
     column_metadata = {}
@@ -94,7 +96,7 @@ def _create_metadata(df, version=None):
 
         crs = None
         if series.crs:
-            if version == "0.1.0":
+            if schema_version == "0.1.0":
                 crs = series.crs.to_wkt()
             else:  # version >= 0.4.0
                 crs = series.crs.to_json_dict()
@@ -112,7 +114,7 @@ def _create_metadata(df, version=None):
     return {
         "primary_column": df._geometry_column_name,
         "columns": column_metadata,
-        "version": METADATA_VERSION,
+        "version": schema_version or METADATA_VERSION,
         "creator": {"library": "geopandas", "version": geopandas.__version__},
     }
 
@@ -224,7 +226,7 @@ def _validate_metadata(metadata):
             raise ValueError("Only WKB geometry encoding is supported")
 
 
-def _geopandas_to_arrow(df, index=None, version=None):
+def _geopandas_to_arrow(df, index=None, schema_version=None):
     """
     Helper function with main, shared logic for to_parquet/to_feather.
     """
@@ -233,7 +235,7 @@ def _geopandas_to_arrow(df, index=None, version=None):
     _validate_dataframe(df)
 
     # create geo metadata before altering incoming data frame
-    geo_metadata = _create_metadata(df, version=version)
+    geo_metadata = _create_metadata(df, schema_version=schema_version)
 
     df = df.to_wkb()
 
@@ -243,10 +245,13 @@ def _geopandas_to_arrow(df, index=None, version=None):
     # This must be done AFTER creating the table or it is not persisted
     metadata = table.schema.metadata
     metadata.update({b"geo": _encode_metadata(geo_metadata)})
+
     return table.replace_schema_metadata(metadata)
 
 
-def _to_parquet(df, path, index=None, compression="snappy", version=None, **kwargs):
+def _to_parquet(
+    df, path, index=None, compression="snappy", schema_version=None, **kwargs
+):
     """
     Write a GeoDataFrame to the Parquet format.
 
@@ -270,7 +275,7 @@ def _to_parquet(df, path, index=None, compression="snappy", version=None, **kwar
         output except `RangeIndex` which is stored as metadata only.
     compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
         Name of the compression to use. Use ``None`` for no compression.
-    version : {'0.1.0', '0.4.0', None}
+    schema_version : {'0.1.0', '0.4.0', None}
         GeoParquet specification version; if not provided will default to
         latest supported version.
     kwargs
@@ -280,12 +285,25 @@ def _to_parquet(df, path, index=None, compression="snappy", version=None, **kwar
         "pyarrow.parquet", extra="pyarrow is required for Parquet support."
     )
 
+    if kwargs and "version" in kwargs and kwargs["version"] is not None:
+        warnings.warn(
+            "the `version` parameter has been replaced with `schema_version` "
+            "and will be removed in a future release.  It will instead be "
+            "passed to the underlying parquet writer.  If it is 0.1.0 or 0.4.0 "
+            "it will temporarily be used for this method and not passed to the "
+            "parquet writer.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if schema_version is None and kwargs["version"] in SUPPORTED_VERSIONS:
+            schema_version = kwargs.pop("version")
+
     path = _expand_user(path)
-    table = _geopandas_to_arrow(df, index=index, version=version)
+    table = _geopandas_to_arrow(df, index=index, schema_version=schema_version)
     parquet.write_table(table, path, compression=compression, **kwargs)
 
 
-def _to_feather(df, path, index=None, compression=None, version=None, **kwargs):
+def _to_feather(df, path, index=None, compression=None, schema_version=None, **kwargs):
     """
     Write a GeoDataFrame to the Feather format.
 
@@ -310,7 +328,7 @@ def _to_feather(df, path, index=None, compression=None, version=None, **kwargs):
     compression : {'zstd', 'lz4', 'uncompressed'}, optional
         Name of the compression to use. Use ``"uncompressed"`` for no
         compression. By default uses LZ4 if available, otherwise uncompressed.
-    version : {'0.1.0', '0.4.0', None}
+    schema_version : {'0.1.0', '0.4.0', None}
         GeoParquet specification version; if not provided will default to
         latest supported version.
     kwargs
@@ -325,8 +343,21 @@ def _to_feather(df, path, index=None, compression=None, version=None, **kwargs):
     if Version(pyarrow.__version__) < Version("0.17.0"):
         raise ImportError("pyarrow >= 0.17 required for Feather support")
 
+    if kwargs and "version" in kwargs and kwargs["version"] is not None:
+        warnings.warn(
+            "the `version` parameter has been replaced with `schema_version` "
+            "and will be removed in a future release.  It will instead be "
+            "passed to the underlying feather writer.  If it is 0.1.0 or 0.4.0 "
+            "it will temporarily be used for this method and not passed to the "
+            "feather writer.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if schema_version is None and kwargs["version"] in SUPPORTED_VERSIONS:
+            schema_version = kwargs.pop("version")
+
     path = _expand_user(path)
-    table = _geopandas_to_arrow(df, index=index, version=version)
+    table = _geopandas_to_arrow(df, index=index, schema_version=schema_version)
     feather.write_feather(table, path, compression=compression, **kwargs)
 
 
@@ -337,6 +368,7 @@ def _arrow_to_geopandas(table, metadata=None):
     df = table.to_pandas()
 
     metadata = metadata or table.schema.metadata
+
     if metadata is None or b"geo" not in metadata:
         raise ValueError(
             """Missing geo metadata in Parquet/Feather file.

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -286,16 +286,14 @@ def _to_parquet(
     )
 
     if kwargs and "version" in kwargs and kwargs["version"] is not None:
-        warnings.warn(
-            "the `version` parameter has been replaced with `schema_version` "
-            "and will be removed in a future release.  It will instead be "
-            "passed to the underlying parquet writer.  If it is 0.1.0 or 0.4.0 "
-            "it will temporarily be used for this method and not passed to the "
-            "parquet writer.",
-            FutureWarning,
-            stacklevel=2,
-        )
         if schema_version is None and kwargs["version"] in SUPPORTED_VERSIONS:
+            warnings.warn(
+                "the `version` parameter has been replaced with `schema_version`. "
+                "`version` will instead be passed directly to the underlying "
+                "parquet writer unless `version` is 0.1.0 or 0.4.0.",
+                FutureWarning,
+                stacklevel=2,
+            )
             schema_version = kwargs.pop("version")
 
     path = _expand_user(path)
@@ -344,16 +342,14 @@ def _to_feather(df, path, index=None, compression=None, schema_version=None, **k
         raise ImportError("pyarrow >= 0.17 required for Feather support")
 
     if kwargs and "version" in kwargs and kwargs["version"] is not None:
-        warnings.warn(
-            "the `version` parameter has been replaced with `schema_version` "
-            "and will be removed in a future release.  It will instead be "
-            "passed to the underlying feather writer.  If it is 0.1.0 or 0.4.0 "
-            "it will temporarily be used for this method and not passed to the "
-            "feather writer.",
-            FutureWarning,
-            stacklevel=2,
-        )
         if schema_version is None and kwargs["version"] in SUPPORTED_VERSIONS:
+            warnings.warn(
+                "the `version` parameter has been replaced with `schema_version`. "
+                "`version` will instead be passed directly to the underlying "
+                "feather writer unless `version` is 0.1.0 or 0.4.0.",
+                FutureWarning,
+                stacklevel=2,
+            )
             schema_version = kwargs.pop("version")
 
     path = _expand_user(path)

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -679,7 +679,8 @@ def test_write_read_default_crs(tmpdir, format):
 
 
 @pytest.mark.parametrize(
-    "format,schema_version", product(["feather", "parquet"], [None] + SUPPORTED_VERSIONS)
+    "format,schema_version",
+    product(["feather", "parquet"], [None] + SUPPORTED_VERSIONS),
 )
 def test_write_spec_version(tmpdir, format, schema_version):
     if format == "feather":

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -105,8 +105,8 @@ def test_crs_metadata_datum_ensemble():
 
 def test_write_metadata_invalid_spec_version():
     gdf = geopandas.GeoDataFrame(geometry=[box(0, 0, 10, 10)], crs="EPSG:4326")
-    with pytest.raises(ValueError, match="version must be one of"):
-        _create_metadata(gdf, version="invalid")
+    with pytest.raises(ValueError, match="schema_version must be one of"):
+        _create_metadata(gdf, schema_version="invalid")
 
 
 def test_encode_metadata():
@@ -259,7 +259,7 @@ def test_to_parquet_does_not_pass_engine_along(mock_to_parquet):
     # assert that engine keyword is not passed through to _to_parquet (and thus
     # parquet.write_table)
     mock_to_parquet.assert_called_with(
-        df, "", compression="snappy", index=None, version=None
+        df, "", compression="snappy", index=None, schema_version=None
     )
 
 
@@ -681,35 +681,36 @@ def test_write_read_default_crs(tmpdir, format):
 @pytest.mark.parametrize(
     "format,version", product(["feather", "parquet"], [None] + SUPPORTED_VERSIONS)
 )
-def test_write_spec_version(tmpdir, format, version):
+def test_write_deprecated_version_parameter(tmpdir, format, version):
     if format == "feather":
         from pyarrow.feather import read_table
+
+        version = version or 2
 
     else:
         from pyarrow.parquet import read_table
 
+        version = version or "2.6"
+
     filename = os.path.join(str(tmpdir), f"test.{format}")
     gdf = geopandas.GeoDataFrame(geometry=[box(0, 0, 10, 10)], crs="EPSG:4326")
     write = getattr(gdf, f"to_{format}")
-    write(filename, version=version)
 
-    # ensure that we can roundtrip data regardless of version
-    read = getattr(geopandas, f"read_{format}")
-    df = read(filename)
-    assert_geodataframe_equal(df, gdf)
+    with pytest.warns(
+        FutureWarning,
+        match="the `version` parameter has been replaced with `schema_version`",
+    ):
+        write(filename, version=version)
 
-    table = read_table(filename)
-    metadata = json.loads(table.schema.metadata[b"geo"])
-    assert metadata["version"] == version or METADATA_VERSION
+        table = read_table(filename)
+        metadata = json.loads(table.schema.metadata[b"geo"])
 
-    # verify that CRS is correctly handled between versions
-    if version == "0.1.0":
-        assert metadata["columns"]["geometry"]["crs"] == gdf.crs.to_wkt()
-
-    else:
-        crs_expected = gdf.crs.to_json_dict()
-        _remove_id_from_member_of_ensembles(crs_expected)
-        assert metadata["columns"]["geometry"]["crs"] == crs_expected
+        if version in SUPPORTED_VERSIONS:
+            # version is captured as a parameter
+            assert metadata["version"] == version
+        else:
+            # version is passed to underlying writer
+            assert metadata["version"] == METADATA_VERSION
 
 
 @pytest.mark.parametrize("version", ["0.1.0", "0.4.0"])


### PR DESCRIPTION
Fixes #2495 

This deprecates the `version` parameter used for `to_feather` / `to_parquet` because it collides with the underlying feather / parquet writer parameter of the same name.  It is replaced with `schema_version`.

Temporarily, this captures the `version` parameter only if it is 0.1.0 or 0.4.0 (since neither collide with versions of feather or parquet); otherwise it is passed directly to the underlying writer.