### PR TITLE
COMPAT: return None instead of empty collection in unary_union using shapely 2.0

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -998,7 +998,11 @@ def relate(data, other):
 
 def unary_union(data):
     if compat.USE_SHAPELY_20:
-        return shapely.union_all(data)
+        data = shapely.union_all(data)
+        if data.empty:
+            return None
+        else:
+            return data
     elif compat.USE_PYGEOS:
         return _pygeos_to_shapely(pygeos.union_all(data))
     else:

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -999,7 +999,7 @@ def relate(data, other):
 def unary_union(data):
     if compat.USE_SHAPELY_20:
         data = shapely.union_all(data)
-        if data.empty:
+        if data.is_empty:
             return None
         else:
             return data

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -999,7 +999,9 @@ def relate(data, other):
 def unary_union(data):
     if compat.USE_SHAPELY_20:
         data = shapely.union_all(data)
-        if data.is_empty:
+        if data is None:  # shapely 2.0a1
+            return None
+        if data.is_empty:  # shapely 2.0
             return None
         else:
             return data


### PR DESCRIPTION
xref #2579 

This should ensure we have the same behaviour or unary_union not matter the geometry backend and turn our CI green again.

There is still an open discussion on whether we want to keep `None` or transition towards GeometryCollection Empty to have a consistency with shapely.