### PR TITLE
ENH: enable list-like parameters in explore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Development version
 -------------------
 
 New features and improvements:
+- Enable array-like parameters to be passed to ``GeoDataFrame.explore()`` 
+  ``style_kwds`` and ``marker_kwds``.  Effectively a simpler interface to
+  ``style_function``
 
 Deprecations and compatibility notes:
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -154,10 +154,10 @@ def _explore(
     marker_kwds: dict (default {})
         Additional keywords to be passed to the selected ``marker_type``, e.g.:
 
-        radius : float (default 2 for ``circle_marker`` and 50 for ``circle``))
-            Radius of the circle, in meters (for ``circle``) or pixels
+        radius : float, array-like
+            Radius of the circle, in meters (for ``'circle'``) or pixels
             (for ``circle_marker``).
-        fill : bool (default True)
+        fill : bool, array-like (default True)
             Whether to fill the ``circle`` or ``circle_marker`` with color.
         icon : folium.map.Icon
             the :class:`folium.map.Icon` object to use to render the marker.
@@ -167,21 +167,21 @@ def _explore(
     style_kwds : dict (default {})
         Additional style to be passed to folium ``style_function``:
 
-        stroke : bool (default True)
+        stroke : bool, array-like (default True)
             Whether to draw stroke along the path. Set it to ``False`` to
             disable borders on polygons or circles.
-        color : str
+        color : str, array-like
             Stroke color
-        weight : int
+        weight : int, array-like
             Stroke width in pixels
         opacity : float (default 1.0)
             Stroke opacity
-        fill : boolean (default True)
+        fill : boolean, array-like (default True)
             Whether to fill the path with color. Set it to ``False`` to
             disable filling on polygons or circles.
-        fillColor : str
+        fillColor : str, array-like
             Fill color. Defaults to the value of the color option
-        fillOpacity : float (default 0.5)
+        fillOpacity : float, array-like (default 0.5)
             Fill opacity.
         style_function : callable
             Function mapping a GeoJson Feature to a style ``dict``.
@@ -265,7 +265,8 @@ GON (((180.00000 -16.06713, 180.00000...
     try:
         import branca as bc
         import folium
-        import matplotlib.cm as cm
+
+        # import matplotlib.cm as cm
         import matplotlib.colors as colors
         import matplotlib.pyplot as plt
         from mapclassify import classify
@@ -276,6 +277,22 @@ GON (((180.00000 -16.06713, 180.00000...
             "'conda install -c conda-forge folium matplotlib mapclassify' "
             "or 'pip install folium matplotlib mapclassify'."
         )
+    # prepare for change in matplotlib
+    try:
+        from matplotlib import colormaps as cm_
+
+        cm_["viridis"].resampled(10)
+
+        def _cm(cmap, lut=None):
+            cmap = "viridis" if not cmap else cmap
+            cm = cm_[cmap]
+            return cm.resampled(lut) if lut else cm
+
+    except (ImportError, AttributeError):
+        import matplotlib.cm as cm_
+
+        def _cm(cmap, lut=None):
+            return cm_.get_cmap(cmap, lut)
 
     # xyservices is an optional dependency
     try:
@@ -395,11 +412,9 @@ GON (((180.00000 -16.06713, 180.00000...
             # colormap exists in matplotlib
             if cmap in plt.colormaps():
 
-                color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, N)(cat.codes)
-                )
+                color = np.apply_along_axis(colors.to_hex, 1, _cm(cmap, N)(cat.codes))
                 legend_colors = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, N)(range(N))
+                    colors.to_hex, 1, _cm(cmap, N)(range(N))
                 )
 
             # colormap is matplotlib.Colormap
@@ -439,9 +454,7 @@ GON (((180.00000 -16.06713, 180.00000...
                 binning = classify(
                     np.asarray(gdf[column][~nan_idx]), scheme, **classification_kwds
                 )
-                color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, k)(binning.yb)
-                )
+                color = np.apply_along_axis(colors.to_hex, 1, _cm(cmap, k)(binning.yb))
 
             else:
 
@@ -451,8 +464,16 @@ GON (((180.00000 -16.06713, 180.00000...
                 )
 
                 color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, 256)(binning.yb)
+                    colors.to_hex, 1, _cm(cmap, 256)(binning.yb)
                 )
+
+    # some marker and style parameters can be list like.
+    # add columns and style function to support this
+    gdf, style_list_params = _list_like_params(
+        gdf,
+        style_kwds=style_kwds,
+        marker_kwds=marker_kwds,
+    )
 
     # set default style
     if "fillOpacity" not in style_kwds:
@@ -467,7 +488,7 @@ GON (((180.00000 -16.06713, 180.00000...
     else:
 
         def _no_style(x):
-            return {}
+            return style_list_params(x)
 
         style_kwds_function = _no_style
 
@@ -513,6 +534,7 @@ GON (((180.00000 -16.06713, 180.00000...
                     }
                     return {
                         **base_style,
+                        **style_list_params(x),
                         **style_kwds_function(x),
                     }
 
@@ -527,6 +549,7 @@ GON (((180.00000 -16.06713, 180.00000...
                     }
                     return {
                         **base_style,
+                        **style_list_params(x),
                         **style_kwds_function(x),
                     }
 
@@ -534,7 +557,7 @@ GON (((180.00000 -16.06713, 180.00000...
     else:  # use folium default
 
         def _style_default(x):
-            return {**style_kwds, **style_kwds_function(x)}
+            return {**style_kwds, **style_list_params(x), **style_kwds_function(x)}
 
         style_function = _style_default
 
@@ -622,7 +645,7 @@ GON (((180.00000 -16.06713, 180.00000...
                 colormap_kwds["max_labels"] = legend_kwds.pop("max_labels")
             if scheme:
                 cb_colors = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, binning.k)(range(binning.k))
+                    colors.to_hex, 1, _cm(cmap, binning.k)(range(binning.k))
                 )
                 if cbar:
                     if legend_kwds.pop("scale", True):
@@ -657,7 +680,7 @@ GON (((180.00000 -16.06713, 180.00000...
                     colorbar = cmap
                 else:
 
-                    mp_cmap = cm.get_cmap(cmap)
+                    mp_cmap = _cm(cmap)
                     cb_colors = np.apply_along_axis(
                         colors.to_hex, 1, mp_cmap(range(mp_cmap.N))
                     )
@@ -706,7 +729,9 @@ def _tooltip_popup(type, fields, gdf, **kwds):
         elif isinstance(fields, str):
             fields = [fields]
 
-    for field in ["__plottable_column", "__folium_color"]:
+    for field in ["__plottable_column"] + [
+        c for c in gdf.columns if c.startswith("__folium_")
+    ]:
         if field in fields:
             fields.remove(field)
 
@@ -834,6 +859,39 @@ def _categorical_legend(m, title, categories, colors):
     m.get_root().html.add_child(body)
 
 
+def _list_like_params(gdf, style_kwds={}, marker_kwds={}):
+    """
+    add columns if required and create a style function for list like
+    parameters
+    """
+    cols = {}
+
+    def _kwds_extract(gdf, kwds, cols):
+        # copy dict as in some cases deleting from it
+        for k, v in kwds.copy().items():
+            if pd.api.types.is_list_like(v) and len(v) == len(gdf):
+                c = f"__folium_{k}"
+                if isinstance(gdf, geopandas.GeoSeries):
+                    gdf = geopandas.GeoDataFrame(geometry=gdf, crs=gdf.crs)
+                gdf[c] = v
+                cols[k] = c
+                # a number of list like structures do not serialize into folium/
+                # leaflet.  drop it as it has been consumed
+                del kwds[k]
+            elif isinstance(gdf, geopandas.GeoDataFrame) and v in gdf.columns:
+                cols[k] = v
+
+        return gdf, cols
+
+    gdf, cols = _kwds_extract(gdf, marker_kwds, cols)
+    gdf, cols = _kwds_extract(gdf, style_kwds, cols)
+
+    def _style_list_params(x):
+        return {k: x["properties"][v] for k, v in cols.items()}
+
+    return gdf, _style_list_params
+
+
 def _explore_geoseries(
     s,
     color=None,
@@ -892,7 +950,7 @@ def _explore_geoseries(
     marker_kwds: dict (default {})
         Additional keywords to be passed to the selected ``marker_type``, e.g.:
 
-        radius : float
+        radius : float, array-like
             Radius of the circle, in meters (for ``'circle'``) or pixels
             (for ``circle_marker``).
         icon : folium.map.Icon
@@ -903,21 +961,21 @@ def _explore_geoseries(
     style_kwds : dict (default {})
         Additional style to be passed to folium ``style_function``:
 
-        stroke : bool (default True)
+        stroke : bool, array-like (default True)
             Whether to draw stroke along the path. Set it to ``False`` to
             disable borders on polygons or circles.
-        color : str
+        color : str, array-like
             Stroke color
-        weight : int
+        weight : int, array-like
             Stroke width in pixels
-        opacity : float (default 1.0)
+        opacity : float, array-like (default 1.0)
             Stroke opacity
-        fill : boolean (default True)
+        fill : boolean, array-like (default True)
             Whether to fill the path with color. Set it to ``False`` to
             disable filling on polygons or circles.
-        fillColor : str
+        fillColor : str, array-like
             Fill color. Defaults to the value of the color option
-        fillOpacity : float (default 0.5)
+        fillOpacity : float, array-like (default 0.5)
             Fill opacity.
         style_function : callable
             Function mapping a GeoJson Feature to a style ``dict``.

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -362,6 +362,34 @@ class TestExplore:
         with pytest.raises(ValueError, match="'style_function' has to be a callable"):
             self.world.explore(style_kwds={"style_function": "not callable"})
 
+        # geopandas/issues/2564 list like paramters to marker_kwds and style_kwds
+        gdf = self.cities.copy()
+        gdf["cool"] = (gdf["name"].str[0].apply(ord) - ord("A")) // 8
+        gdf["size"] = gdf["cool"] * 4
+        gdf["fill"] = gdf["cool"] >= 2
+        m = gdf.explore(
+            marker_kwds={"radius": "size", "fill": pd.Series(gdf["fill"])},
+            style_kwds={
+                "fillColor": gdf["cool"].map(
+                    {0: "red", 1: "blue", 2: "green", 3: "yellow"}
+                )
+            },
+        )
+        actual = [
+            "".join(line.split())
+            for line in m._parent.render().split("\n")
+            if "return" in line and "radius" in line
+        ]
+
+        expected = [
+            'return{"fill":true,"fillColor":"green","fillOpacity":0.5,"radius":8,"weight":2};',    # noqa: E501
+            'return{"fill":false,"fillColor":"red","fillOpacity":0.5,"radius":0,"weight":2};',     # noqa: E501
+            'return{"fill":true,"fillColor":"yellow","fillOpacity":0.5,"radius":12,"weight":2};',  # noqa: E501
+            'return{"fill":false,"fillColor":"blue","fillOpacity":0.5,"radius":4,"weight":2};',    # noqa: E501
+        ]
+
+        assert actual == expected
+
     def test_tooltip(self):
         """Test tooltip"""
         # default with no tooltip or popup


### PR DESCRIPTION
Extend capability to pass list-like parameters to be used in styling **folium** map when parameters of `style_kwds` and `marker_kwds` are list like

<details>
<summary>Example</summary>

```
import geopandas as gpd
import pandas as pd

gdf = gpd.read_file(gpd.datasets.get_path("naturalearth_cities"))
gdf["cool"] = (gdf["name"].str[0].apply(ord) - ord("A")) // 8
gdf["size"] = gdf["cool"] * 4
gdf["fill"] = gdf["cool"] >= 2
gdf.explore(
    marker_kwds={"radius": "size", "fill": pd.Series(gdf["fill"])},
    style_kwds={
        "fillColor": gdf["cool"].map({0: "red", 1: "blue", 2: "green", 3: "yellow"})
    },
    height=300, width=600
)

```

<img width="619" alt="image" src="https://user-images.githubusercontent.com/42769112/192518798-67891342-7da4-4088-9014-1b6d9cbaffd9.png">

</details>

Additionally have updated approach to using **matplotlib** colormaps so that tests do not generate deprecation warnings.
