### PR TITLE
Versioneer CI: Allow Black to fix formatting

### DIFF
--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -18,6 +18,8 @@ jobs:
     - run: pip install versioneer
     - run: versioneer install
     - uses: psf/black@stable
+      with:
+        options: "--verbose"
     - uses: actions/upload-artifact@v3
       with:
         path: versioneer.py


### PR DESCRIPTION
The default black options _for GitHub Actions_ are `--check --diff`, which is different from the regular CLI. This PR overwrites that which allows Black to fix things instead giving an error.
```yml
    - uses: psf/black@stable
      with:
        options: "--verbose"
```

Succeeds #2634.