### PR TITLE
CI: update shapely versions in test build matrix

### DIFF
--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -36,5 +36,4 @@ dependencies:
   - pytest-doctestplus
   - pip
   - pip:
-      - --pre
-      - shapely==2.0b1
+      - git+https://github.com/shapely/shapely.git@main

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -1,12 +1,11 @@
 name: test
 channels:
   - conda-forge
-  # - conda-forge/label/shapely_dev
 dependencies:
   - python=3.9
   # required
   - pandas=1.3
-  # - shapely=2
+  - shapely=2
   - geos
   - cython
   - fiona
@@ -36,6 +35,3 @@ dependencies:
   - pyarrow
   # doctest testing
   - pytest-doctestplus
-  - pip
-  - pip:
-      - git+https://github.com/shapely/shapely.git@main

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -7,6 +7,7 @@ dependencies:
   # required
   - pandas=1.3
   # - shapely=2
+  - geos
   - fiona
   - pyproj
   # use this build to have one with only shapely 2.0 installed

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pandas=1.3
   # - shapely=2
   - geos
+  - cython
   - fiona
   - pyproj
   # use this build to have one with only shapely 2.0 installed


### PR DESCRIPTION
Testing the latest main in an additional build, and then will later today update this to use the actually released 2.0.0