### PR TITLE
DOC: pin pydata-sphinx-theme to 0.9 for now

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - mapclassify
   - sphinx
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme=0.9
   - numpydoc
   - ipython
   - pillow


### PR DESCRIPTION
The readthedocs build is also failing since a few weeks (since pydata-sphinx-theme 0.10 was out): https://readthedocs.org/projects/geopandas/builds/17963754/)

Temporary pinning this to 0.9.0, but we should also look into fixing the errors -> https://github.com/geopandas/geopandas/issues/2561