### PR TITLE
COMPAT: resolve new Shapely 2 deprecation warnings

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -796,12 +796,13 @@ def clip_by_rect(data, xmin, ymin, xmax, ymax):
         return pygeos.clip_by_rect(data, xmin, ymin, xmax, ymax)
     else:
         clipped_geometries = np.empty(len(data), dtype=object)
-        clipped_geometries[:] = [
-            shapely.ops.clip_by_rect(s, xmin, ymin, xmax, ymax)
-            if s is not None
-            else None
-            for s in data
-        ]
+        with compat.ignore_shapely2_warnings():
+            clipped_geometries[:] = [
+                shapely.ops.clip_by_rect(s, xmin, ymin, xmax, ymax)
+                if s is not None
+                else None
+                for s in data
+            ]
         return clipped_geometries
 
 

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -519,9 +519,9 @@ def is_ring(data):
         for geom in data:
             if geom is None:
                 results.append(False)
-            elif geom.type == "Polygon":
+            elif geom.geom_type == "Polygon":
                 results.append(geom.exterior.is_ring)
-            elif geom.type in ["LineString", "LinearRing"]:
+            elif geom.geom_type in ["LineString", "LinearRing"]:
                 results.append(geom.is_ring)
             else:
                 results.append(False)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -9,6 +9,7 @@ from pandas.core.internals import SingleBlockManager
 from pyproj import CRS
 import shapely
 from shapely.geometry.base import BaseGeometry
+from shapely.geometry import GeometryCollection
 
 from geopandas.base import GeoPandasBase, _delegate_property
 from geopandas.plotting import plot_series
