### PR TITLE
ENH: enable and test append mode for pyogrio engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ New features and improvements:
 - Added ``minimum_bounding_circle()`` method from shapely to GeoSeries/GeoDataframe (#2621).
 - Support specifying ``min_zoom`` and ``max_zoom`` inside the ``map_kwds`` argument for ``.explore()`` (#2599).
 - Added `minimum_bounding_radius()` as GeoSeries method (#2827).
+- Added support for append (``mode="a"`` or ``append=True``) in ``to_file()``
+  using ``engine="pyogrio"`` (#2788).
 
 Deprecations and compatibility notes:
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -477,10 +477,15 @@ def _to_file(
         .. versionadded:: 0.7
             Previously the index was not written.
     mode : string, default 'w'
-        The write mode, 'w' to overwrite the existing file and 'a' to append.
-        Not all drivers support appending. The drivers that support appending
-        are listed in fiona.supported_drivers or
-        https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py
+        The write mode, 'w' to overwrite the existing file and 'a' to append;
+        when using the pyogrio engine, you can also pass ``append=True``.
+        Not all drivers support appending. For the fiona engine, the drivers
+        that support appending are listed in fiona.supported_drivers or
+        https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py.
+        For the pyogrio engine, you should be able to use any driver that
+        is available in your installation of GDAL that supports append
+        capability; see the specific driver entry at
+        https://gdal.org/drivers/vector/index.html for more information.
     crs : pyproj.CRS, default None
         If specified, the CRS is passed to Fiona to
         better control how the file is written. If None, GeoPandas

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -532,6 +532,9 @@ def _to_file(
             stacklevel=3,
         )
 
+    if mode not in ("w", "a"):
+        raise ValueError("'mode' should be one of 'w' or 'a', got '{mode}' instead")
+
     if engine == "fiona":
         _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs)
     elif engine == "pyogrio":
@@ -572,9 +575,6 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs):
         raise ValueError(
             "The 'schema' argument is not supported with the 'pyogrio' engine."
         )
-
-    if mode not in ("w", "a"):
-        raise ValueError("'mode' should be one of 'w' or 'a', got '{mode}' instead")
 
     if mode == "a":
         kwargs["append"] = True

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -582,12 +582,12 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs):
             "The 'schema' argument is not supported with the 'pyogrio' engine."
         )
 
-    append = False
-    if mode == "a":
-        append = True
-    elif mode != "w":
+    if mode not in ("w", "a"):
         raise ValueError("'mode' should be one of 'w' or 'a', got '{mode}' instead")
-    kwargs["append"] = append
+
+    if "append" not in kwargs:
+        append = mode == "a"
+        kwargs["append"] = append
 
     if crs is not None:
         raise ValueError("Passing 'crs' it not supported with the 'pyogrio' engine.")

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -582,10 +582,12 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs):
             "The 'schema' argument is not supported with the 'pyogrio' engine."
         )
 
-    if mode != "w":
-        raise ValueError(
-            "Only mode='w' is supported for now with the 'pyogrio' engine."
-        )
+    append = False
+    if mode == "a":
+        append = True
+    elif mode != "w":
+        raise ValueError("'mode' should be one of 'w' or 'a', got '{mode}' instead")
+    kwargs["append"] = append
 
     if crs is not None:
         raise ValueError("Passing 'crs' it not supported with the 'pyogrio' engine.")

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -576,9 +576,8 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs):
     if mode not in ("w", "a"):
         raise ValueError("'mode' should be one of 'w' or 'a', got '{mode}' instead")
 
-    if "append" not in kwargs:
-        append = mode == "a"
-        kwargs["append"] = append
+    if mode == "a":
+        kwargs["append"] = True
 
     if crs is not None:
         raise ValueError("Passing 'crs' it not supported with the 'pyogrio' engine.")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -487,6 +487,15 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext, engine):
     expected = pd.concat([df_nybb] * 2, ignore_index=True)
     assert_geodataframe_equal(df, expected, check_less_precise=True)
 
+    if engine == "pyogrio":
+        # for pyogrio also ensure append=True works
+        tempfilename = os.path.join(str(tmpdir), "boros2" + ext)
+        df_nybb.to_file(tempfilename, driver=driver, engine=engine)
+        df_nybb.to_file(tempfilename, append=True, driver=driver, engine=engine)
+        # Read layer back in
+        df = GeoDataFrame.from_file(tempfilename, engine=engine)
+        assert len(df) == (5 * 2)
+
     # Write layer with null geometry out to file
     tempfilename = os.path.join(str(tmpdir), "null_geom" + ext)
     df_null.to_file(tempfilename, driver=driver, engine=engine)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -475,13 +475,8 @@ def test_to_file_with_duplicate_columns(tmpdir, engine):
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_append_file(tmpdir, df_nybb, df_null, driver, ext, engine):
     """Test to_file with append mode and from_file"""
-    skip_pyogrio_not_supported(engine)
-    from fiona import supported_drivers
-
     tempfilename = os.path.join(str(tmpdir), "boros" + ext)
     driver = driver if driver else _detect_driver(tempfilename)
-    if "a" not in supported_drivers[driver]:
-        return None
 
     df_nybb.to_file(tempfilename, driver=driver, engine=engine)
     df_nybb.to_file(tempfilename, mode="a", driver=driver, engine=engine)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -508,6 +508,12 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext, engine):
     assert_geodataframe_equal(df, expected, check_less_precise=True)
 
 
+def test_mode_unsupported(tmpdir, df_nybb, engine):
+    tempfilename = os.path.join(str(tmpdir), "data.shp")
+    with pytest.raises(ValueError, match="'mode' should be one of 'w' or 'a'"):
+        df_nybb.to_file(tempfilename, mode="r", engine=engine)
+
+
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_empty_crs(tmpdir, driver, ext, engine):
     """Test handling of undefined CRS with GPKG driver (GH #1975)."""

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -494,7 +494,7 @@ def test_append_file(tmpdir, df_nybb, df_null, driver, ext, engine):
         df_nybb.to_file(tempfilename, append=True, driver=driver, engine=engine)
         # Read layer back in
         df = GeoDataFrame.from_file(tempfilename, engine=engine)
-        assert len(df) == (5 * 2)
+        assert len(df) == (len(df_nybb) * 2)
 
     # Write layer with null geometry out to file
     tempfilename = os.path.join(str(tmpdir), "null_geom" + ext)


### PR DESCRIPTION
cc @brendan-ward this translates the current `mode` keyword and enables the tests

I think it would still be good to document (and test) you can also pass `append=True` (that should already work since we pass through the keywords). And we could actually also do that for the fiona engine (translate append=True to mode="a")