### PR TITLE
MAINT: move static metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,67 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+    "setuptools>=61.0.0",
+]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "geopandas"
+dynamic = ["version"]
+authors = [
+    {name = "Kelsey Jordahl", email = "kjordahl@alum.mit.edu"},
+]
+maintainers = [
+    {name = "GeoPandas contributors"},
+]
+license = {text = "BSD 3-Clause"}
+description = "Geographic pandas extensions"
+keywords = ["GIS", "cartography", "pandas", "shapely"]
+readme = {text = """\
+GeoPandas is a project to add support for geographic data to
+`pandas`_ objects.
+
+The goal of GeoPandas is to make working with geospatial data in
+python easier. It combines the capabilities of `pandas`_ and `shapely`_,
+providing geospatial operations in pandas and a high-level interface
+to multiple geometries to shapely. GeoPandas enables you to easily do
+operations in python that would otherwise require a spatial database
+such as PostGIS.
+
+.. _pandas: https://pandas.pydata.org
+.. _shapely: https://shapely.readthedocs.io/en/latest/
+""", content-type = "text/x-rst"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: GIS",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "fiona >= 1.8",
+    "packaging",
+    "pandas >= 1.0.0",
+    "pyproj >= 2.6.1.post1",
+    "shapely >= 1.7",
+]
+
+[project.urls]
+Home = "https://geopandas.org"
+Repository = "https://github.com/geopandas/geopandas"
+
+[tool.setuptools.packages.find]
+include = [
+    "geopandas",
+    "geopandas.*",
+]
+
+[tool.setuptools.package-data]
+geopandas = [
+    "datasets/nybb_16a.zip",
+    "datasets/naturalearth_cities/*",
+    "datasets/naturalearth_lowres/*",
+    "tests/data/*",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env/python
-"""Installation script
-
-"""
+#!/usr/bin/env python3
+"""Installation script."""
 
 import os
 import sys
@@ -15,67 +13,8 @@ sys.path.append(os.path.dirname(__file__))
 
 import versioneer  # noqa: E402
 
-LONG_DESCRIPTION = """GeoPandas is a project to add support for geographic data to
-`pandas`_ objects.
-
-The goal of GeoPandas is to make working with geospatial data in
-python easier. It combines the capabilities of `pandas`_ and `shapely`_,
-providing geospatial operations in pandas and a high-level interface
-to multiple geometries to shapely. GeoPandas enables you to easily do
-operations in python that would otherwise require a spatial database
-such as PostGIS.
-
-.. _pandas: http://pandas.pydata.org
-.. _shapely: http://shapely.readthedocs.io/en/latest/
-"""
-
-if os.environ.get("READTHEDOCS", False) == "True":
-    INSTALL_REQUIRES = []
-else:
-    INSTALL_REQUIRES = [
-        "pandas >= 1.0.0",
-        "shapely >= 1.7",
-        "fiona >= 1.8",
-        "pyproj >= 2.6.1.post1",
-        "packaging",
-    ]
-
-# get all data dirs in the datasets module
-data_files = []
-
-for item in os.listdir("geopandas/datasets"):
-    if not item.startswith("__"):
-        if os.path.isdir(os.path.join("geopandas/datasets/", item)):
-            data_files.append(os.path.join("datasets", item, "*"))
-        elif item.endswith(".zip"):
-            data_files.append(os.path.join("datasets", item))
-
-data_files.append("tests/data/*")
-
-
+# see pyproject.toml for static project metadata
 setup(
-    name="geopandas",
     version=versioneer.get_version(),
-    description="Geographic pandas extensions",
-    license="BSD",
-    author="GeoPandas contributors",
-    author_email="kjordahl@alum.mit.edu",
-    url="http://geopandas.org",
-    project_urls={
-        "Source": "https://github.com/geopandas/geopandas",
-    },
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/x-rst",
-    packages=[
-        "geopandas",
-        "geopandas.io",
-        "geopandas.tools",
-        "geopandas.datasets",
-        "geopandas.tests",
-        "geopandas.tools.tests",
-    ],
-    package_data={"geopandas": data_files},
-    python_requires=">=3.8",
-    install_requires=INSTALL_REQUIRES,
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
This PR is a follow-up from #2419, and moves the project metatdata from `setup.py` to `pyproject.toml` as described by [PEP 621](https://peps.python.org/pep-0621/) and supported by [setuptools >= 61](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). This supersedes #2424 as there are more community commitments behind maintaining project metadata in `pyproject.toml` than `setup.cfg`.

Details:

- Add new metadata: keywords and classifiers.
- Change author to "Kelsey Jordahl" (with existing email match), move "GeoPandas contributors" as maintainers.
- Change licence from slightly ambiguous "BSD" to SPDX compliant "BSD 3-Clause".
- Change how packages are found, using patterns `geopandas` and `geopandas.*`. This now finds `geopandas.io.tests`, which seems to be unintentionally excluded.
- Change how package data is found, using an explicit list of datasets.
- Option `install_requires` is moved to `pyproject.toml` as `dependencies`. If a workaround is indeed required for ReadTheDocs, a modern approach should be found.
- Most of `setup.py` is used to support versioneer or anyone that expects to see this file. For POSIX systems, it is now an executable, and runs python3.

Some of these are new or changed, so feedback or suggestions are welcome.