### PR TITLE
DOC: replace geopandas.datasets with geodatasets in user-facing documentation

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -43,4 +43,4 @@ dependencies:
   - pip
   - pip:
       - sphinx-toggleprompt
-      - geodatasets
+      - git+https://github.com/geopandas/geodatasets.git@main

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -43,3 +43,4 @@ dependencies:
   - pip
   - pip:
       - sphinx-toggleprompt
+      - geodatasets

--- a/doc/nyc_boros.py
+++ b/doc/nyc_boros.py
@@ -16,11 +16,12 @@ import matplotlib.pyplot as plt
 from shapely.geometry import Point
 from geopandas import GeoSeries, GeoDataFrame
 import geopandas as gpd
+import geodatasets
 
 np.random.seed(1)
 DPI = 100
 
-path_nybb = gpd.datasets.get_path("nybb")
+path_nybb = geodatasets.get_path("nybb")
 boros = GeoDataFrame.from_file(path_nybb)
 boros = boros.set_index("BoroCode")
 boros

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,6 +13,19 @@
 
 import sys, os
 import warnings
+import geodatasets
+
+geodatasets.fetch(
+    [
+        "geoda.chile_labor",
+        "ny.bb",
+        "geoda.malaria",
+        "geoda.chicago_health",
+        "geoda.groceries",
+        "geoda.natregimes",
+    ]
+)
+
 
 sys.path.insert(0, os.path.abspath("../.."))
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,6 +23,7 @@ geodatasets.fetch(
         "geoda.chicago_health",
         "geoda.groceries",
         "geoda.natregimes",
+        "geoda.nepal",
     ]
 )
 

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -23,34 +23,34 @@ In a non-spatial setting, when all we need are summary statistics of the data, w
 :meth:`~geopandas.GeoDataFrame.dissolve` Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose we are interested in studying continents, but we only have country-level data like the country dataset included in GeoPandas. We can easily convert this to a continent-level dataset.
+Suppose we are interested in Nepalese zone, but we only have Nepalese district-level data like the `geoda.nepal` dataset included in `geodatasets`. We can easily convert this to a zone-level dataset.
 
 
-First, let's look at the most simple case where we just want continent shapes and names. By default, :meth:`~geopandas.GeoDataFrame.dissolve` will pass ``'first'`` to :ref:`groupby.aggregate <groupby.aggregate>`.
+First, let's look at the most simple case where we just want zone shapes and names. By default, :meth:`~geopandas.GeoDataFrame.dissolve` will pass ``'first'`` to :ref:`groupby.aggregate <groupby.aggregate>`.
 
 .. ipython:: python
 
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-    world = world[['continent', 'geometry']]
-    continents = world.dissolve(by='continent')
+    nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
+    nepal = nepal[['name_2', 'geometry']]  # name_2 contains zone names
+    zones = nepal.dissolve(by='name_2')
 
-    @savefig continents1.png
-    continents.plot();
+    @savefig zones1.png
+    zones.plot();
 
-    continents.head()
+    zones.head()
 
 If we are interested in aggregate populations, however, we can pass different functions to the :meth:`~geopandas.GeoDataFrame.dissolve` method to aggregate populations using the ``aggfunc =`` argument:
 
 .. ipython:: python
 
-   world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-   world = world[['continent', 'geometry', 'pop_est']]
-   continents = world.dissolve(by='continent', aggfunc='sum')
+   nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
+   nepal = nepal[['name_2', 'geometry', 'population']]  # name_2 contains zone names
+   zones = nepal.dissolve(by='name_2', aggfunc='sum')
 
-   @savefig continents2.png
-   continents.plot(column = 'pop_est', scheme='quantiles', cmap='YlOrRd');
+   @savefig zones2.png
+   zones.plot(column = 'population', scheme='quantiles', cmap='YlOrRd');
 
-   continents.head()
+   zones.head()
 
 
 .. ipython:: python
