### PR TITLE
BUG: Fix out of bounds datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Deprecations and compatibility notes:
 Bug fixes:
 - Fix a crash in datetime column reading where the file contains mixed timezone
   offsets (#2479).
-
+- Fix a crash in datetime column reading where the file contains datetimes
+  outside the range supported by [ns] precision (#2505).
 Notes on (optional) dependencies:
 
 Version 0.11 (June 20, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ New features and improvements:
 Deprecations and compatibility notes:
 
 Bug fixes:
+- Fix a crash in datetime column reading where the file contains mixed timezone
+  offsets (#2479).
 
 Notes on (optional) dependencies:
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -344,7 +344,7 @@ def _read_file_fiona(
                 # fiona only supports up to ms precision, any microseconds are
                 # floating point rounding error
                 as_dt = pd.to_datetime(df[k])
-                # if to_datetime succeeded, (i.e. mixed timezone offsets)
+                # # if to_datetime succeeded, (i.e. not mixed timezone offsets)
                 if not (as_dt.dtype == "object"):
                     df[k] = as_dt.dt.round(freq="ms")
             return df

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -343,7 +343,7 @@ def _read_file_fiona(
             for k in datetime_fields:
                 # fiona only supports up to ms precision, any microseconds are
                 # floating point rounding error
-                as_dt = pd.to_datetime(df[k])
+                as_dt = pd.to_datetime(df[k], errors="ignore")
                 # # if to_datetime succeeded, (i.e. not mixed timezone offsets)
                 if not (as_dt.dtype == "object"):
                     df[k] = as_dt.dt.round(freq="ms")

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -343,7 +343,10 @@ def _read_file_fiona(
             for k in datetime_fields:
                 # fiona only supports up to ms precision, any microseconds are
                 # floating point rounding error
-                df[k] = pd.to_datetime(df[k]).dt.round(freq="ms")
+                as_dt = pd.to_datetime(df[k])
+                # if to_datetime succeeded, (i.e. mixed timezone offsets)
+                if not (as_dt.dtype == "object"):
+                    df[k] = as_dt.dt.round(freq="ms")
             return df
 
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -258,7 +258,7 @@ def write_invalid_date_file(date_str, tmpdir, ext, engine):
 
 
 @pytest.mark.parametrize("ext", dt_exts)
-def test_read_file_invalid_datetime(tmpdir, ext, engine):
+def test_read_file_datetime_invalid(tmpdir, ext, engine):
     # https://github.com/geopandas/geopandas/issues/2502
     if not FIONA_GE_1821 and ext == "gpkg":
         # https://github.com/Toblerity/Fiona/issues/1035
@@ -272,21 +272,24 @@ def test_read_file_invalid_datetime(tmpdir, ext, engine):
         assert pd.isna(res["date"].iloc[-1])
     else:
         assert res["date"].dtype == "object"
+        assert isinstance(res["date"].iloc[-1], str)
 
 
 @pytest.mark.parametrize("ext", dt_exts)
-def test_read_file_pandas_invalid_datetime(tmpdir, ext, engine):
+def test_read_file_datetime_out_of_bounds_ns(tmpdir, ext, engine):
     # https://github.com/geopandas/geopandas/issues/2502
-    date_str = "9999-12-31T00:00:00"  # valid to GDAL, not to [ns] format
     if ext == "geojson":
         skip_pyogrio_not_supported(engine)
+
+    date_str = "9999-12-31T00:00:00"  # valid to GDAL, not to [ns] format
     tempfilename = write_invalid_date_file(date_str, tmpdir, ext, engine)
     res = read_file(tempfilename)
-    # Pandas invalid datetimes are read in as object dtype
+    # Pandas invalid datetimes are read in as object dtype (strings)
     assert res["date"].dtype == "object"
+    assert isinstance(res["date"].iloc[0], str)
 
 
-def test_read_file_mixed_datetimes(tmpdir):
+def test_read_file_datetime_mixed_offsets(tmpdir):
     # https://github.com/geopandas/geopandas/issues/2478
     tempfilename = os.path.join(str(tmpdir), "test_mixed_datetime.geojson")
     df = GeoDataFrame(

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -263,6 +263,8 @@ def test_read_file_invalid_datetime(tmpdir, ext, engine):
     if not FIONA_GE_1821 and ext == "gpkg":
         # https://github.com/Toblerity/Fiona/issues/1035
         pytest.skip("Invalid datetime throws in Fiona<1.8.21")
+    elif ext == "geojson":
+        skip_pyogrio_not_supported(engine)
 
     date_str = "9999-99-99T00:00:00"  # invalid date handled by GDAL
     tempfilename = write_invalid_date_file(date_str, tmpdir, ext, engine)
@@ -277,7 +279,7 @@ def test_read_file_invalid_datetime(tmpdir, ext, engine):
 @pytest.mark.parametrize("ext", dt_exts)
 def test_read_file_pandas_invalid_datetime(tmpdir, ext, engine):
     # https://github.com/geopandas/geopandas/issues/2502
-    date_str = "9999-12-31T00:00:00"  # invalid date handled by GDAL
+    date_str = "9999-12-31T00:00:00"  # valid to GDAL, not to [ns] format
     tempfilename = write_invalid_date_file(date_str, tmpdir, ext, engine)
     res = read_file(tempfilename)
     # Pandas invalid datetimes are read in as object dtype

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -232,25 +232,18 @@ def test_to_file_datetime(tmpdir, driver, ext, time, engine):
         assert_series_equal(df["b"], df_read["b"])
 
 
-GEOSJON_WITH_MIXED_TIMEZONES = """
-{
-"type": "FeatureCollection",
-"features": [
-{ "type": "Feature", "properties": {
-                    "date": "2014-08-26 10:01:23.040001+02:00" },
-                    "geometry": { "type": "Point", "coordinates": [ 1.0, 1.0 ] } },
-{ "type": "Feature", "properties": {
-                    "date": "2019-03-07 17:31:43.118999+01:00" },
-                    "geometry": { "type": "Point", "coordinates": [ 1.0, 1.0 ] } }
-            ]
-}
-"""
-
-
 def test_read_file_mixed_datetimes(tmpdir):
     tempfilename = os.path.join(str(tmpdir), "test_mixed_datetime.geojson")
-    with open(tempfilename, "w") as f:
-        print(GEOSJON_WITH_MIXED_TIMEZONES, file=f)
+    df = GeoDataFrame(
+        {
+            "date": [
+                "2014-08-26 10:01:23.040001+02:00",
+                "2019-03-07 17:31:43.118999+01:00",
+            ],
+            "geometry": [Point(1, 1), Point(1, 1)],
+        }
+    )
+    df.to_file(tempfilename)
     res = read_file(tempfilename)  # check mixed tz don't crash GH2478
     if FIONA_GE_1814:
         # cannot represent mixed timezones as datetime type

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -251,6 +251,7 @@ def test_read_file_mixed_datetimes(tmpdir):
     with open(tempfilename, "w") as f:
         print(GEOSJON_WITH_MIXED_TIMEZONES, file=f)
     res = read_file(tempfilename)  # check mixed tz don't crash GH2478
+    print(res)
     assert res["date"].dtype == "object"
 
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -231,19 +231,25 @@ def test_to_file_datetime(tmpdir, driver, ext, time, engine):
         assert_series_equal(df["b"], df_read["b"])
 
 
+GEOSJON_WITH_MIXED_TIMEZONES = """
+{
+"type": "FeatureCollection",
+"features": [
+{ "type": "Feature", "properties": {
+                    "date": "2014-08-26 10:01:23.040001+02:00" },
+                    "geometry": { "type": "Point", "coordinates": [ 1.0, 1.0 ] } },
+{ "type": "Feature", "properties": {
+                    "date": "2019-03-07 17:31:43.118999+01:00" },
+                    "geometry": { "type": "Point", "coordinates": [ 1.0, 1.0 ] } }
+            ]
+}
+"""
+
+
 def test_read_file_mixed_datetimes(tmpdir):
     tempfilename = os.path.join(str(tmpdir), "test_mixed_datetime.geojson")
-    points = [Point(1, 1), Point(1, 1)]
-    df = GeoDataFrame(
-        {
-            "date": [
-                "2014-08-26 10:01:23.040001+02:00",
-                "2019-03-07 17:31:43.118999+01:00",
-            ],
-        },
-        geometry=points,
-    )
-    df.to_file(tempfilename)
+    with open(tempfilename, "w") as f:
+        print(GEOSJON_WITH_MIXED_TIMEZONES, file=f)
     res = read_file(tempfilename)  # check mixed tz don't crash GH2478
     assert res["date"].dtype == "object"
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -263,8 +263,6 @@ def test_read_file_invalid_datetime(tmpdir, ext, engine):
     if not FIONA_GE_1821 and ext == "gpkg":
         # https://github.com/Toblerity/Fiona/issues/1035
         pytest.skip("Invalid datetime throws in Fiona<1.8.21")
-    elif ext == "geojson":
-        skip_pyogrio_not_supported(engine)
 
     date_str = "9999-99-99T00:00:00"  # invalid date handled by GDAL
     tempfilename = write_invalid_date_file(date_str, tmpdir, ext, engine)
@@ -280,6 +278,8 @@ def test_read_file_invalid_datetime(tmpdir, ext, engine):
 def test_read_file_pandas_invalid_datetime(tmpdir, ext, engine):
     # https://github.com/geopandas/geopandas/issues/2502
     date_str = "9999-12-31T00:00:00"  # valid to GDAL, not to [ns] format
+    if ext == "geojson":
+        skip_pyogrio_not_supported(engine)
     tempfilename = write_invalid_date_file(date_str, tmpdir, ext, engine)
     res = read_file(tempfilename)
     # Pandas invalid datetimes are read in as object dtype

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -231,6 +231,23 @@ def test_to_file_datetime(tmpdir, driver, ext, time, engine):
         assert_series_equal(df["b"], df_read["b"])
 
 
+def test_read_file_mixed_datetimes(tmpdir):
+    tempfilename = os.path.join(str(tmpdir), "test_mixed_datetime.geojson")
+    points = [Point(1, 1), Point(1, 1)]
+    df = GeoDataFrame(
+        {
+            "date": [
+                "2014-08-26 10:01:23.040001+02:00",
+                "2019-03-07 17:31:43.118999+01:00",
+            ],
+        },
+        geometry=points,
+    )
+    df.to_file(tempfilename)
+    res = read_file(tempfilename)  # check mixed tz don't crash GH2478
+    assert res["date"].dtype == "object"
+
+
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_to_file_with_point_z(tmpdir, ext, driver, engine):
     """Test that 3D geometries are retained in writes (GH #612)."""

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -40,6 +40,7 @@ try:
 except ImportError:
     fiona = False
     FIONA_GE_1814 = False
+    FIONA_GE_1821 = False
 
 
 PYOGRIO_MARK = pytest.mark.skipif(not pyogrio, reason="pyogrio not installed")


### PR DESCRIPTION
Fixes #2502 dealing with out of bounds datetimes.
Note that this includes #2479 so that should be merged before this (I originally was going to solve both things in the one PR but the tests were a little more complicated than I first thought - with GPKG and GeoJSON behaving differently.