### PR TITLE
COMPAT: support fiona 1.9 (without warnings) + 2.0 for Feature model changes

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -332,6 +332,10 @@ def _read_file_fiona(
             if bbox is not None:
                 filters["bbox"] = bbox
             if mask is not None:
+                if FIONA_GE_19:
+                    from fiona.model import Geometry
+
+                    mask = Geometry.from_dict(mask)
                 filters["mask"] = mask
             if where is not None:
                 filters["where"] = where

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -569,10 +569,17 @@ def _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs):
             crs_wkt = crs.to_wkt()
         elif crs:
             crs_wkt = crs.to_wkt("WKT1_GDAL")
+        if FIONA_GE_19:
+            from fiona.model import Feature
+
+            features = [Feature.from_dict(feat) for feat in df.iterfeatures()]
+        else:
+            features = df.iterfeatures()
+
         with fiona.open(
             filename, mode=mode, driver=driver, crs_wkt=crs_wkt, schema=schema, **kwargs
         ) as colxn:
-            colxn.writerecords(df.iterfeatures())
+            colxn.writerecords(features)
 
 
 def _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs):


### PR DESCRIPTION
Fiona 1.9 is adding deprecation warnings in advance of some changes coming to Fiona 2.0 (cfr https://github.com/Toblerity/Fiona/issues/758, https://github.com/Toblerity/fiona-rfc/blob/master/rfc/0001-fiona-2-0-changes.md)

In the dev build (where fiona 1.9b1 is installed), we can see those:

```
geopandas/io/tests/test_file.py: 2108 warnings
geopandas/io/tests/test_file_geom_types_drivers.py: 99 warnings
geopandas/tests/test_geoseries.py: 2 warnings
  /usr/share/miniconda3/envs/test/lib/python3.10/site-packages/fiona/collection.py:551: 
        FionaDeprecationWarning: Support for feature and geometry dicts is deprecated. 
        Instances of Feature and Geometry will be required in 2.0.
    self.session.writerecs(records, self)
```

This PR already starts using the new API if fiona >= 1.9


