### PR TITLE
Improve overlay difference robustness for shapely >=2

### DIFF
--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -1,5 +1,4 @@
 import warnings
-from functools import reduce
 
 import numpy as np
 import pandas as pd
@@ -87,9 +86,7 @@ def _overlay_difference(df1, df2):
     # Create differences
     new_g = []
     for geom, neighbours in zip(df1.geometry, sidx):
-        new = reduce(
-            lambda x, y: x.difference(y), [geom] + list(df2.geometry.iloc[neighbours])
-        )
+        new = geom.difference(df2.geometry.iloc[neighbours].unary_union)
         new_g.append(new)
     differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
     poly_ix = differences.type.isin(["Polygon", "MultiPolygon"])


### PR DESCRIPTION
Using the stress test harness here: https://github.com/bretttully/shapely-v2 I found several collections of geometries that led to a failure of overlay “union” and “difference” when run using shapely v2 and `set_precision(…, 1)`. Shapely 1.8.2 (with naive integer rounding) fails on almost all tests in that repo and v2 passes in all but a small handful of rare cases that are fixed by this PR.

If I am right, this change is only useful for shapely >=2 so not sure how to add tests that fail on main and pass on this PR.

cc @jorisvandenbossche as I believe you wrote the original code here.