### PR TITLE
TST: add test to close GH1852

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -663,6 +663,24 @@ def test_df_apply_returning_series(df):
     assert result.dtype == "object"
 
 
+def test_df_apply_geometry_dtypes(df):
+    # https://github.com/geopandas/geopandas/issues/1852
+    apply_types = []
+
+    def get_dtypes(srs):
+        apply_types.append((srs.name, type(srs)))
+
+    df['geom2'] = df.geometry
+    df.apply(get_dtypes)
+    expected = [
+        ("geometry", GeoSeries),
+        ("value1", pd.Series),
+        ("value2", pd.Series),
+        ("geom2", GeoSeries),
+    ]
+    assert apply_types == expected
+
+
 def test_pivot(df):
     # https://github.com/geopandas/geopandas/issues/2057
     # pivot failing due to creating a MultiIndex

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -670,7 +670,7 @@ def test_df_apply_geometry_dtypes(df):
     def get_dtypes(srs):
         apply_types.append((srs.name, type(srs)))
 
-    df['geom2'] = df.geometry
+    df["geom2"] = df.geometry
     df.apply(get_dtypes)
     expected = [
         ("geometry", GeoSeries),


### PR DESCRIPTION
Closes #1852.

Note this issue was already resolved (pretty sure as part of 0.11 and defining _constructor_sliced but I haven't checked explicitly), this is just a test to document correct behaviour.