### PR TITLE
CI: install pyogrio from conda-forge instead of pip

### DIFF
--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -27,6 +27,4 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow
-  - pip
-  - pip:
-    - pyogrio
+  - pyogrio


### PR DESCRIPTION
I don't think there is a reason to still install it with pip (originally this was done to install the latest main version)