### PR TITLE
COMPAT: branca 0.6.0

### DIFF
--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -565,17 +565,20 @@ class TestExplore:
         assert "red'></span>NaN" in out_str
 
     def test_colorbar(self):
+        def quoted_in(find, s):
+            return find in s or find.replace("'", '"') in s
+
         m = self.world.explore("range", legend=True)
         out_str = self._fetch_map_string(m)
         assert "attr(\"id\",'legend')" in out_str
-        assert "text('range')" in out_str
+        assert quoted_in("text('range')", out_str)
 
         m = self.world.explore(
             "range", legend=True, legend_kwds=dict(caption="my_caption")
         )
         out_str = self._fetch_map_string(m)
         assert "attr(\"id\",'legend')" in out_str
-        assert "text('my_caption')" in out_str
+        assert quoted_in("text('my_caption')", out_str)
 
         m = self.missing.explore("pop_est", legend=True, missing_kwds=dict(color="red"))
         out_str = self._fetch_map_string(m)


### PR DESCRIPTION
new branca release https://github.com/python-visualization/branca/releases/tag/v0.6.0

used in `explore()`.   There's a subtle change where embedded html/javascript that is generated by **branca** has changed from single quoted to double quoted strings.  Change test cases to pass on either case,  making it forward and backward compatible test case.

Where CI virtual machines have been rebuilt and using **branca** 0.6.0 CI is failing.