### PR TITLE
REGR: regression in ``GeoDataFrame.explode()`` with non-default geometry column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New features and improvements:
 
 Deprecations and compatibility notes:
 
--   The `version` parameter for the `to_feather` and `to_parquet` methods has
+- The `version` parameter for the `to_feather` and `to_parquet` methods has
     been replaced with `schema_version`.  `version` will be passed directly to
     underlying feather or parquet writer. `version` will only be used to set
     `schema_version` if `version` is one of 0.1.0 or 0.4.0 (#2496).
@@ -18,6 +18,8 @@ Bug fixes:
 - Fix regression (RecursionError) in reshape methods such as ``unstack()``
   and ``pivot()`` involving MultiIndex, or GeoDataFrame construction with
   MultiIndex (#2486).
+- Fix regression in ``GeoDataFrame.explode()`` with non-default
+  geometry column name.
 
 Notes on (optional) dependencies:
 
@@ -141,7 +143,6 @@ Notes on (optional) dependencies:
   dependencies have now changed to shapely 1.7, fiona 1.8.13.post1, pyproj 2.6.1.post1,
   matplotlib 3.2, mapclassify 2.4.0 (#2358, #2391)
 
-
 Version 0.10.2 (October 16, 2021)
 ---------------------------------
 
@@ -161,7 +162,6 @@ Small bug-fix release:
 - Fix ``unary_union`` to correctly handle a GeoSeries with missing values (#2181).
 - Avoid internal deprecation warning in ``clip()`` (#2179).
 
-
 Version 0.10.1 (October 8, 2021)
 --------------------------------
 
@@ -169,7 +169,6 @@ Small bug-fix release:
 
 - Fix regression in ``overlay()`` with non-overlapping geometries and a
   non-default ``how`` (i.e. not "intersection") (#2157).
-
 
 Version 0.10.0 (October 3, 2021)
 --------------------------------
@@ -207,7 +206,7 @@ New features and improvements:
 - Improved heuristic to decide how many decimals to show in the repr based on
   whether the CRS is projected or geographic (#1895).
 - Switched the default for ``geocode()`` from GeoCode.Farm to the Photon
-  geocoding API (https://photon.komoot.io) (#2007).
+  geocoding API (<https://photon.komoot.io>) (#2007).
 
 Deprecations and compatibility notes:
 
@@ -256,7 +255,6 @@ Notes on (optional) dependencies:
 - Compatibility fixes for the upcoming Shapely 1.8 (#2087).
 - Compatibility fixes for the latest PyGEOS (#1872, #2014) and matplotlib
   (colorbar issue, #2066).
-
 
 Version 0.9.0 (February 28, 2021)
 ---------------------------------
@@ -374,12 +372,10 @@ Notes on (optional) dependencies:
   is still a default requirement) (#1775).
 - Compatibility with the upcoming Shapely 1.8 (#1659, #1662, #1819).
 
-
 Version 0.8.2 (January 25, 2021)
 --------------------------------
 
 Small bug-fix release for compatibility with PyGEOS 0.9.
-
 
 Version 0.8.1 (July 15, 2020)
 -----------------------------
@@ -391,7 +387,6 @@ Small bug-fix release:
 - Fix spurious warning in ``GeoDataFrame.to_postgis`` (#1497).
 - Fix the un-pickling with ``pd.read_pickle`` of files written with older
   GeoPandas versions (#1511).
-
 
 Version 0.8.0 (June 24, 2020)
 -----------------------------
@@ -491,7 +486,6 @@ And we now have a [Code of Conduct](https://github.com/geopandas/geopandas/blob/
 GeoPandas 0.8.0 is the last release to support Python 3.5. The next release
 will require Python 3.6, pandas 0.24, numpy 1.15 and shapely 1.6 or higher.
 
-
 Version 0.7.0 (February 16, 2020)
 ---------------------------------
 
@@ -536,7 +530,6 @@ Bug fixes:
 - Fixed the ``geopandas.sjoin`` function to handle MultiIndex correctly (#1159).
 - Fixed the ``geopandas.sjoin`` function to preserve the index name of the left GeoDataFrame (#1150).
 
-
 Version 0.6.3 (February 6, 2020)
 ---------------------------------
 
@@ -546,7 +539,6 @@ Small bug-fix release:
 - Fix ``GeoDataFrame.fillna`` to accept non-geometry values again when there are
   no missing values in the geometry column. This should make it easier to fill
   the numerical columns of the GeoDataFrame (#1279).
-
 
 Version 0.6.2 (November 18, 2019)
 ---------------------------------
@@ -560,7 +552,6 @@ Small bug-fix release fixing a few regressions:
 - Fix filtering of a GeoDataFrame to preserve the index type when ending up
   with an empty result (#1190).
 
-
 Version 0.6.1 (October 12, 2019)
 --------------------------------
 
@@ -568,7 +559,6 @@ Small bug-fix release fixing a few regressions:
 
 - Fix ``astype`` when converting to string with Multi geometries (#1145) or when converting a dataframe without geometries (#1144).
 - Fix ``GeoSeries.fillna`` to accept ``np.nan`` again (#1149).
-
 
 Version 0.6.0 (September 27, 2019)
 ----------------------------------
@@ -610,9 +600,7 @@ Bug fixes:
 - Fixed ``GeoDataFrame.to_file`` to preserve VFS file paths (e.g. when a "s3://" path is specified) (#1124).
 - Fixed failing case in ``geopandas.sjoin`` with empty geometries (#1138).
 
-
 In addition, the minimum required versions of some dependencies have been increased: GeoPandas now requirs pandas >=0.23.4 and matplotlib >=2.0.1 (#1002).
-
 
 Version 0.5.1 (July 11, 2019)
 -----------------------------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1825,16 +1825,11 @@ individually so that features may have different properties
 
         exploded_geom = self.geometry.reset_index(drop=True).explode(index_parts=True)
 
-        df = (
-            GeoDataFrame(
-                self.drop(self._geometry_column_name, axis=1).take(
-                    exploded_geom.index.droplevel(-1)
-                ),
-                geometry=exploded_geom.values,
-            )
-            .rename(columns={"geometry": self._geometry_column_name})  # GH2501
-            .__finalize__(self)
+        df = self.drop(self._geometry_column_name, axis=1).take(
+            exploded_geom.index.droplevel(-1)
         )
+        df[exploded_geom.name] = exploded_geom.values
+        df = df.set_geometry(self._geometry_column_name)
 
         if ignore_index:
             df.reset_index(inplace=True, drop=True)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1825,12 +1825,16 @@ individually so that features may have different properties
 
         exploded_geom = self.geometry.reset_index(drop=True).explode(index_parts=True)
 
-        df = GeoDataFrame(
-            self.drop(self._geometry_column_name, axis=1).take(
-                exploded_geom.index.droplevel(-1)
-            ),
-            geometry=exploded_geom.values,
-        ).__finalize__(self)
+        df = (
+            GeoDataFrame(
+                self.drop(self._geometry_column_name, axis=1).take(
+                    exploded_geom.index.droplevel(-1)
+                ),
+                geometry=exploded_geom.values,
+            )
+            .rename(columns={"geometry": self._geometry_column_name})  # GH2501
+            .__finalize__(self)
+        )
 
         if ignore_index:
             df.reset_index(inplace=True, drop=True)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1829,7 +1829,7 @@ individually so that features may have different properties
             exploded_geom.index.droplevel(-1)
         )
         df[exploded_geom.name] = exploded_geom.values
-        df = df.set_geometry(self._geometry_column_name)
+        df = df.set_geometry(self._geometry_column_name).__finalize__(self)
 
         if ignore_index:
             df.reset_index(inplace=True, drop=True)

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1220,6 +1220,15 @@ class TestGeomMethods:
         )
         assert_geodataframe_equal(test_df, expected_df)
 
+    @pytest.mark.parametrize("geom_col", ["geom", "geometry"])
+    def test_explode_geometry_name(self, geom_col):
+        s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
+        df = GeoDataFrame({"col": [1, 2], geom_col: s}, geometry=geom_col)
+        test_df = df.explode(index_parts=True)
+
+        assert test_df.geometry.name == geom_col
+        assert test_df.geometry.name == test_df._geometry_column_name
+
     #
     # Test '&', '|', '^', and '-'
     #

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1229,6 +1229,15 @@ class TestGeomMethods:
         assert test_df.geometry.name == geom_col
         assert test_df.geometry.name == test_df._geometry_column_name
 
+    def test_explode_geometry_name_two_geoms(self):
+        s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
+        df = GeoDataFrame({"col": [1, 2], "geom": s, "geometry": s}, geometry="geom")
+        test_df = df.explode(index_parts=True)
+
+        assert test_df.geometry.name == "geom"
+        assert test_df.geometry.name == test_df._geometry_column_name
+        assert "geometry" in test_df.columns
+
     #
     # Test '&', '|', '^', and '-'
     #


### PR DESCRIPTION
Fixes #2501

Changes in #2292 resulted in a geometry column name being lost and only partially recovered in `__finalize__`. This should ensure that it gets always fully retained.