### PR TITLE
CI: 310-dev tests failing

### DIFF
--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -11,6 +11,7 @@ from shapely.geometry import (
 from numpy.testing import assert_array_equal
 
 import geopandas
+import pandas as pd
 from geopandas import _compat as compat
 from geopandas import GeoDataFrame, GeoSeries, read_file, datasets
 
@@ -75,14 +76,13 @@ class TestSeriesSindex:
         s = GeoSeries([t1, t2, sq])
         assert s.sindex.size == 3
 
-    @pytest.mark.filterwarnings("ignore:The series.append method is deprecated")
     def test_polygons_append(self):
         t1 = Polygon([(0, 0), (1, 0), (1, 1)])
         t2 = Polygon([(0, 0), (1, 1), (0, 1)])
         sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
         s = GeoSeries([t1, t2, sq])
         t = GeoSeries([t1, t2, sq], [3, 4, 5])
-        s = s.append(t)
+        s = pd.concat([s, t])
         assert len(s) == 6
         assert s.sindex.size == 6
 


### PR DESCRIPTION
**pandas** 2.0 is removing `Series.append()`.  There is a test that incorrectly suppresses deprecation warning.  Changed to use `pandas.concat()`