### PR TITLE
CI: fix versioneer update action

### DIFF
--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -15,21 +15,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - run: pip install versioneer
-      - run: versioneer install
-      - uses: psf/black@stable
+      - name: Install and run versioneer
+        run: |
+          pip install versioneer
+          versioneer install
+      - name: Blacken code
+        uses: psf/black@stable
         with:
           options: "--verbose"
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           path: versioneer.py
-      - run: |
+      - name: Ignore changes in __init__
+        run: |
           git reset -- setup.py geopandas/__init__.py
           git checkout -- setup.py geopandas/__init__.py
-      - uses: peter-evans/create-pull-request@v4
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v4
         with:
           title: "Update Versioneer"
-          branch: update-versioneer
+          branch: update-versioneer-test
           base: main
           commit-message: "[Bot] Update Versioneer"
 

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -23,12 +23,15 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: versioneer.py
+      - run: |
+          git reset -- setup.py geopandas/__init__.py
+          git checkout -- setup.py geopandas/__init__.py
       - uses: peter-evans/create-pull-request@v4
         with:
           title: "Update Versioneer"
           branch: update-versioneer
           base: main
           commit-message: "[Bot] Update Versioneer"
-          add-paths: versioneer.py, */_version.py
+
           body: |
             Automatic update of Versioneer by the `versioneer.yml` workflow.

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -35,7 +35,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           title: "Update Versioneer"
-          branch: update-versioneer-test
+          branch: update-versioneer
           base: main
           commit-message: "[Bot] Update Versioneer"
 

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -3,33 +3,34 @@ name: "Update Versioneer"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 1 * *' # 1st day of each month at 06:00 UTC
+    - cron: "0 6 1 * *" # 1st day of each month at 06:00 UTC
   push:
     paths:
-    - 'setup.cfg'
-    - '.github/workflows/versioneer.yml'
+      - "setup.cfg"
+      - ".github/workflows/versioneer.yml"
 
 jobs:
   versioneer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - run: pip install versioneer
-    - run: versioneer install
-    - uses: psf/black@stable
-      with:
-        options: "--verbose"
-    - uses: actions/upload-artifact@v3
-      with:
-        path: versioneer.py
-    - uses: peter-evans/create-pull-request@v4
-      with:
-        title: "Update Versioneer"
-        branch: update-versioneer
-        base: main
-        commit-message: "[Bot] Update Versioneer"
-        body: |
-          Automatic update of Versioneer by the `versioneer.yml` workflow.
-          
-          Please review changes manually, especially if a duplicate `from . import _version` is added.
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install versioneer
+      - run: versioneer install
+      - uses: psf/black@stable
+        with:
+          options: "--verbose"
+      - uses: actions/upload-artifact@v3
+        with:
+          path: versioneer.py
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update Versioneer"
+          branch: update-versioneer
+          base: main
+          commit-message: "[Bot] Update Versioneer"
+          add-paths: |
+            versioneer.py
+            geopandas/_version.py
+          body: |
+            Automatic update of Versioneer by the `versioneer.yml` workflow.

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -29,8 +29,6 @@ jobs:
           branch: update-versioneer
           base: main
           commit-message: "[Bot] Update Versioneer"
-          add-paths: |
-            versioneer.py
-            geopandas/_version.py
+          add-paths: versioneer.py
           body: |
             Automatic update of Versioneer by the `versioneer.yml` workflow.

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -29,8 +29,8 @@ jobs:
           path: versioneer.py
       - name: Ignore changes in __init__
         run: |
-          git reset -- setup.py geopandas/__init__.py
-          git checkout -- setup.py geopandas/__init__.py
+          git reset -- geopandas/__init__.py
+          git checkout -- geopandas/__init__.py
       - name: Create PR
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/versioneer.yml
+++ b/.github/workflows/versioneer.yml
@@ -29,6 +29,6 @@ jobs:
           branch: update-versioneer
           base: main
           commit-message: "[Bot] Update Versioneer"
-          add-paths: versioneer.py
+          add-paths: versioneer.py, */_version.py
           body: |
             Automatic update of Versioneer by the `versioneer.yml` workflow.


### PR DESCRIPTION
Fixes #2690.

Manually remove `__init__.py` changes from the commit to avoid the duplication of those two lines like we have now in #2694.

I tested it on my fork but it will probably needs to be merged to test it properly.