@@ -80,19 +80,19 @@ However it also accepts other summary statistic options as allowed by :meth:`pan
 * list of functions and/or function names, e.g. [np.sum, 'mean']
 * dict of axis labels -> functions, function names or list of such.
 
-For example, to get the number of countries on each continent, 
+For example, to get the number of countries on each continent,
 as well as the populations of the largest and smallest country of each,
 we can aggregate the ``'name'`` column using ``'count'``,
 and the ``'pop_est'`` column using ``'min'`` and ``'max'``:
 
 .. ipython:: python
 
-    world = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
-    continents = world.dissolve(
-        by="continent",
+    nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
+    zones = nepal.dissolve(
+        by="name_2",
         aggfunc={
-            "name": "count",
-            "pop_est": ["min", "max"],
+            "district": "count",
+            "population": ["min", "max"],
         },
     )
-   continents.head()
+   zones.head()

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -23,7 +23,7 @@ In a non-spatial setting, when you need summary statistics of the data, you can 
 :meth:`~geopandas.GeoDataFrame.dissolve` Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Suppose you are interested in Nepalese zone, but you only have Nepalese district-level data like the `geoda.nepal` dataset included in `geodatasets`. You can easily convert this to a zone-level dataset.
+Take example of administrative areas in Nepal. You have districts, which are smaller, and zones, which are larger. A group of districts always compose a single zone. Suppose you are interested in Nepalese zone, but you only have Nepalese district-level data like the `geoda.nepal` dataset included in `geodatasets`. You can easily convert this to a zone-level dataset.
 
 
 First, let's look at the most simple case where you just want zone shapes and names. By default, :meth:`~geopandas.GeoDataFrame.dissolve` will pass ``'first'`` to :ref:`groupby.aggregate <groupby.aggregate>`.
@@ -32,9 +32,10 @@ First, let's look at the most simple case where you just want zone shapes and na
 
     import geodatasets
 
-    nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
-    nepal = nepal[['name_2', 'geometry']]  # name_2 contains zone names
-    zones = nepal.dissolve(by='name_2')
+    nepal = geopandas.read_file(geodatasets.get_path('geoda.nepal'))
+    nepal = nepal.rename(columns={"name_2": "zone"})  # rename to remember the column
+    nepal_zone = nepal[['zone', 'geometry']]
+    zones = nepal_zone.dissolve(by='zone')
 
     @savefig zones1.png
     zones.plot();
@@ -45,9 +46,8 @@ If you are interested in aggregate populations, however, you can pass different 
 
 .. ipython:: python
 
-   nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
-   nepal = nepal[['name_2', 'geometry', 'population']]  # name_2 contains zone names
-   zones = nepal.dissolve(by='name_2', aggfunc='sum')
+   nepal_pop = nepal[['zone', 'geometry', 'population']]
+   zones = nepal_pop.dissolve(by='zone', aggfunc='sum')
 
    @savefig zones2.png
    zones.plot(column = 'population', scheme='quantiles', cmap='YlOrRd');
@@ -89,9 +89,8 @@ and the ``'pop_est'`` column using ``'min'`` and ``'max'``:
 
 .. ipython:: python
 
-    nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
     zones = nepal.dissolve(
-        by="name_2",
+        by="zone",
         aggfunc={
             "district": "count",
             "population": ["min", "max"],

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -4,7 +4,7 @@
    import geopandas
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
-   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
+   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1] * 1.5]
 
 
 Aggregation with dissolve

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -30,6 +30,8 @@ First, let's look at the most simple case where we just want zone shapes and nam
 
 .. ipython:: python
 
+    import geodatasets
+
     nepal = geopandas.read_file(geodatasets.get_path('geoda nepal'))
     nepal = nepal[['name_2', 'geometry']]  # name_2 contains zone names
     zones = nepal.dissolve(by='name_2')

--- a/doc/source/docs/user_guide/aggregation_with_dissolve.rst
+++ b/doc/source/docs/user_guide/aggregation_with_dissolve.rst
@@ -26,7 +26,7 @@ In a non-spatial setting, when you need summary statistics of the data, you can 
 Take example of administrative areas in Nepal. You have districts, which are smaller, and zones, which are larger. A group of districts always compose a single zone. Suppose you are interested in Nepalese zone, but you only have Nepalese district-level data like the `geoda.nepal` dataset included in `geodatasets`. You can easily convert this to a zone-level dataset.
 
 
-First, let's look at the most simple case where you just want zone shapes and names. By default, :meth:`~geopandas.GeoDataFrame.dissolve` will pass ``'first'`` to :ref:`groupby.aggregate <groupby.aggregate>`.
+First, let's look at the most simple case where you just want zone shapes and names.
 
 .. ipython:: python
 
@@ -34,6 +34,13 @@ First, let's look at the most simple case where you just want zone shapes and na
 
     nepal = geopandas.read_file(geodatasets.get_path('geoda.nepal'))
     nepal = nepal.rename(columns={"name_2": "zone"})  # rename to remember the column
+    nepal[["zone", "geometry"]].head()
+
+
+By default, :meth:`~geopandas.GeoDataFrame.dissolve` will pass ``'first'`` to :ref:`groupby.aggregate <groupby.aggregate>`.
+
+.. ipython:: python
+
     nepal_zone = nepal[['zone', 'geometry']]
     zones = nepal_zone.dissolve(by='zone')
 

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -8,8 +8,6 @@
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
    matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
-   geodatasets.fetch('geoda.colombia')
-
 
 
 Data structures
@@ -100,7 +98,7 @@ An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing t
     colombia.head()
     # Plot countries
     @savefig colombia_borders.png
-    colombia.plot();
+    colombia.plot(markersize=.5);
 
 Currently, the column named "geometry" with district borders is the active
 geometry column:

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -4,7 +4,6 @@
    :suppress:
 
    import geopandas
-   import geodatasets
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
    matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
@@ -92,6 +91,8 @@ A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely
 An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing the districts of Colombia:
 
 .. ipython:: python
+
+    import geodatasets
 
     colombia = geopandas.read_file(geodatasets.get_path('geoda.malaria'))
 

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -4,9 +4,11 @@
    :suppress:
 
    import geopandas
+   import geodatasets
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
    matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
+   geodatasets.fetch('geoda.colombia')
 
 
 
@@ -89,41 +91,41 @@ The "geometry" column -- no matter its name -- can be accessed through the :attr
 
 A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the :meth:`GeoDataFrame.set_geometry` method.
 
-An example using the ``worlds`` GeoDataFrame:
+An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing the districts of Colombia:
 
 .. ipython:: python
 
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
+    colombia = geopandas.read_file(geodatasets.get_path('geoda.malaria'))
 
-    world.head()
-    #Plot countries
-    @savefig world_borders.png
-    world.plot();
+    colombia.head()
+    # Plot countries
+    @savefig colombia_borders.png
+    colombia.plot();
 
-Currently, the column named "geometry" with country borders is the active
+Currently, the column named "geometry" with district borders is the active
 geometry column:
 
 .. ipython:: python
 
-    world.geometry.name
+    colombia.geometry.name
 
 We can also rename this column to "borders":
 
 .. ipython:: python
 
-    world = world.rename(columns={'geometry': 'borders'}).set_geometry('borders')
-    world.geometry.name
+    colombia = colombia.rename(columns={'geometry': 'borders'}).set_geometry('borders')
+    colombia.geometry.name
 
 Now, we create centroids and make it the geometry:
 
 .. ipython:: python
    :okwarning:
 
-    world['centroid_column'] = world.centroid
-    world = world.set_geometry('centroid_column')
+    colombia['centroid_column'] = colombia.centroid
+    colombia = colombia.set_geometry('centroid_column')
 
-    @savefig world_centroids.png
-    world.plot();
+    @savefig colombia_centroids.png
+    colombia.plot();
 
 
 **Note:** A :class:`GeoDataFrame` keeps track of the active column by name, so if you rename the active geometry column, you must also reset the geometry::
@@ -159,16 +161,16 @@ option to control:
 
 The ``geopandas.options.display_precision`` option can control the number of
 decimals to show in the display of coordinates in the geometry column.
-In the ``world`` example of above, the default is to show 5 decimals for
+In the ``colombia`` example of above, the default is to show 5 decimals for
 geographic coordinates:
 
 .. ipython:: python
 
-    world['centroid_column'].head()
+    colombia['centroid_column'].head()
 
 If you want to change this, for example to see more decimals, you can do:
 
 .. ipython:: python
 
     geopandas.options.display_precision = 9
-    world['centroid_column'].head()
+    colombia['centroid_column'].head()

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -88,7 +88,7 @@ The "geometry" column -- no matter its name -- can be accessed through the :attr
 
 A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the :meth:`GeoDataFrame.set_geometry` method.
 
-An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing the districts of Colombia:
+An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing the counties of Colombia:
 
 .. ipython:: python
 
@@ -101,7 +101,7 @@ An example using the ``geoda.malaria`` dataset from ``geodatasets`` containing t
     @savefig colombia_borders.png
     colombia.plot(markersize=.5);
 
-Currently, the column named "geometry" with district borders is the active
+Currently, the column named "geometry" with county borders is the active
 geometry column:
 
 .. ipython:: python
@@ -112,7 +112,7 @@ You can also rename this column to "borders":
 
 .. ipython:: python
 
-    colombia = colombia.rename(columns={'geometry': 'borders'}).set_geometry('borders')
+    colombia = colombia.rename_geometry('borders')
     colombia.geometry.name
 
 Now, you create centroids and make it the geometry:

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -6,7 +6,7 @@
    import geopandas
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
-   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
+   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1] * 1.5]
 
 
 Data structures

--- a/doc/source/docs/user_guide/geocoding.rst
+++ b/doc/source/docs/user_guide/geocoding.rst
@@ -19,7 +19,9 @@ with the detailed borough boundary file included within GeoPandas.
 
 .. ipython:: python
 
-    boros = geopandas.read_file(geopandas.datasets.get_path("nybb"))
+    import geodatasets
+
+    boros = geopandas.read_file(geodatasets.get_path("nybb"))
     boros.BoroName
     boro_locations = geopandas.tools.geocode(boros.BoroName)
     boro_locations

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -124,7 +124,8 @@ GeoPandas also implements alternate constructors that can read any data format r
 
 .. sourcecode:: python
 
-    >>> nybb_path = geopandas.datasets.get_path('nybb')
+    >>> import geodatasets
+    >>> nybb_path = geodatasets.get_path('nybb')
     >>> boros = geopandas.read_file(nybb_path)
     >>> boros.set_index('BoroCode', inplace=True)
     >>> boros.sort_index(inplace=True)

--- a/doc/source/docs/user_guide/indexing.rst
+++ b/doc/source/docs/user_guide/indexing.rst
@@ -5,7 +5,6 @@
 
    import geopandas
    import geodatasets
-   geodatasets.fetch('geoda.chile_labor')
 
 
 Indexing and selecting data
@@ -21,11 +20,11 @@ box. Geometries in the :class:`GeoSeries` or :class:`GeoDataFrame` that intersec
 bounding box will be returned.
 
 Using the ``geoda.chile_labor`` dataset, we can use this functionality to quickly select parts
-of Chile whose boundaries extend south of the -40 degrees latitude.
+of Chile whose boundaries extend south of the -50 degrees latitude.
 
 .. ipython:: python
 
    chile = geopandas.read_file(geodatasets.get_path('geoda.chile_labor'))
-   southern_chile = chile.cx[:, :-40]
+   southern_chile = chile.cx[:, :-50]
    @savefig chile_southern.png
-   southern_chile.plot(figsize=(10, 3));
+   southern_chile.plot(figsize=(8, 8));

--- a/doc/source/docs/user_guide/indexing.rst
+++ b/doc/source/docs/user_guide/indexing.rst
@@ -4,7 +4,6 @@
    :suppress:
 
    import geopandas
-   import geodatasets
 
 
 Indexing and selecting data
@@ -23,6 +22,8 @@ Using the ``geoda.chile_labor`` dataset, we can use this functionality to quickl
 of Chile whose boundaries extend south of the -50 degrees latitude.
 
 .. ipython:: python
+
+   import geodatasets
 
    chile = geopandas.read_file(geodatasets.get_path('geoda.chile_labor'))
    southern_chile = chile.cx[:, :-50]

--- a/doc/source/docs/user_guide/indexing.rst
+++ b/doc/source/docs/user_guide/indexing.rst
@@ -19,13 +19,20 @@ box. Geometries in the :class:`GeoSeries` or :class:`GeoDataFrame` that intersec
 bounding box will be returned.
 
 Using the ``geoda.chile_labor`` dataset, you can use this functionality to quickly select parts
-of Chile whose boundaries extend south of the -50 degrees latitude.
+of Chile whose boundaries extend south of the -50 degrees latitude. You can first check the original GeoDataFrame.
 
 .. ipython:: python
 
    import geodatasets
 
    chile = geopandas.read_file(geodatasets.get_path('geoda.chile_labor'))
+   @savefig chile.png
+   chile.plot(figsize=(8, 8));
+
+And then select only the southern part of the country.
+
+.. ipython:: python
+
    southern_chile = chile.cx[:, :-50]
    @savefig chile_southern.png
    southern_chile.plot(figsize=(8, 8));

--- a/doc/source/docs/user_guide/indexing.rst
+++ b/doc/source/docs/user_guide/indexing.rst
@@ -4,6 +4,8 @@
    :suppress:
 
    import geopandas
+   import geodatasets
+   geodatasets.fetch('geoda.chile_labor')
 
 
 Indexing and selecting data
@@ -18,12 +20,12 @@ coordinate based indexing with the :attr:`~GeoDataFrame.cx` indexer, which slice
 box. Geometries in the :class:`GeoSeries` or :class:`GeoDataFrame` that intersect the
 bounding box will be returned.
 
-Using the ``world`` dataset, we can use this functionality to quickly select all
-countries whose boundaries extend into the southern hemisphere.
+Using the ``geoda.chile_labor`` dataset, we can use this functionality to quickly select parts
+of Chile whose boundaries extend south of the -40 degrees latitude.
 
 .. ipython:: python
 
-   world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-   southern_world = world.cx[:, :0]
-   @savefig world_southern.png
-   southern_world.plot(figsize=(10, 3));
+   chile = geopandas.read_file(geodatasets.get_path('geoda.chile_labor'))
+   southern_chile = chile.cx[:, :-40]
+   @savefig chile_southern.png
+   southern_chile.plot(figsize=(10, 3));

--- a/doc/source/docs/user_guide/interactive_mapping.ipynb
+++ b/doc/source/docs/user_guide/interactive_mapping.ipynb
@@ -132,7 +132,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "geopandas_dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -29,17 +29,17 @@ the ``driver`` keyword, or pick a single layer from a multi-layered file with
 the ``layer`` keyword::
 
     countries_gdf = geopandas.read_file("package.gpkg", layer='countries')
-    
+
 Currently fiona only exposes the default drivers. To display those, type::
 
-    import fiona; fiona.supported_drivers 
+    import fiona; fiona.supported_drivers
 
 There is a `list of available drivers <https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py>`_
-which are unexposed but supported (depending on the GDAL-build). You can activate 
+which are unexposed but supported (depending on the GDAL-build). You can activate
 these on runtime by updating the `supported_drivers` dictionary like::
 
     fiona.supported_drivers["NAS"] = "raw"
-    
+
 Where supported in :mod:`Fiona`, GeoPandas can also load resources directly from
 a web URL, for example for GeoJSON files from `geojson.xyz <http://geojson.xyz/>`_::
 
