### PR TITLE
TST/CI: pytest warning cleanup

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -20,6 +20,7 @@ PANDAS_GE_115 = Version(pd.__version__) >= Version("1.1.5")
 PANDAS_GE_12 = Version(pd.__version__) >= Version("1.2.0")
 PANDAS_GE_13 = Version(pd.__version__) >= Version("1.3.0")
 PANDAS_GE_14 = Version(pd.__version__) >= Version("1.4.0rc0")
+PANDAS_GE_15 = Version(pd.__version__) >= Version("1.5.0")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -558,6 +558,9 @@ class TestDataFrame:
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[:, 5:])
         assert_frame_equal(self.df2.loc[5:], self.df2.cx[5:, 5:])
 
+    @pytest.mark.filterwarnings(
+        "" if compat.SHAPELY_GE_20 else "ignore:The array interface is deprecated.*"
+    )
     def test_from_dict(self):
         data = {"A": [1], "geometry": [Point(0.0, 0.0)]}
         df = GeoDataFrame.from_dict(data, crs=3857)

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -341,6 +341,11 @@ def test_constructor_sliced_column_slices(df2):
     assert type(df2.iloc[0, :]) == pd.Series
 
 
+@pytest.mark.filterwarnings(
+    ""
+    if compat.PANDAS_GE_13
+    else "ignore:the `interpolation=`:DeprecationWarning:pandas.*"
+)
 def test_constructor_sliced_in_pandas_methods(df2):
     # constructor sliced is used in many places, checking a sample of non
     # geometry cases are sensible
@@ -348,5 +353,5 @@ def test_constructor_sliced_in_pandas_methods(df2):
     # drop the secondary geometry columns as not hashable
     hashable_test_df = df2.drop(columns=["geometry2", "geometry3"])
     assert type(hashable_test_df.duplicated()) == pd.Series
-    assert type(df2.quantile()) == pd.Series
+    assert type(df2.quantile(numeric_only=True)) == pd.Series
     assert type(df2.memory_usage()) == pd.Series

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1731,6 +1731,24 @@ class TestGeoplotAccessor:
     if MPL_DECORATORS:
 
         @pytest.mark.parametrize("kind", _pandas_kinds)
+        @pytest.mark.filterwarnings(
+            ""
+            if compat.PANDAS_GE_15
+            else (
+                "ignore:The get_cmap function will be deprecated in a future version:"
+                "PendingDeprecationWarning:pandas.*"
+            )
+        )
+        @pytest.mark.filterwarnings(
+            ""
+            if compat.PANDAS_GE_15
+            else "ignore:No data for colormapping provided:UserWarning:pandas.*"
+        )
+        @pytest.mark.filterwarnings(
+            ""
+            if compat.PANDAS_GE_12
+            else "ignore::DeprecationWarning:matplotlib.*|fontTools.*"
+        )
         @check_figures_equal(extensions=["png", "pdf"])
         def test_pandas_kind(self, kind, fig_test, fig_ref):
             """Test Pandas kind."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,10 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:pandas.*",
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:numpy.*"
 ]
+# optimise collection
+testpaths = [
+    "geopandas/io/tests",
+    "geopandas/tools/tests",
+    "geopandas/tests"
+
+]


### PR DESCRIPTION
There are too many warnings in **pytest** log files in CI.  Structured cleanup to enable more structured review of change in logs.

Split out from PR #2642 

Summary post change:
```
logs_post_change/310-dev.log:1799 passed, 266 skipped, 11 xfailed, 2 xpassed, 2306 warnings in 250.91s (0:04:10)
logs_post_change/310-latest-conda-forge.log:1924 passed, 139 skipped, 13 xfailed, 2 xpassed, 117 warnings in 230.60s (0:03:50)
logs_post_change/311-latest-conda-forge.log:1924 passed, 139 skipped, 13 xfailed, 2 xpassed, 118 warnings in 244.20s (0:04:04)
logs_post_change/38-latest-conda-forge.log:1774 passed, 291 skipped, 11 xfailed, 2 xpassed, 120 warnings in 203.19s (0:03:23)
logs_post_change/38-latest-defaults.log:1713 passed, 352 skipped, 11 xfailed, 2 xpassed, 22 warnings in 229.03s (0:03:49)
logs_post_change/38-minimal.log:1605 passed, 347 skipped, 26 xfailed, 1 xpassed, 24 warnings in 177.52s (0:02:57)
logs_post_change/38-pd11-defaults.log:1658 passed, 343 skipped, 21 xfailed, 1 xpassed, 32 warnings in 199.19s (0:03:19)
logs_post_change/39-latest-conda-forge.log:1715 passed, 344 skipped, 7 xfailed, 2 xpassed, 18 warnings in 203.71s (0:03:23)
logs_post_change/39-no-optional-deps.log:1064 passed, 790 skipped, 8 xfailed, 2 xpassed, 19 warnings in 85.90s (0:01:25)
logs_post_change/39-pd12-conda-forge.log:1769 passed, 268 skipped, 21 xfailed, 1 xpassed, 79 warnings in 222.56s (0:03:42)
```

summary before change:
```
logs/310-dev.log:1799 passed, 266 skipped, 11 xfailed, 2 xpassed, 2311 warnings in 243.74s (0:04:03)
logs/310-latest-conda-forge.log:1924 passed, 139 skipped, 13 xfailed, 2 xpassed, 125 warnings in 232.15s (0:03:52)
logs/311-latest-conda-forge.log:1924 passed, 139 skipped, 13 xfailed, 2 xpassed, 125 warnings in 250.22s (0:04:10)
logs/38-latest-conda-forge.log:1774 passed, 291 skipped, 11 xfailed, 2 xpassed, 127 warnings in 208.21s (0:03:28)
logs/38-latest-defaults.log:1713 passed, 352 skipped, 11 xfailed, 2 xpassed, 25 warnings in 227.88s (0:03:47)
logs/38-minimal.log:1605 passed, 347 skipped, 25 xfailed, 2 xpassed, 24 warnings in 179.41s (0:02:59)
logs/38-pd11-defaults.log:1658 passed, 343 skipped, 21 xfailed, 1 xpassed, 48 warnings in 190.56s (0:03:10)
logs/39-latest-conda-forge.log:1715 passed, 344 skipped, 7 xfailed, 2 xpassed, 43 warnings in 205.64s (0:03:25)
logs/39-no-optional-deps.log:1064 passed, 790 skipped, 8 xfailed, 2 xpassed, 26 warnings in 80.90s (0:01:20)
logs/39-pd12-conda-forge.log:1769 passed, 268 skipped, 21 xfailed, 1 xpassed, 109 warnings in 226.67s (0:03:46)

```