### PR TITLE
CI: numpy version for pandas 1.2

### DIFF
--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   # - conda-forge/label/shapely_dev
 dependencies:
-  - numpy <1.24 # compat with matplotlib 3.3.2
+  - numpy
   - python=3.9
   # required
   - pandas=1.3

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   # - conda-forge/label/shapely_dev
 dependencies:
-  - numpy
   - python=3.9
   # required
   - pandas=1.3

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   # - conda-forge/label/shapely_dev
 dependencies:
+  - numpy <1.24 # compat with matplotlib 3.3.2
   - python=3.9
   # required
   - pandas=1.3

--- a/ci/envs/39-pd12-conda-forge.yaml
+++ b/ci/envs/39-pd12-conda-forge.yaml
@@ -2,6 +2,7 @@ name: test
 channels:
   - conda-forge
 dependencies:
+  - numpy <1.24 # compat with matplotlib 3.3.2
   - python=3.9
   # required
   - pandas=1.2

--- a/ci/envs/39-pd12-conda-forge.yaml
+++ b/ci/envs/39-pd12-conda-forge.yaml
@@ -2,10 +2,10 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - numpy <1.24 # compat with matplotlib 3.3.2
   - python=3.9
   # required
   - pandas=1.2
+  - numpy=1.20 # released 1 month after pandas 1.2
   - shapely
   - fiona
   - pyproj


### PR DESCRIPTION
This is trying to address the crashes in the pandas 1.2 and pandas 3.9 latest environments seen here: https://github.com/geopandas/geopandas/actions/runs/3771037533/jobs/6411224335

----------------------
Subsequently repurposed to pin numpy versions after this was fixed upstream.