### PR TITLE
DOC: update usage of `folium.TileLayer`

### DIFF
--- a/doc/source/docs/user_guide/interactive_mapping.ipynb
+++ b/doc/source/docs/user_guide/interactive_mapping.ipynb
@@ -118,7 +118,7 @@
     "    name=\"cities\",  # name of the layer in the map\n",
     ")\n",
     "\n",
-    "folium.TileLayer(\"Stamen Toner\", control=True).add_to(\n",
+    "folium.TileLayer(\"Stamen Toner\", show=False).add_to(\n",
     "    m\n",
     ")  # use folium to add alternative tiles\n",
     "folium.LayerControl().add_to(m)  # use folium to add layer control\n",


### PR DESCRIPTION
Small change to the notebook showing interactive mapping.

- The `control` parameter is already True by default, no need to specify it.
- [We've recently merged a PR in folium](https://github.com/python-visualization/folium/pull/1690) that changes the default behavior when adding multiple base layers. Keep the current behavior by specifying we don't want to see the extra tilelayer when opening the map.