### PR TITLE
pre-commit config: Add auto update schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+    autofix_prs: false
+    autoupdate_schedule: weekly
+
 files: 'geopandas\/'
 repos:
     - repo: https://github.com/psf/black


### PR DESCRIPTION
Currently the pre-commit.ci configuration, [`.pre-commit-config.yaml`](https://github.com/shapely/shapely/edit/main/.pre-commit-config.yaml), is a bit outdated. We could update it manually or write a custom workflow for it, but the easiest way to fix is is enable [pre-commit.ci](https://pre-commit.ci/). By default, it checks weekly if pre-commit versions can be updated and if so opens a PR to do so.

It also has an option to autofix PRs, which can be a great quality of life feature. It's `false` for now because it's a bit of a larger change.