### PR TITLE
DEPR: remove `_crs` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features and improvements:
 - Add where filter to ``read_file`` (#2552)
 
 Deprecations and compatibility notes:
-- Deprecated internal GeoDataFrame attribute `_crs` has been removed (#2578).
+- Accessing the `crs` of a `GeoDataFrame` without active geometry column was deprecated and this now raises an AttributeError (#2578).
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New features and improvements:
 - Add where filter to ``read_file`` (#2552)
 
 Deprecations and compatibility notes:
+- Deprecated internal GeoDataFrame attribute `_crs` has been removed (#2578).
 
 Bug fixes:
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -424,14 +424,13 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         GeoDataFrame.to_crs : re-project to another CRS
 
         """
-        # TODO: remove try/except in 0.12
         try:
             return self.geometry.crs
         except AttributeError:
-            # the active geometry column might not be set
             raise AttributeError(
-                "The CRS attribute of a GeoDataFrame without a "
-                "geometry column is not defined."
+                "The CRS attribute of a GeoDataFrame without an active "
+                "geometry column is not defined. Use GeoDataFrame.set_geometry "
+                "to set the active geometry column."
             )
 
     @crs.setter

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -297,12 +297,14 @@ class TestGeometryArrayCRS:
 
         # geometry column without geometry
         df = GeoDataFrame({"geometry": [0, 1]})
-        with pytest.warns(
-            FutureWarning, match="Accessing CRS of a GeoDataFrame without a geometry"
+        with pytest.raises(
+            ValueError,
+            match="Assigning CRS to a GeoDataFrame without an active geometry",
         ):
             df.crs = 27700
-        with pytest.warns(
-            FutureWarning, match="Accessing CRS of a GeoDataFrame without a geometry"
+        with pytest.raises(
+            AttributeError,
+            match="The CRS attribute of a GeoDataFrame without a geometry",
         ):
             assert df.crs == self.osgb
 
@@ -310,8 +312,9 @@ class TestGeometryArrayCRS:
         df = GeoDataFrame({"col": range(10)}, geometry=self.arr)
         df["geom2"] = df.geometry.centroid
         subset = df[["col", "geom2"]]
-        with pytest.warns(
-            FutureWarning, match="Accessing CRS of a GeoDataFrame without a geometry"
+        with pytest.raises(
+            AttributeError,
+            match="The CRS attribute of a GeoDataFrame without a geometry",
         ):
             assert subset.crs == self.osgb
 
@@ -355,17 +358,13 @@ class TestGeometryArrayCRS:
         arr = from_shapely(self.geoms)
         df = GeoDataFrame({"col1": [1, 2], "geometry": arr}, crs=4326)
 
-        # create a dataframe without geometry column, but currently has cached _crs
+        # override geometry with non geometry
         with pytest.warns(UserWarning):
             df["geometry"] = 1
 
-        # assigning a list of geometry object will currently use _crs
-        with pytest.warns(
-            FutureWarning,
-            match="Setting geometries to a GeoDataFrame without a geometry",
-        ):
-            df["geometry"] = self.geoms
-        assert df.crs == self.wgs
+        # assigning a list of geometry object doesn't have cached access to 4326
+        df["geometry"] = self.geoms
+        assert df.crs is None
 
     @pytest.mark.parametrize(
         "scalar", [None, Point(0, 0), LineString([(0, 0), (1, 1)])]

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -304,7 +304,7 @@ class TestGeometryArrayCRS:
             df.crs = 27700
         with pytest.raises(
             AttributeError,
-            match="The CRS attribute of a GeoDataFrame without a geometry",
+            match="The CRS attribute of a GeoDataFrame without an active",
         ):
             assert df.crs == self.osgb
 
@@ -314,7 +314,7 @@ class TestGeometryArrayCRS:
         subset = df[["col", "geom2"]]
         with pytest.raises(
             AttributeError,
-            match="The CRS attribute of a GeoDataFrame without a geometry",
+            match="The CRS attribute of a GeoDataFrame without an active",
         ):
             assert subset.crs == self.osgb
 

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -112,11 +112,11 @@ class TestMerging:
         # Note this is not consistent with concat([gdf, gdf], axis=1) where the
         # left metadata is set on the result. This is deliberate for now.
         assert type(result) is GeoDataFrame
-        self._check_metadata(result, geometry_column_name=None, crs=None)
+        assert result._geometry_column_name is None
         assert_index_equal(pd.Index([0, 1]), result.columns)
 
         gseries2.name = "foo"
         result2 = pd.concat([gseries2, self.gseries], axis=1)
         assert type(result2) is GeoDataFrame
-        self._check_metadata(result2, geometry_column_name=None, crs=None)
+        assert result._geometry_column_name is None
         assert_index_equal(pd.Index(["foo", 0]), result2.columns)


### PR DESCRIPTION
This is almost entirely based on the TODOs in https://github.com/geopandas/geopandas/pull/2373.

The only deviation I've made is in the getter for `crs`, I re-raise an AttributeError for trying to access `gdf.crs` when the active geometry column is not set. I think this is clearer for a user - rather than getting an error about `gdf.geometry` not being defined propagating from inside `gdf.crs` - and there is also the current case of where `gdf.geometry` isn't defined but `"geometry"` is in `gdf.columns` which gives pd.Series has no attribute crs right now - but that would change after #2575.
 