### PR TITLE
BUG: Add name to setup.py for GitHub, re-format text TOML entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,20 +16,6 @@ maintainers = [
 license = {text = "BSD 3-Clause"}
 description = "Geographic pandas extensions"
 keywords = ["GIS", "cartography", "pandas", "shapely"]
-readme = {text = """\
-GeoPandas is a project to add support for geographic data to
-`pandas`_ objects.
-
-The goal of GeoPandas is to make working with geospatial data in
-python easier. It combines the capabilities of `pandas`_ and `shapely`_,
-providing geospatial operations in pandas and a high-level interface
-to multiple geometries to shapely. GeoPandas enables you to easily do
-operations in python that would otherwise require a spatial database
-such as PostGIS.
-
-.. _pandas: https://pandas.pydata.org
-.. _shapely: https://shapely.readthedocs.io/en/latest/
-""", content-type = "text/x-rst"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
@@ -47,6 +33,23 @@ dependencies = [
     "pyproj >= 2.6.1.post1",
     "shapely >= 1.7",
 ]
+
+[project.readme]
+text = """\
+GeoPandas is a project to add support for geographic data to
+`pandas`_ objects.
+
+The goal of GeoPandas is to make working with geospatial data in
+python easier. It combines the capabilities of `pandas`_ and `shapely`_,
+providing geospatial operations in pandas and a high-level interface
+to multiple geometries to shapely. GeoPandas enables you to easily do
+operations in python that would otherwise require a spatial database
+such as PostGIS.
+
+.. _pandas: https://pandas.pydata.org
+.. _shapely: https://shapely.readthedocs.io/en/latest/
+"""
+content-type = "text/x-rst"
 
 [project.urls]
 Home = "https://geopandas.org"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import versioneer  # noqa: E402
 
 # see pyproject.toml for static project metadata
 setup(
+    name="geopandas",  # need by GitHub dependency graph
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
This fixes two things:

1. There is a GitHub bug where the project name is assumed to be in `setup.py` to show dependents in the dependency graph; currently [it is empty](https://github.com/geopandas/geopandas/network/dependents)
2. Re-format the "text" TOML entry to it's own section, as the current form has problems with some packages, e.g. try "tox", and see "toml.decoder.TomlDecodeError: Stuff after closed string. WTF? (line 32 column 1 char 977)". The content of the readme is unchanged.