### PR TITLE
Add warning when having both PyGEOS and Shapely 2.0 installed

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -140,8 +140,13 @@ def set_use_pygeos(val=None):
             "GeoPandas will still use PyGEOS by default for now. To force to use and "
             "test Shapely 2.0, you have to set the environment variable USE_PYGEOS=0. "
             "You can do this before starting the Python process, or in your code "
-            "before importing geopandas:\n\nimport os\nos.environ['USE_PYGEOS'] = '0'"
-            "\nimport geopandas\n\n",
+            "before importing geopandas:"
+            "\n\nimport os\nos.environ['USE_PYGEOS'] = '0'\nimport geopandas\n\n"
+            "In a future release, GeoPandas will switch to using Shapely by default. "
+            "If you are using PyGEOS directly (calling PyGEOS functions on geometries "
+            "from GeoPandas), this will then stop working and you are encouraged to "
+            "migrate from PyGEOS to Shapely 2.0 "
+            "(https://shapely.readthedocs.io/en/latest/migration_pygeos.html).",
             stacklevel=6,
         )
 

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -79,6 +79,8 @@ def set_use_pygeos(val=None):
     global USE_SHAPELY_20
     global PYGEOS_SHAPELY_COMPAT
 
+    env_use_pygeos = os.getenv("USE_PYGEOS", None)
+
     if val is not None:
         USE_PYGEOS = bool(val)
     else:
@@ -86,7 +88,6 @@ def set_use_pygeos(val=None):
 
             USE_PYGEOS = HAS_PYGEOS
 
-            env_use_pygeos = os.getenv("USE_PYGEOS", None)
             if env_use_pygeos is not None:
                 USE_PYGEOS = bool(int(env_use_pygeos))
 
@@ -132,6 +133,17 @@ def set_use_pygeos(val=None):
 
         except ImportError:
             raise ImportError(INSTALL_PYGEOS_ERROR)
+
+    if USE_PYGEOS and env_use_pygeos is None and SHAPELY_GE_20:
+        warnings.warn(
+            "Shapely 2.0 is installed, but because PyGEOS is also installed, "
+            "GeoPandas will still use PyGEOS by default for now. To force to use and "
+            "test Shapely 2.0, you have to set the environment variable USE_PYGEOS=0. "
+            "You can do this before starting the Python process, or in your code "
+            "before importing geopandas:\n\nimport os\nos.environ['USE_PYGEOS'] = '0'"
+            "\nimport geopandas\n\n",
+            stacklevel=6,
+        )
 
     USE_SHAPELY_20 = (not USE_PYGEOS) and SHAPELY_GE_20
 


### PR DESCRIPTION
This gives:

```
>>> import geopandas
<stdin>:1: UserWarning: Shapely 2.0 is installed, but because PyGEOS is also installed, GeoPandas will still
use PyGEOS by default for now. To force to use and test Shapely 2.0, you have to set the environment
variable USE_PYGEOS=0. You can do this before starting the Python process, or in your code before
importing geopandas:

import os
os.environ['USE_PYGEOS'] = '0'
import geopandas