@@ -98,11 +98,11 @@ The geometry filter only loads data that intersects with the geometry.
 .. code-block:: python
 
     gdf_mask = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres")
+        geodatasets.get_path("geoda nyc")
     )
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_cities"),
-        mask=gdf_mask[gdf_mask.continent=="Africa"],
+        geodatasets.get_path("geoda nyc education"),
+        mask=gdf_mask[gdf_mask.name=="Coney Island"],
     )
 
 Bounding box filter
@@ -118,7 +118,7 @@ The bounding box filter only loads data that intersects with the bounding box.
         1031051.7879884212, 224272.49231459625, 1047224.3104931959, 244317.30894023244
     )
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("nybb"),
+        geodatasets.get_path("nybb"),
         bbox=bbox,
     )
 
@@ -133,11 +133,11 @@ or a slice object.
 .. code-block:: python
 
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
+        geodatasets.get_path("geoda nyc"),
         rows=10,
     )
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
+        geodatasets.get_path("geoda nyc"),
         rows=slice(10, 20),
     )
 
@@ -151,8 +151,8 @@ Load in a subset of fields from the file:
 .. code-block:: python
 
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
-        include_fields=["pop_est", "continent", "name"],
+        geodatasets.get_path("geoda nyc"),
+        include_fields=["name", "rent2008", "kids2000"],
     )
 
 .. note:: Requires Fiona 1.8+
