### PR TITLE
Fix docstring typo in to_crs

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -698,7 +698,7 @@ class GeometryArray(ExtensionArray):
         be set.  Either ``crs`` or ``epsg`` may be specified for output.
 
         This method will transform all points in all objects.  It has no notion
-        or projecting entire geometries.  All segments joining points are
+        of projecting entire geometries.  All segments joining points are
         assumed to be lines in the current projection, not geodesics.  Objects
         crossing the dateline (or other projection boundary) will have
         undesirable behavior.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1289,7 +1289,7 @@ individually so that features may have different properties
         be set.  Either ``crs`` or ``epsg`` may be specified for output.
 
         This method will transform all points in all objects. It has no notion
-        or projecting entire geometries.  All segments joining points are
+        of projecting entire geometries.  All segments joining points are
         assumed to be lines in the current projection, not geodesics. Objects
         crossing the dateline (or other projection boundary) will have
         undesirable behavior.

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1053,7 +1053,7 @@ class GeoSeries(GeoPandasBase, Series):
         be set.  Either ``crs`` or ``epsg`` may be specified for output.
 
         This method will transform all points in all objects.  It has no notion
-        or projecting entire geometries.  All segments joining points are
+        of projecting entire geometries.  All segments joining points are
         assumed to be lines in the current projection, not geodesics.  Objects
         crossing the dateline (or other projection boundary) will have
         undesirable behavior.


### PR DESCRIPTION
Fix typo `no notion or projecting` -> `no notion of projecting`