### PR TITLE
DOC: change geometries’s to geometry's

### DIFF
--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -18,7 +18,7 @@ Constructive Methods
 .. attribute:: GeoSeries.boundary
 
   Returns a :class:`~geopandas.GeoSeries` of lower dimensional objects representing
-  each geometries's set-theoretic `boundary`.
+  each geometry's set-theoretic `boundary`.
 
 .. attribute:: GeoSeries.centroid
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -424,7 +424,7 @@ GeometryCollection
     @property
     def boundary(self):
         """Returns a ``GeoSeries`` of lower dimensional objects representing
-        each geometries's set-theoretic `boundary`.
+        each geometry's set-theoretic `boundary`.
 
         Examples
         --------


### PR DESCRIPTION
I worked on the following issue and fixed typos (geometries’s to geometry's) in docs.

https://github.com/geopandas/geopandas/issues/2563