@@ -160,8 +160,8 @@ Load in a subset of fields from the file:
 .. code-block:: python
 
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
-        ignore_fields=["iso_a3", "gdp_md_est"],
+        geodatasets.get_path("geoda nyc"),
+        ignore_fields=["rent2008", "kids2000"],
     )
 
 Skip loading geometry from the file:
@@ -172,7 +172,7 @@ Skip loading geometry from the file:
 .. code-block:: python
 
     pdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
+        geodatasets.get_path("geoda nyc"),
         ignore_geometry=True,
     )
 
@@ -189,8 +189,8 @@ Load in a subset of data with a `SQL WHERE clause <https://gdal.org/user/ogr_sql
 .. code-block:: python
 
     gdf = geopandas.read_file(
-        geopandas.datasets.get_path("naturalearth_lowres"),
-        where="continent='Africa'",
+        geodatasets.get_path("geoda nyc"),
+        where="subborough='Coney Island'",
     )
 
 

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -97,6 +97,8 @@ The geometry filter only loads data that intersects with the geometry.
 
 .. code-block:: python
 
+    import geodatasets
+
     gdf_mask = geopandas.read_file(
         geodatasets.get_path("geoda nyc")
     )

--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -31,7 +31,7 @@ We can now plot those GeoDataFrames:
 
 .. ipython:: python
 
-    # Examine country GeoDataFrame
+    # Examine chicago GeoDataFrame
     chicago.head()
 
     # Basic plot, single color

--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -6,7 +6,7 @@
    import geopandas
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
-   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
+   matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1] * 1.5]
    import matplotlib.pyplot as plt
    plt.close('all')
 
@@ -25,14 +25,14 @@ Loading some example data:
 
     import geodatasets
 
-    chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
-    groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
+    chicago = geopandas.read_file(geodatasets.get_path("geoda.chicago_health"))
+    groceries = geopandas.read_file(geodatasets.get_path("geoda.groceries"))
 
 You can now plot those GeoDataFrames:
 
 .. ipython:: python
 
-    # Examine chicago GeoDataFrame
+    # Examine the chicago GeoDataFrame
     chicago.head()
 
     # Basic plot, single color
@@ -255,6 +255,7 @@ the ``kind`` keyword argument in :meth:`~GeoDataFrame.plot`, and include:
     chicago.plot(kind="scatter", x="Pop2012", y="shape_area")
 
 You can also create these other plots using the ``GeoDataFrame.plot.<kind>`` accessor methods instead of providing the ``kind`` keyword argument.
+For example, ``hist``, can be used to plot histograms of population for two different years from the Chicago dataset.
 
 .. ipython:: python
 

--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -4,6 +4,7 @@
    :suppress:
 
    import geopandas
+   import geodatasets
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
    matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
@@ -23,19 +24,19 @@ Loading some example data:
 
 .. ipython:: python
 
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-    cities = geopandas.read_file(geopandas.datasets.get_path('naturalearth_cities'))
+    chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
+    groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
 
 We can now plot those GeoDataFrames:
 
 .. ipython:: python
 
     # Examine country GeoDataFrame
-    world.head()
+    chicago.head()
 
-    # Basic plot, random colors
-    @savefig world_randomcolors.png
-    world.plot();
+    # Basic plot, single color
+    @savefig chicago_singlecolor.png
+    chicago.plot();
 
 Note that in general, any options one can pass to `pyplot <http://matplotlib.org/api/pyplot_api.html>`_ in matplotlib_ (or `style options that work for lines <http://matplotlib.org/api/lines_api.html>`_) can be passed to the :meth:`~GeoDataFrame.plot` method.
 
