### PR TITLE
COMPAT: Fix pandas tz defaults

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -20,7 +20,7 @@ PANDAS_GE_115 = Version(pd.__version__) >= Version("1.1.5")
 PANDAS_GE_12 = Version(pd.__version__) >= Version("1.2.0")
 PANDAS_GE_13 = Version(pd.__version__) >= Version("1.3.0")
 PANDAS_GE_14 = Version(pd.__version__) >= Version("1.4.0rc0")
-
+PANDAS_GE_20 = Version(pd.__version__) >= Version("2.0.0.dev0")
 
 # -----------------------------------------------------------------------------
 # Shapely / PyGEOS compat

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -16,6 +16,7 @@ from shapely.geometry import Point, Polygon, box
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
+from geopandas._compat import PANDAS_GE_20
 from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
@@ -309,7 +310,11 @@ def test_read_file_datetime_mixed_offsets(tmpdir):
     if FIONA_GE_1814:
         # Convert mixed timezones to UTC equivalent
         assert is_datetime64_any_dtype(res["date"])
-        assert res["date"].dt.tz == pytz.utc
+        if not PANDAS_GE_20:
+            utc = pytz.utc
+        else:
+            utc = datetime.timezone.utc
+        assert res["date"].dt.tz == utc
     else:
         # old fiona and pyogrio ignore timezones and read as datetimes successfully
         assert is_datetime64_any_dtype(res["date"])


### PR DESCRIPTION
This fixes one of the CI failures at the moment, the default representation of timezones has changed on the pandas main branch.