@@ -788,7 +789,7 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.isna : detect missing values
         """
         if value is None:
-            value = BaseGeometry()
+            value = GeometryCollection()
         return super().fillna(value=value, method=method, inplace=inplace, **kwargs)
 
     def __contains__(self, other):

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -924,7 +924,7 @@ class GeoSeries(GeoPandasBase, Series):
         index = []
         geometries = []
         for idx, s in self.geometry.items():
-            if s.type.startswith("Multi") or s.type == "GeometryCollection":
+            if s.geom_type.startswith("Multi") or s.geom_type == "GeometryCollection":
                 geoms = s.geoms
                 idxs = [(idx, i) for i in range(len(geoms))]
             else:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -48,7 +48,7 @@ def _flatten_multi_geoms(geoms, prefix="Multi"):
         return geoms, np.arange(len(geoms))
 
     for ix, geom in enumerate(geoms):
-        if geom is not None and geom.type.startswith(prefix) and not geom.is_empty:
+        if geom is not None and geom.geom_type.startswith(prefix) and not geom.is_empty:
             for poly in geom.geoms:
                 components.append(poly)
                 component_index.append(ix)
@@ -435,7 +435,7 @@ def plot_series(
     expl_color = np.take(color, multiindex, axis=0) if color_given else color
     expl_series = geopandas.GeoSeries(geoms)
 
-    geom_types = expl_series.type
+    geom_types = expl_series.geom_type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
     line_idx = np.asarray(
         (geom_types == "LineString")
@@ -834,7 +834,7 @@ GON (((-122.84000 49.00000, -120.0000...
     nan_idx = np.take(nan_idx, multiindex, axis=0)
     expl_series = geopandas.GeoSeries(geoms)
 
-    geom_types = expl_series.type
+    geom_types = expl_series.geom_type
     poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
     line_idx = np.asarray(
         (geom_types == "LineString")

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -180,9 +180,9 @@ def assert_geoseries_equal(
     assert left.index.equals(right.index), "index: %s != %s" % (left.index, right.index)
 
     if check_geom_type:
-        assert (left.type == right.type).all(), "type: %s != %s" % (
-            left.type,
-            right.type,
+        assert (left.geom_type == right.geom_type).all(), "type: %s != %s" % (
+            left.geom_type,
+            right.geom_type,
         )
 
     if normalize:

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_index_equal
 
 from pyproj import CRS
 from shapely.geometry import (
+    GeometryCollection,
     LineString,
     MultiLineString,
     MultiPoint,
@@ -384,7 +385,7 @@ class TestSeries:
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_missing_values():
-    s = GeoSeries([Point(1, 1), None, np.nan, BaseGeometry(), Polygon()])
+    s = GeoSeries([Point(1, 1), None, np.nan, GeometryCollection(), Polygon()])
 
     # construction -> missing values get normalized to None
     assert s[1] is None

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -888,7 +888,7 @@ class TestColorParamArray:
             color += ["red", "green", "blue"]
 
         self.gdf = GeoDataFrame({"geometry": geom, "color_rgba": color})
-        self.mgdf = self.gdf.dissolve(self.gdf.type)
+        self.mgdf = self.gdf.dissolve(self.gdf.geom_type)
 
     def test_color_single(self):
         ax = self.gdf.plot(color=self.gdf["color_rgba"])

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -34,7 +34,7 @@ def validate_boro_df(df, case_sensitive=False):
     else:
         for col in columns:
             assert col.lower() in (dfcol.lower() for dfcol in df.columns)
-    assert Series(df.geometry.type).dropna().eq("MultiPolygon").all()
+    assert Series(df.geometry.geom_type).dropna().eq("MultiPolygon").all()
 
 
 def get_srid(df):

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -35,7 +35,7 @@ def _overlay_intersection(df1, df2):
         right = df2.geometry.take(idx2)
         right.reset_index(drop=True, inplace=True)
         intersections = left.intersection(right)
-        poly_ix = intersections.type.isin(["Polygon", "MultiPolygon"])
+        poly_ix = intersections.geom_type.isin(["Polygon", "MultiPolygon"])
         intersections.loc[poly_ix] = intersections[poly_ix].buffer(0)
 
         # only keep actual intersecting geometries
@@ -92,7 +92,7 @@ def _overlay_difference(df1, df2):
         )
         new_g.append(new)
     differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
-    poly_ix = differences.type.isin(["Polygon", "MultiPolygon"])
+    poly_ix = differences.geom_type.isin(["Polygon", "MultiPolygon"])
     differences.loc[poly_ix] = differences[poly_ix].buffer(0)
     geom_diff = differences[~differences.is_empty].copy()
     dfdiff = df1[~differences.is_empty].copy()

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -404,7 +404,7 @@ class TestSpatialJoinNYBB:
         df = sjoin(self.pointdf, self.polydf, how="left")
         assert df.shape == (21, 8)
         for i, row in df.iterrows():
-            assert row.geometry.type == "Point"
+            assert row.geometry.geom_type == "Point"
         assert "pointattr1" in df.columns
         assert "BoroCode" in df.columns
 
@@ -415,9 +415,9 @@ class TestSpatialJoinNYBB:
         assert df.shape == (12, 8)
         assert df.shape == df2.shape
         for i, row in df.iterrows():
-            assert row.geometry.type == "MultiPolygon"
+            assert row.geometry.geom_type == "MultiPolygon"
         for i, row in df2.iterrows():
-            assert row.geometry.type == "MultiPolygon"
+            assert row.geometry.geom_type == "MultiPolygon"
 
     def test_sjoin_inner(self):
         df = sjoin(self.pointdf, self.polydf, how="inner")

--- a/geopandas/tools/util.py
+++ b/geopandas/tools/util.py
@@ -32,8 +32,8 @@ def collect(x, multi=False):
     # must be the same. If there is more than one element,
     # they cannot be Multi*, i.e., can't pass in combination of
     # Point and MultiPoint... or even just MultiPoint
-    t = x[0].type
-    if not all(g.type == t for g in x):
+    t = x[0].geom_type
+    if not all(g.geom_type == t for g in x):
         raise ValueError("Geometry type must be homogeneous")
     if len(x) > 1 and t.startswith("Multi"):
         raise ValueError("Cannot collect {0}. Must have single geometries".format(t))


### PR DESCRIPTION
This fixes some new warnings that you get when running with Shapely 2:

- `BaseGeometry()` -> `GeometryCollection()` (the result is the same in practice, both on shapely 1.8 as 2.0)
- `type` -> `geom_type` (shapely deprecated `.type` to only have `.geom_type`, so I updated that in our code base. I also updated equivalent usage for GeoSeries, but so we can also deprecate GeoSeries.type for GeoSeries.geom_type if we want)