@@ -48,11 +49,8 @@ GeoPandas makes it easy to create Choropleth maps (maps where the color of each 
 .. ipython:: python
    :okwarning:
 
-    # Plot by GDP per capita
-    world = world[(world.pop_est>0) & (world.name!="Antarctica")]
-    world['gdp_per_cap'] = world.gdp_md_est / world.pop_est
-    @savefig world_gdp_per_cap.png
-    world.plot(column='gdp_per_cap');
+    # Plot by population
+    chicago.plot(column="Pop2014");
 
 
 Creating a legend
@@ -63,37 +61,38 @@ When plotting a map, one can enable a legend using the ``legend`` argument:
 .. ipython:: python
 
     # Plot population estimates with an accurate legend
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots(1, 1)
-    @savefig world_pop_est.png
-    world.plot(column='pop_est', ax=ax, legend=True)
+    @savefig chicago_choro.png
+    chicago.plot(column='Pop2014', legend=True);
 
-However, the default appearance of the legend and plot axes may not be desirable. One can define the plot axes (with ``ax``) and the legend axes (with ``cax``) and then pass those in to the :meth:`~GeoDataFrame.plot` call. The following example uses ``mpl_toolkits`` to vertically align the plot axes and the legend axes:
+The following example plots the color bar below the map and adds its label using ``legend_kwds``:
 
 .. ipython:: python
 
     # Plot population estimates with an accurate legend
+    @savefig chicago_horizontal.png
+    chicago.plot(
+        column="Pop2014",
+        legend=True,
+        legend_kwds={"label": "Population in 2014", "orientation": "horizontal"},
+    );
+
+However, the default appearance of the legend and plot axes may not be desirable. One can define the plot axes (with ``ax``) and the legend axes (with ``cax``) and then pass those in to the :meth:`~GeoDataFrame.plot` call. The following example uses ``mpl_toolkits`` to horizontally align the plot axes and the legend axes and change the width:
+
+.. ipython:: python
+
+    # Plot population estimates with an accurate legend
+    import matplotlib.pyplot as plt
     from mpl_toolkits.axes_grid1 import make_axes_locatable
     fig, ax = plt.subplots(1, 1)
     divider = make_axes_locatable(ax)
-    cax = divider.append_axes("right", size="5%", pad=0.1)
-    @savefig world_pop_est_fixed_legend_height.png
-    world.plot(column='pop_est', ax=ax, legend=True, cax=cax)
-
-
-And the following example plots the color bar below the map and adds its label using ``legend_kwds``:
-
-.. ipython:: python
-
-    # Plot population estimates with an accurate legend
-    import matplotlib.pyplot as plt
-    fig, ax = plt.subplots(1, 1)
-    @savefig world_pop_est_horizontal.png
-    world.plot(column='pop_est',
-               ax=ax,
-               legend=True,
-               legend_kwds={'label': "Population by Country",
-                            'orientation': "horizontal"})
+    cax = divider.append_axes("bottom", size="5%", pad=0.1)
+    chicago.plot(
+        column="Pop2014",
+        ax=ax,
+        legend=True,
+        cax=cax,
+        legend_kwds={"label": "Population in 2014", "orientation": "horizontal"},
+    );
 
 
 Choosing colors
@@ -103,16 +102,16 @@ You can also modify the colors used by :meth:`~GeoDataFrame.plot` with the ``cma
 
 .. ipython:: python
 
-    @savefig world_gdp_per_cap_red.png
-    world.plot(column='gdp_per_cap', cmap='OrRd');
+    @savefig chicago_red.png
+    chicago.plot(column='Pop2014', cmap='OrRd');
 
 
-To make the color transparent for when you just want to show the boundary, you have two options. One option is to do ``world.plot(facecolor="none", edgecolor="black")``. However, this can cause a lot of confusion because ``"none"``  and ``None`` are different in the context of using ``facecolor`` and they do opposite things. ``None`` does the "default behavior" based on matplotlib, and if you use it for ``facecolor``, it actually adds a color. The second option is to use ``world.boundary.plot()``. This option is more explicit and clear.:
+To make the color transparent for when you just want to show the boundary, you have two options. One option is to do ``chicago.plot(facecolor="none", edgecolor="black")``. However, this can cause a lot of confusion because ``"none"``  and ``None`` are different in the context of using ``facecolor`` and they do opposite things. ``None`` does the "default behavior" based on matplotlib, and if you use it for ``facecolor``, it actually adds a color. The second option is to use ``chicago.boundary.plot()``. This option is more explicit and clear.:
 
 .. ipython:: python
 
-    @savefig world_gdp_per_cap_transparent.png
-    world.boundary.plot();
+    @savefig chicago_transparent.png
+    chicago.boundary.plot();
 
 
 The way color maps are scaled can also be manipulated with the ``scheme`` option (if you have ``mapclassify`` installed, which can be accomplished via ``conda install -c conda-forge mapclassify``). The ``scheme`` option can be set to any scheme provided by mapclassify (e.g. 'box_plot', 'equal_interval',
@@ -120,8 +119,8 @@ The way color maps are scaled can also be manipulated with the ``scheme`` option
 
 .. ipython:: python
 
-    @savefig world_gdp_per_cap_quantiles.png
-    world.plot(column='gdp_per_cap', cmap='OrRd', scheme='quantiles');
+    @savefig chicago_quantiles.png
+    chicago.plot(column='Pop2014', cmap='OrRd', scheme='quantiles');
 
 
 Missing data
@@ -132,20 +131,20 @@ In some cases one may want to plot data which contains missing values - for some
 .. ipython:: python
 
     import numpy as np
-    world.loc[np.random.choice(world.index, 40), 'pop_est'] = np.nan
+    chicago.loc[np.random.choice(chicago.index, 30), 'Pop2014'] = np.nan
     @savefig missing_vals.png
-    world.plot(column='pop_est');
+    chicago.plot(column='Pop2014');
 
 However, passing ``missing_kwds`` one can specify the style and label of features containing None or NaN.
 
 .. ipython:: python
 
     @savefig missing_vals_grey.png
-    world.plot(column='pop_est', missing_kwds={'color': 'lightgrey'});
+    chicago.plot(column='Pop2014', missing_kwds={'color': 'lightgrey'});
 
     @savefig missing_vals_hatch.png
-    world.plot(
-        column="pop_est",
+    chicago.plot(
+        column="Pop2014",
         legend=True,
         scheme="quantiles",
         figsize=(15, 10),
@@ -164,7 +163,7 @@ Maps usually do not have to have axis labels. You can turn them off using ``set_
 
 .. ipython:: python
 
-    ax = world.plot()
+    ax = chicago.plot()
     @savefig set_axis_off.png
     ax.set_axis_off();
 
@@ -180,38 +179,30 @@ Before combining maps, however, remember to always ensure they share a common CR
     # Look at capitals
     # Note use of standard `pyplot` line style options
     @savefig capitals.png
-    cities.plot(marker='*', color='green', markersize=5);
+    groceries.plot(marker='*', color='green', markersize=5);
 
     # Check crs
-    cities = cities.to_crs(world.crs)
+    groceries = groceries.to_crs(chicago.crs)
 
-    # Now we can overlay over country outlines
-    # And yes, there are lots of island capitals
-    # apparently in the middle of the ocean!
+    # Now we can overlay over the outlines
 
 **Method 1**
 
 .. ipython:: python
 
-    base = world.plot(color='white', edgecolor='black')
-    @savefig capitals_over_countries_1.png
-    cities.plot(ax=base, marker='o', color='red', markersize=5);
+    base = chicago.plot(color='white', edgecolor='black')
+    @savefig groceries_over_chicago_1.png
+    groceries.plot(ax=base, marker='o', color='red', markersize=5);
 
 **Method 2: Using matplotlib objects**
 
 .. ipython:: python
 
-    import matplotlib.pyplot as plt
     fig, ax = plt.subplots()
 
-    # set aspect to equal. This is done automatically
-    # when using GeoPandas plot on it's own, but not when
-    # working with pyplot directly.
-    ax.set_aspect('equal')
-
-    world.plot(ax=ax, color='white', edgecolor='black')
-    cities.plot(ax=ax, marker='o', color='red', markersize=5)
-    @savefig capitals_over_countries_2.png
+    chicago.plot(ax=ax, color='white', edgecolor='black')
+    groceries.plot(ax=ax, marker='o', color='red', markersize=5)
+    @savefig groceries_over_chicago_2.png
     plt.show();
 
 Control the order of multiple layers in a plot
@@ -224,17 +215,17 @@ Without specified ``zorder``, cities (Points) gets plotted below world (Polygons
 
 .. ipython:: python
 
-    ax = cities.plot(color='k')
+    ax = groceries.plot(color='k')
     @savefig zorder_default.png
-    world.plot(ax=ax);
+    chicago.plot(ax=ax);
 
 We can set the ``zorder`` for cities higher than for world to move it of top.
 
 .. ipython:: python
 
-    ax = cities.plot(color='k', zorder=2)
+    ax = groceries.plot(color='k', zorder=2)
     @savefig zorder_set.png
-    world.plot(ax=ax, zorder=1);
+    chicago.plot(ax=ax, zorder=1);
 
 
 Pandas plots

--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -50,6 +50,7 @@ GeoPandas makes it easy to create Choropleth maps (maps where the color of each 
    :okwarning:
 
     # Plot by population
+    @savefig chicago_population.png
     chicago.plot(column="Pop2014");
 
 
@@ -86,6 +87,7 @@ However, the default appearance of the legend and plot axes may not be desirable
     fig, ax = plt.subplots(1, 1)
     divider = make_axes_locatable(ax)
     cax = divider.append_axes("bottom", size="5%", pad=0.1)
+    @savefig chicago_cax.png
     chicago.plot(
         column="Pop2014",
         ax=ax,
@@ -248,16 +250,15 @@ the ``kind`` keyword argument in :meth:`~GeoDataFrame.plot`, and include:
 
 .. ipython:: python
 
-    gdf = world.head(10)
     @savefig pandas_line_plot.png
-    gdf.plot(kind='scatter', x="pop_est", y="gdp_md_est")
+    chicago.plot(kind="scatter", x="Pop2012", y="shape_area")
 
 You can also create these other plots using the ``GeoDataFrame.plot.<kind>`` accessor methods instead of providing the ``kind`` keyword argument.
 
 .. ipython:: python
 
-    @savefig pandas_bar_plot.png
-    gdf.plot.bar()
+    @savefig pandas_hist_plot.png
+    chicago[["Pop2012", "Pop2014", "geometry"]].plot.hist(alpha=.4)
 
 For more information, see `Chart visualization <https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html>`_ in the pandas documentation.
 

--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -4,7 +4,6 @@
    :suppress:
 
    import geopandas
-   import geodatasets
    import matplotlib
    orig = matplotlib.rcParams['figure.figsize']
    matplotlib.rcParams['figure.figsize'] = [orig[0] * 1.5, orig[1]]
@@ -23,6 +22,8 @@ GeoPandas provides a high-level interface to the matplotlib_ library for making 
 Loading some example data:
 
 .. ipython:: python
+
+    import geodatasets
 
     chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
     groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -23,6 +23,8 @@ In the following examples, we use these datasets:
 
 .. ipython:: python
 
+   import geodatasets
+
    chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
    groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
 

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -31,7 +31,7 @@ In the following examples, we use these datasets:
    chicago_names = chicago[['community', 'ComAreaID']]
 
    # For spatial join
-   chicago = chicago[['geometry', 'community']]
+   chicago = chicago[['geometry', 'community']].to_crs(groceries.crs)
 
 
 Appending
@@ -61,17 +61,17 @@ if a :class:`~pandas.DataFrame` is in the ``left`` argument and a :class:`GeoDat
 is in the ``right`` position, the result will no longer be a :class:`GeoDataFrame`.
 
 For example, consider the following merge that adds full names to a :class:`GeoDataFrame`
-that initially has only ISO codes for each country by merging it with a :class:`~pandas.DataFrame`.
+that initially has only area ID for each geometry by merging it with a :class:`~pandas.DataFrame`.
 
 .. ipython:: python
 
-   # `chicago_shapes` is GeoDataFrame with country shapes and iso codes
+   # `chicago_shapes` is GeoDataFrame with community shapes and area IDs
    chicago_shapes.head()
 
-   # `chicago_names` is DataFrame with country names and iso codes
+   # `chicago_names` is DataFrame with community names and area ID
    chicago_names.head()
 
-   # Merge with `merge` method on shared variable (iso codes):
+   # Merge with `merge` method on shared variable (area ID):
    chicago_shapes = chicago_shapes.merge(chicago_names, on='ComAreaID')
    chicago_shapes.head()
 
@@ -84,8 +84,8 @@ In a spatial join, two geometry objects are merged based on their spatial relati
 .. ipython:: python
 
 
-   # One GeoDataFrame of countries, one of Cities.
-   # Want to merge so we can get each city's country.
+   # One GeoDataFrame of communities, one of grocery stores.
+   # Want to merge so we can get each grocery's community.
    chicago.head()
    groceries.head()
 

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -23,16 +23,15 @@ In the following examples, we use these datasets:
 
 .. ipython:: python
 
-   world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-   cities = geopandas.read_file(geopandas.datasets.get_path('naturalearth_cities'))
+   chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
+   groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
 
    # For attribute join
-   country_shapes = world[['geometry', 'iso_a3']]
-   country_names = world[['name', 'iso_a3']]
+   chicago_shapes = chicago[['geometry', 'ComAreaID']]
+   chicago_names = chicago[['community', 'ComAreaID']]
 
    # For spatial join
-   countries = world[['geometry', 'name']]
-   countries = countries.rename(columns={'name':'country'})
+   chicago = chicago[['geometry', 'community']]
 
 
 Appending
@@ -44,12 +43,12 @@ Keep in mind, that appended geometry columns needs to have the same CRS.
 .. ipython:: python
 
     # Appending GeoSeries
-    joined = pd.concat([world.geometry, cities.geometry])
+    joined = pd.concat([chicago.geometry, groceries.geometry])
 
     # Appending GeoDataFrames
-    europe = world[world.continent == 'Europe']
-    asia = world[world.continent == 'Asia']
-    eurasia = pd.concat([europe, asia])
+    douglas = chicago[chicago.community == 'DOUGLAS']
+    oakland = chicago[chicago.community == 'OAKLAND']
+    douglas_oakland = pd.concat([douglas, oakland])
 
 
 Attribute joins
@@ -66,15 +65,15 @@ that initially has only ISO codes for each country by merging it with a :class:`
 
 .. ipython:: python
 
-   # `country_shapes` is GeoDataFrame with country shapes and iso codes
-   country_shapes.head()
+   # `chicago_shapes` is GeoDataFrame with country shapes and iso codes
+   chicago_shapes.head()
 
-   # `country_names` is DataFrame with country names and iso codes
-   country_names.head()
+   # `chicago_names` is DataFrame with country names and iso codes
+   chicago_names.head()
 
    # Merge with `merge` method on shared variable (iso codes):
-   country_shapes = country_shapes.merge(country_names, on='iso_a3')
-   country_shapes.head()
+   chicago_shapes = chicago_shapes.merge(chicago_names, on='ComAreaID')
+   chicago_shapes.head()
 
 
 Spatial joins
@@ -87,13 +86,13 @@ In a spatial join, two geometry objects are merged based on their spatial relati
 
    # One GeoDataFrame of countries, one of Cities.
    # Want to merge so we can get each city's country.
-   countries.head()
-   cities.head()
+   chicago.head()
+   groceries.head()
 
    # Execute spatial join
 
-   cities_with_country = cities.sjoin(countries, how="inner", predicate='intersects')
-   cities_with_country.head()
+   groceries_with_community = groceries.sjoin(chicago, how="inner", predicate='intersects')
+   groceries_with_community.head()
 
 
 GeoPandas provides two spatial-join functions:

--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -80,6 +80,8 @@ Re-projecting is the process of changing the representation of locations from on
 
 .. ipython:: python
 
+    import geodatasets
+
     # load example data
     usa = geopandas.read_file(geodatasets.get_path('geoda nat regimes'))
 

--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -81,23 +81,22 @@ Re-projecting is the process of changing the representation of locations from on
 .. ipython:: python
 
     # load example data
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
+    usa = geopandas.read_file(geodatasets.get_path('geoda nat regimes'))
 
     # Check original projection
     # (it's Plate Carrée! x-y are long and lat)
-    world.crs
+    usa.crs
 
     # Visualize
-    ax = world.plot()
-    @savefig world_starting.png
+    ax = usa.plot()
+    @savefig usa_starting.png
     ax.set_title("WGS84 (lat/lon)");
 
-    # Reproject to Mercator (after dropping Antartica)
-    world = world[(world.name != "Antarctica") & (world.name != "Fr. S. Antarctic Lands")]
-    world = world.to_crs("EPSG:3395") # world.to_crs(epsg=3395) would also work
-    ax = world.plot()
-    @savefig world_reproj.png
-    ax.set_title("Mercator");
+    # Reproject to Albers contiguous USA
+    usa = usa.to_crs("ESRI:102003")
+    ax = usa.plot()
+    @savefig usa_reproj.png
+    ax.set_title("NAD 1983 Albers contiguous USA");
 
 
 Projection for multiple geometry columns

--- a/doc/source/docs/user_guide/reproject_fiona.rst
+++ b/doc/source/docs/user_guide/reproject_fiona.rst
@@ -18,7 +18,6 @@ Fiona example
     from functools import partial
 
     import fiona
-    import geodatasets
     import geopandas
     from fiona.transform import transform_geom
     from packaging import version
@@ -47,15 +46,16 @@ Fiona example
             )
         )
 
-    # load example data
-    nybb = geopandas.read_file(geodatasets.get_path('nybb'))
+    # load natuural earth land data
+    world = geopandas.read_file("https://naciscdn.org/naturalearth/110m/physical/ne_110m_land.zip")
 
     destination_crs = "EPSG:3395"
-    forward_transformer = partial(base_transformer, src_crs=nybb.crs, dst_crs=destination_crs)
+    forward_transformer = partial(base_transformer, src_crs=world.crs, dst_crs=destination_crs)
 
-    # Reproject to Mercator
+    # Reproject to Mercator (after dropping Antartica)
+    world = world.drop(7)
     with fiona.Env(OGR_ENABLE_PARTIAL_REPROJECTION="YES"):
-        mercator_nybb = nybb.set_geometry(nybb.geometry.apply(forward_transformer), crs=destination_crs)
+        mercator_world = world.set_geometry(world.geometry.apply(forward_transformer), crs=destination_crs)
 
 
 Rasterio example
@@ -71,16 +71,16 @@ This example requires rasterio 1.2+ and GDAL 3+.
     from shapely.geometry import shape
 
     # load example data
-    nybb = geopandas.read_file(geodatasets.get_path('nybb'))
-
-    # Reproject to Mercator
+    world = geopandas.read_file("https://naciscdn.org/naturalearth/110m/physical/ne_110m_land.zip")
+    # Reproject to Mercator (after dropping Antartica)
+    world = world.drop(7)
     destination_crs = "EPSG:3395"
     geometry = rasterio.warp.transform_geom(
-        src_crs=nybb.crs,
+        src_crs=world.crs,
         dst_crs=destination_crs,
-        geom=nybb.geometry.values,
+        geom=world.geometry.values,
     )
-    mercator_nybb = nybb.set_geometry(
+    mercator_world = world.set_geometry(
         [shape(geom) for geom in geometry],
         crs=destination_crs,
     )

--- a/doc/source/docs/user_guide/reproject_fiona.rst
+++ b/doc/source/docs/user_guide/reproject_fiona.rst
@@ -18,6 +18,7 @@ Fiona example
     from functools import partial
 
     import fiona
+    import geodatasets
     import geopandas
     from fiona.transform import transform_geom
     from packaging import version
@@ -47,15 +48,14 @@ Fiona example
         )
 
     # load example data
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
+    nybb = geopandas.read_file(geodatasets.get_path('nybb'))
 
     destination_crs = "EPSG:3395"
-    forward_transformer = partial(base_transformer, src_crs=world.crs, dst_crs=destination_crs)
+    forward_transformer = partial(base_transformer, src_crs=nybb.crs, dst_crs=destination_crs)
 
-    # Reproject to Mercator (after dropping Antartica)
-    world = world[(world.name != "Antarctica") & (world.name != "Fr. S. Antarctic Lands")]
+    # Reproject to Mercator
     with fiona.Env(OGR_ENABLE_PARTIAL_REPROJECTION="YES"):
-        mercator_world = world.set_geometry(world.geometry.apply(forward_transformer), crs=destination_crs)
+        mercator_nybb = nybb.set_geometry(nybb.geometry.apply(forward_transformer), crs=destination_crs)
 
 
 Rasterio example
@@ -71,17 +71,16 @@ This example requires rasterio 1.2+ and GDAL 3+.
     from shapely.geometry import shape
 
     # load example data
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-    # Reproject to Mercator (after dropping Antartica)
-    world = world[(world.name != "Antarctica") & (world.name != "Fr. S. Antarctic Lands")]
+    nybb = geopandas.read_file(geodatasets.get_path('nybb'))
 
+    # Reproject to Mercator
     destination_crs = "EPSG:3395"
     geometry = rasterio.warp.transform_geom(
-        src_crs=world.crs,
+        src_crs=nybb.crs,
         dst_crs=destination_crs,
-        geom=world.geometry.values,
+        geom=nybb.geometry.values,
     )
-    mercator_world = world.set_geometry(
+    mercator_nybb = nybb.set_geometry(
         [shape(geom) for geom in geometry],
         crs=destination_crs,
     )

--- a/doc/source/docs/user_guide/set_operations.rst
+++ b/doc/source/docs/user_guide/set_operations.rst
@@ -135,60 +135,56 @@ but with the geometries obtained from overlaying ``df1`` with ``df2``:
     df2.plot(ax=ax, facecolor='none', edgecolor='k');
 
 
-Overlay countries example
+Overlay groceries example
 -------------------------
 
-First, we load the countries and cities example datasets and select :
+First, we load the Chicago boroughs and groceries example datasets and select :
 
 .. ipython:: python
 
-    world = geopandas.read_file(geopandas.datasets.get_path('naturalearth_lowres'))
-    capitals = geopandas.read_file(geopandas.datasets.get_path('naturalearth_cities'))
-
-    # Select South America and some columns
-    countries = world[world['continent'] == "South America"]
-    countries = countries[['geometry', 'name']]
+    chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
+    groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
 
     # Project to crs that uses meters as distance measure
-    countries = countries.to_crs('epsg:3395')
-    capitals = capitals.to_crs('epsg:3395')
+    chicago = chicago.to_crs("ESRI:102003")
+    groceries = groceries.to_crs("ESRI:102003")
 
 To illustrate the :meth:`~geopandas.GeoDataFrame.overlay` method, consider the following case in which one
-wishes to identify the "core" portion of each country -- defined as areas within
-500km of a capital -- using a ``GeoDataFrame`` of countries and a
-``GeoDataFrame`` of capitals.
+wishes to identify the "served" portion of each borough -- defined as areas within
+1km of a grocery store -- using a ``GeoDataFrame`` of boroughs and a
+``GeoDataFrame`` of groceries.
 
 .. ipython:: python
 
-    # Look at countries:
-    @savefig world_basic.png width=5in
-    countries.plot();
+    # Look at Chicago:
+    @savefig chicago_basic.png width=5in
+    chicago.plot();
 
-    # Now buffer cities to find area within 500km.
-    # Check CRS -- World Mercator, units of meters.
-    capitals.crs
+    # Now buffer groceries to find area within 1km.
+    # Check CRS -- USA Contiguous Albers Equal Area, units of meters.
+    groceries.crs
 
-    # make 500km buffer
-    capitals['geometry']= capitals.buffer(500000)
-    @savefig capital_buffers.png width=5in
-    capitals.plot();
+    # make 1km buffer
+    groceries['geometry']= groceries.buffer(1000)
+    @savefig groceries_buffers.png width=5in
+    groceries.plot();
 
 
-To select only the portion of countries within 500km of a capital, we specify the ``how`` option to be "intersect", which creates a new set of polygons where these two layers overlap:
-
-.. ipython:: python
-
-   country_cores = countries.overlay(capitals, how='intersection')
-   @savefig country_cores.png width=5in
-   country_cores.plot(alpha=0.5, edgecolor='k', cmap='tab10');
-
-Changing the "how" option allows for different types of overlay operations. For example, if we were interested in the portions of countries *far* from capitals (the peripheries), we would compute the difference of the two.
+To select only the portion of boroughs within 1km of a grocery, we specify the ``how`` option to be "intersect", which creates a new set of polygons where these two layers overlap:
 
 .. ipython:: python
 
-   country_peripheries = countries.overlay(capitals, how='difference')
-   @savefig country_peripheries.png width=5in
-   country_peripheries.plot(alpha=0.5, edgecolor='k', cmap='tab10');
+   chicago_cores = chicago.overlay(groceries, how='intersection')
+   @savefig chicago_cores.png width=5in
+   chicago_cores.plot(alpha=0.5, edgecolor='k', cmap='tab10');
+
+Changing the "how" option allows for different types of overlay operations. For example, if we were interested in the portions of Chicago *far* from groceries (the peripheries), we would compute the difference of the two.
+
+.. ipython:: python
+
+   chicago_peripheries = chicago.overlay(groceries, how='difference')
+   @savefig chicago_peripheries.png width=5in
+   chicago_peripheries.plot(alpha=0.5, edgecolor='k', cmap='tab10');
 
 
 .. ipython:: python

--- a/doc/source/docs/user_guide/set_operations.rst
+++ b/doc/source/docs/user_guide/set_operations.rst
@@ -138,7 +138,7 @@ but with the geometries obtained from overlaying ``df1`` with ``df2``:
 Overlay groceries example
 -------------------------
 
-First, load the Chicago boroughs and groceries example datasets and select :
+First, load the Chicago community areas and groceries example datasets and select :
 
 .. ipython:: python
 
@@ -152,8 +152,8 @@ First, load the Chicago boroughs and groceries example datasets and select :
     groceries = groceries.to_crs("ESRI:102003")
 
 To illustrate the :meth:`~geopandas.GeoDataFrame.overlay` method, consider the following case in which one
-wishes to identify the "served" portion of each borough -- defined as areas within
-1km of a grocery store -- using a ``GeoDataFrame`` of boroughs and a
+wishes to identify the "served" portion of each area -- defined as areas within
+1km of a grocery store -- using a ``GeoDataFrame`` of community areas and a
 ``GeoDataFrame`` of groceries.
 
 .. ipython:: python
@@ -172,7 +172,7 @@ wishes to identify the "served" portion of each borough -- defined as areas with
     groceries.plot();
 
 
-To select only the portion of boroughs within 1km of a grocery, specify the ``how`` option to be "intersect", which creates a new set of polygons where these two layers overlap:
+To select only the portion of community areas within 1km of a grocery, specify the ``how`` option to be "intersect", which creates a new set of polygons where these two layers overlap:
 
 .. ipython:: python
 

--- a/doc/source/docs/user_guide/set_operations.rst
+++ b/doc/source/docs/user_guide/set_operations.rst
@@ -142,6 +142,8 @@ First, we load the Chicago boroughs and groceries example datasets and select :
 
 .. ipython:: python
 
+    import geodatasets
+
     chicago = geopandas.read_file(geodatasets.get_path("geoda chicago health"))
     groceries = geopandas.read_file(geodatasets.get_path("geoda groceries"))
 

--- a/doc/source/getting_started/introduction.ipynb
+++ b/doc/source/getting_started/introduction.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -38,7 +39,7 @@
     "\n",
     "### Reading files\n",
     "\n",
-    "Assuming you have a file containing both data and geometry (e.g. GeoPackage, GeoJSON, Shapefile), you can read it using `geopandas.read_file()`, which automatically detects the filetype and creates a `GeoDataFrame`. This tutorial uses the `\"nybb\"` dataset, a map of New York boroughs, which is part of the GeoPandas installation. Therefore, we use `geopandas.datasets.get_path()` to retrieve the path to the dataset."
+    "Assuming you have a file containing both data and geometry (e.g. GeoPackage, GeoJSON, Shapefile), you can read it using `geopandas.read_file()`, which automatically detects the filetype and creates a `GeoDataFrame`. This tutorial uses the `\"nybb\"` dataset, a map of New York boroughs, which is available through the `geodatasets` package. Therefore, we use `geodatasets.get_path()` to download the dataset and retrieve the path to the local copy."
    ]
   },
   {
@@ -48,8 +49,9 @@
    "outputs": [],
    "source": [
     "import geopandas\n",
+    "from geodatasets import get_path\n",
     "\n",
-    "path_to_data = geopandas.datasets.get_path(\"nybb\")\n",
+    "path_to_data = get_path(\"nybb\")\n",
     "gdf = geopandas.read_file(path_to_data)\n",
     "\n",
     "gdf"
@@ -532,7 +534,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "geopandas_dev",
    "language": "python",
    "name": "python3"
   },
@@ -546,7 +548,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.11.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b1fe2ae8565152c84d3dbd08488d3746f754c9bdf2de9b61cf939da5306d3793"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR will eventually replace all occurrences of `geopandas.datasets` with alternative data using `geodatasets`. At the moment WIP, want to see RTD builds.

It will allow us to deprecate `geopandas.datasets`.