### PR TITLE
DOC: Update copyright year, fix 3rd clause ref to GeoPandas

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2016, GeoPandas developers.
+Copyright (c) 2013-2022, GeoPandas developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -9,7 +9,7 @@ modification, are permitted provided that the following conditions are met:
  * Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- * Neither the name of Enthought, Inc. nor the names of its contributors may
+ * Neither the name of GeoPandas nor the names of its contributors may
    be used to endorse or promote products derived from this software without
    specific prior written permission.
 


### PR DESCRIPTION
This updates the copyright year to current year.

This also corrects the 3rd clause to be the name of the copyright holder as per [BSD license](https://opensource.org/licenses/BSD-3-Clause) 