### PR TITLE
DOC: assign bounds to geodataframe example

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2628,10 +2628,10 @@ GeometryCollection
         1   0.0   0.0   1.0   1.0
         2   0.0   1.0   1.0   2.0
 
-        You can assign the values to the ``GeoDataFrame`` as:
+        You can assign the bounds to the ``GeoDataFrame`` as:
 
-        >>> gdf["minx"], gdf["miny"], gdf["maxx"],
-        ... gdf["maxy"] = gdf["geometry"].bounds.values.T
+        >>> import pandas as pd
+        >>> gdf = pd.concat([gdf, gdf.bounds], axis=1)
         >>> gdf
                                                     geometry  minx  miny  maxx  maxy
         0                            POINT (2.00000 1.00000)   2.0   1.0   2.0   1.0

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2627,7 +2627,7 @@ GeometryCollection
         0   2.0   1.0   2.0   1.0
         1   0.0   0.0   1.0   1.0
         2   0.0   1.0   1.0   2.0
-        
+
         You can assign the values to the ``GeoDataFrame`` as:
         >>> gdf["minx"], gdf["miny"], gdf["maxx"],
         ... gdf["maxy"] = gdf["geometry"].bounds.values.T

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2627,6 +2627,10 @@ GeometryCollection
         0   2.0   1.0   2.0   1.0
         1   0.0   0.0   1.0   1.0
         2   0.0   1.0   1.0   2.0
+        
+        You can assign the values to the ``GeoDataFrame`` as:
+        >>> gdf["minx"], gdf["miny"], gdf["maxx"],
+        ... gdf["maxy"] = gdf["geometry"].bounds.values.T
         """
         bounds = GeometryArray(self.geometry.values).bounds
         return DataFrame(

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2629,6 +2629,7 @@ GeometryCollection
         2   0.0   1.0   1.0   2.0
 
         You can assign the values to the ``GeoDataFrame`` as:
+
         >>> gdf["minx"], gdf["miny"], gdf["maxx"],
         ... gdf["maxy"] = gdf["geometry"].bounds.values.T
         """

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2632,6 +2632,11 @@ GeometryCollection
 
         >>> gdf["minx"], gdf["miny"], gdf["maxx"],
         ... gdf["maxy"] = gdf["geometry"].bounds.values.T
+        >>> gdf
+                                                    geometry  minx  miny  maxx  maxy
+        0                            POINT (2.00000 1.00000)   2.0   1.0   2.0   1.0
+        1  POLYGON ((0.00000 0.00000, 1.00000 1.00000, 1....   0.0   0.0   1.0   1.0
+        2      LINESTRING (0.00000 1.00000, 1.00000 2.00000)   0.0   1.0   1.0   2.0
         """
         bounds = GeometryArray(self.geometry.values).bounds
         return DataFrame(


### PR DESCRIPTION
I have added one line to the example of `bounds` which shows how to assign the values back to the `GeoDataFrame`.

I know this goes beyond a simple example of the function and more into a cookbook but I think users would benefit from this. Adding it here makes it easy to discover for users. I imagine it'll have quite a bit of usage for people wanting to filter rows of the `GeoDataFrame` from the output of `bounds`. The method should be stable that it continues to work in the future.