### PR TITLE
CI: add Python 3.11 to the test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,7 @@ jobs:
           - ci/envs/39-pd12-conda-forge.yaml
           - ci/envs/39-latest-conda-forge.yaml
           - ci/envs/310-latest-conda-forge.yaml
+          - ci/envs/311-latest-conda-forge.yaml
         include:
           - env: ci/envs/38-latest-conda-forge.yaml
             os: macos-latest

--- a/ci/envs/310-latest-conda-forge.yaml
+++ b/ci/envs/310-latest-conda-forge.yaml
@@ -7,7 +7,6 @@ dependencies:
   - pandas
   - shapely
   - fiona
-  - tiledb=2.11.3
   - pyproj
   - pygeos
   - packaging
@@ -36,4 +35,4 @@ dependencies:
   - pytest-doctestplus
   - pip
   - pip:
-    - git+https://github.com/geopandas/pyogrio.git@main
+      - git+https://github.com/geopandas/pyogrio.git@main

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -1,0 +1,35 @@
+name: test
+channels:
+  - conda-forge
+  - conda-forge/label/shapely_dev
+dependencies:
+  - python=3.11
+  # required
+  - pandas
+  - shapely=2
+  - pyogrio
+  - tiledb=2.11.3
+  - pyproj
+  - packaging
+  # testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - fsspec
+  # optional
+  - rtree
+  - matplotlib
+  - mapclassify
+  - folium
+  - xyzservices
+  - scipy
+  - geopy
+  # installed in tests.yaml, because not available on windows
+  # - postgis
+  - SQLalchemy
+  - psycopg2
+  - libspatialite
+  - geoalchemy2
+  - pyarrow
+  # doctest testing
+  - pytest-doctestplus

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -1,12 +1,11 @@
 name: test
 channels:
   - conda-forge
-  - conda-forge/label/shapely_dev
 dependencies:
   - python=3.11
   # required
   - pandas
-  - shapely=2
+  - shapely
   - pyogrio
   - tiledb=2.11.3
   - pyproj
@@ -17,6 +16,7 @@ dependencies:
   - pytest-xdist
   - fsspec
   # optional
+  - pygeos
   - rtree
   - matplotlib
   - mapclassify

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -7,7 +7,6 @@ dependencies:
   - pandas
   - shapely
   - fiona
-  - tiledb=2.11.3
   - pyproj
   - packaging
   # testing

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -6,7 +6,7 @@ dependencies:
   # required
   - pandas
   - shapely
-  - pyogrio
+  - fiona
   - tiledb=2.11.3
   - pyproj
   - packaging
@@ -17,6 +17,7 @@ dependencies:
   - fsspec
   # optional
   - pygeos
+  - pyogrio
   - rtree
   - matplotlib
   - mapclassify

--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -8,7 +8,6 @@ dependencies:
   - shapely
   # - fiona  # build with only pyogrio
   - libgdal
-  - tiledb=2.11.3
   - pyproj
   - pygeos
   - packaging

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pandas=1.3
   # - shapely=2
   - fiona
-  - tiledb=2.11.3
   - pyproj
   # use this build to have one with only shapely 2.0 installed
   # - pygeos

--- a/ci/envs/39-no-optional-deps.yaml
+++ b/ci/envs/39-no-optional-deps.yaml
@@ -7,7 +7,6 @@ dependencies:
   - pandas
   - shapely
   - fiona
-  - tiledb=2.11.3
   - pyproj
   - packaging
   # testing

--- a/ci/envs/39-pd12-conda-forge.yaml
+++ b/ci/envs/39-pd12-conda-forge.yaml
@@ -7,7 +7,6 @@ dependencies:
   - pandas=1.2
   - shapely
   - fiona
-  - tiledb=2.11.3
   - pyproj
   - pygeos
   - packaging


### PR DESCRIPTION
With pyogrio being rebuilt for 3.11 (~Fiona not yet~), we should have all we need to test geopandas with Python 3.11.

~This env also excludes pygeos and uses shapely 2.~ (does not resolve)

Closes #2592