### PR TITLE
COMPAT: resolve matplotlib.cm warning in explore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New features and improvements:
 
 Deprecations and compatibility notes:
 
+- resolve ``matplotlib.cm`` warning in ``.explore()`` (#2596)
+
 Bug fixes:
 
 Notes on (optional) dependencies:

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -265,7 +265,7 @@ GON (((180.00000 -16.06713, 180.00000...
     try:
         import branca as bc
         import folium
-        import matplotlib.cm as cm
+        from matplotlib import colormaps as cm
         import matplotlib.colors as colors
         import matplotlib.pyplot as plt
         from mapclassify import classify
@@ -396,10 +396,10 @@ GON (((180.00000 -16.06713, 180.00000...
             if cmap in plt.colormaps():
 
                 color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, N)(cat.codes)
+                    colors.to_hex, 1, cm.get_cmap(cmap).resampled(N)(cat.codes)
                 )
                 legend_colors = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, N)(range(N))
+                    colors.to_hex, 1, cm.get_cmap(cmap).resampled(N)(range(N))
                 )
 
             # colormap is matplotlib.Colormap
@@ -440,7 +440,7 @@ GON (((180.00000 -16.06713, 180.00000...
                     np.asarray(gdf[column][~nan_idx]), scheme, **classification_kwds
                 )
                 color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, k)(binning.yb)
+                    colors.to_hex, 1, cm.get_cmap(cmap).resampled(k)(binning.yb)
                 )
 
             else:
@@ -451,7 +451,7 @@ GON (((180.00000 -16.06713, 180.00000...
                 )
 
                 color = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, 256)(binning.yb)
+                    colors.to_hex, 1, cm.get_cmap(cmap).resampled(256)(binning.yb)
                 )
 
     # set default style
@@ -622,7 +622,9 @@ GON (((180.00000 -16.06713, 180.00000...
                 colormap_kwds["max_labels"] = legend_kwds.pop("max_labels")
             if scheme:
                 cb_colors = np.apply_along_axis(
-                    colors.to_hex, 1, cm.get_cmap(cmap, binning.k)(range(binning.k))
+                    colors.to_hex,
+                    1,
+                    cm.get_cmap(cmap).resampled(binning.k)(range(binning.k)),
                 )
                 if cbar:
                     if legend_kwds.pop("scale", True):
@@ -656,11 +658,11 @@ GON (((180.00000 -16.06713, 180.00000...
                 if isinstance(cmap, bc.colormap.ColorMap):
                     colorbar = cmap
                 else:
-
                     mp_cmap = cm.get_cmap(cmap)
                     cb_colors = np.apply_along_axis(
                         colors.to_hex, 1, mp_cmap(range(mp_cmap.N))
                     )
+
                     # linear legend
                     if mp_cmap.N > 20:
                         colorbar = bc.colormap.LinearColormap(

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -279,10 +279,19 @@ GON (((180.00000 -16.06713, 180.00000...
         import branca as bc
         import folium
         import matplotlib
-        from matplotlib import colormaps as cm
         import matplotlib.colors as colors
         import matplotlib.pyplot as plt
         from mapclassify import classify
+
+        # isolate MPL version - GH#2596
+        mpl = Version(matplotlib.__version__)
+        if mpl >= Version("3.6"):
+            MPL_36 = True
+            from matplotlib import colormaps as cm
+        else:
+            MPL_36 = False
+            import matplotlib.cm as cm
+
     except (ImportError, ModuleNotFoundError):
         raise ImportError(
             "The 'folium', 'matplotlib' and 'mapclassify' packages are required for "
@@ -298,13 +307,6 @@ GON (((180.00000 -16.06713, 180.00000...
         HAS_XYZSERVICES = True
     except (ImportError, ModuleNotFoundError):
         HAS_XYZSERVICES = False
-
-    # isolate MPL version - GH#2596
-    mpl = Version(matplotlib.__version__)
-    if mpl >= Version("3.6"):
-        MPL_36 = True
-    else:
-        MPL_36 = False
 
     gdf = df.copy()
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -284,12 +284,10 @@ GON (((180.00000 -16.06713, 180.00000...
         from mapclassify import classify
 
         # isolate MPL version - GH#2596
-        mpl = Version(matplotlib.__version__)
-        if mpl >= Version("3.6"):
-            MPL_36 = True
+        MPL_36 = Version(matplotlib.__version__) >= Version("3.6")
+        if MPL_36:
             from matplotlib import colormaps as cm
         else:
-            MPL_36 = False
             import matplotlib.cm as cm
 
     except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
This PR resolves the [`PendingDeprecationWarning`](https://github.com/geopandas/geopandas/actions/runs/3243624358/jobs/5318620857#step:6:4291) that is being thrown by `matplotlib` due to the upcoming deprecation of [`matplotlib.cm`](https://matplotlib.org/stable/api/cm_api.html#module-matplotlib.cm).

```
PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
```