### PR TITLE
Make sure dataframe passed in is not changed

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -5,20 +5,18 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 from pandas.core.accessor import CachedAccessor
-
+from pyproj import CRS
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 
-from pyproj import CRS
-
+import geopandas.io
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely, to_wkb, to_wkt
 from geopandas.base import GeoPandasBase, is_geometry_type
-from geopandas.geoseries import GeoSeries
-import geopandas.io
 from geopandas.explore import _explore
+from geopandas.geoseries import GeoSeries
+
 from . import _compat as compat
 from ._decorator import doc
-
 
 DEFAULT_GEO_COLUMN_NAME = "geometry"
 
@@ -131,6 +129,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     _geometry_column_name = DEFAULT_GEO_COLUMN_NAME
 
     def __init__(self, data=None, *args, geometry=None, crs=None, **kwargs):
+        if type(data) == pd.DataFrame:
+            data = data.copy()
+
         with compat.ignore_shapely2_warnings():
             super().__init__(data, *args, **kwargs)
 


### PR DESCRIPTION
There's probably a more direct way of accomplishing this, and likely this has performance implications, but it does ensure that a DataFrame that is used to create a GeoDataFrame is unchanged, which seems like the behavior that is reasonably assumed and desired.

Resolves #1179 