### PR TITLE
TST: fix point creation in clip test suite

### DIFF
--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -176,7 +176,7 @@ def multi_point(point_gdf):
 @pytest.fixture
 def mixed_gdf():
     """Create a Mixed Polygon and LineString For Testing"""
-    point = Point([(2, 3), (11, 4), (7, 2), (8, 9), (1, 13)])
+    point = Point(2, 3)
     line = LineString([(1, 1), (2, 2), (3, 2), (5, 3), (12, 1)])
     poly = Polygon([(3, 4), (5, 2), (12, 2), (10, 5), (9, 7.5)])
     ring = LinearRing([(1, 1), (2, 2), (3, 2), (5, 3), (12, 1)])
@@ -189,7 +189,7 @@ def mixed_gdf():
 @pytest.fixture
 def geomcol_gdf():
     """Create a Mixed Polygon and LineString For Testing"""
-    point = Point([(2, 3), (11, 4), (7, 2), (8, 9), (1, 13)])
+    point = Point(2, 3)
     poly = Polygon([(3, 4), (5, 2), (12, 2), (10, 5), (9, 7.5)])
     coll = GeometryCollection([point, poly])
     gdf = GeoDataFrame([1], geometry=[coll], crs="EPSG:3857")


### PR DESCRIPTION
This should fix the failures on CI in an env with shapely 2.0b2. https://github.com/shapely/shapely/pull/1590 uncovered that we were passing a list of tuples to a Point constructor. While old shapely uses only the first tuple and ignores the rest, shapely 2.0b2 correctly raises an error.