### PR TITLE
COMPAT: pandas 1.5 loc and iloc FutureWarning

### DIFF
--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -60,13 +60,13 @@ def _clip_gdf_with_mask(gdf, mask):
     if isinstance(gdf_sub, GeoDataFrame):
         clipped = gdf_sub.copy()
         if clipping_by_rectangle:
-            clipped.loc[
-                non_point_mask, clipped._geometry_column_name
-            ] = gdf_sub.geometry.values[non_point_mask].clip_by_rect(*mask)
+            geoms_ = gdf_sub.geometry.values[non_point_mask].clip_by_rect(*mask)
         else:
-            clipped.loc[
-                non_point_mask, clipped._geometry_column_name
-            ] = gdf_sub.geometry.values[non_point_mask].intersection(mask)
+            geoms_ = gdf_sub.geometry.values[non_point_mask].intersection(mask)
+        if non_point_mask.sum() == len(clipped):
+            clipped[clipped._geometry_column_name] = geoms_
+        else:
+            clipped.loc[non_point_mask, clipped._geometry_column_name] = geoms_
     else:
         # GeoSeries
         clipped = gdf_sub.copy()

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -362,7 +362,12 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
             # improve performance (we only need to collect geometries in their
             # respective Multi version)
             dissolved = exploded.dissolve(by="level_0")
-            result.loc[is_collection, geom_col] = dissolved[geom_col].values
+            # https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#inplace-operation-when-setting-values-with-loc-and-iloc
+            if is_collection.sum() == len(result):
+                result[geom_col] = dissolved[geom_col].values
+            else:
+                result.loc[is_collection, geom_col] = dissolved[geom_col].values
+
         else:
             num_dropped_collection = 0
 


### PR DESCRIPTION
**pandas 1.5** generates FutureWarning on specific use cases of `loc[]`
- https://pandas.pydata.org/docs/whatsnew/v1.5.0.html#inplace-operation-when-setting-values-with-loc-and-iloc

`clip()` and `overlay()` were generating inplace FutureWarning. This is a subtle issue, where if mask was all rows, warning is generated. Code below shows solution as standalone:

```
import geopandas as gpd
import pandas as pd
import numpy as np
from shapely.geometry import Point

N = 3
df = gpd.GeoDataFrame(
    geometry=[Point([i, i]) for i in range(N)],
    data=pd.DataFrame({"col": np.repeat(["GeometryCollection"], N)}),
)
# df.loc[2, "col"] = "diff"
mask = df["col"] == "GeometryCollection"
if mask.sum() == len(df):
    df["geometry"] = gpd.GeoSeries([Point([10, 10]) for _ in range(mask.sum())]).values
else:
    df.loc[mask, "geometry"] = gpd.GeoSeries(
        [Point([10, 10]) for _ in range(mask.sum())]
    ).values

df
```