### PR TITLE
TST: fix accessor plotting tests skip for no scipy

### DIFF
--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1740,6 +1740,7 @@ class TestGeoplotAccessor:
                         ModuleNotFoundError, match="No module named 'scipy'"
                     ):
                         self.gdf.plot(kind=kind)
+                    return
             elif kind in _y_kinds:
                 kwargs = {"y": "y"}
             elif kind in _xy_kinds:


### PR DESCRIPTION
Just noticed this while running tests in an environment where I did have matplotlib, but not scipy. We are testing here that the plot call raises an ImportError, but then still continued the rest of the test (triggering that import error again, failing the test)