### PR TITLE
FIX: remove download from URL in read_file before calling Fiona / pyogrio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Bug fixes:
 - Fix `to_parquet`/`to_feather` to not write an invalid bbox (with NaNs) in the
   metadata in case of an empty GeoDataFrame (#2653)
 - Fix `to_parquet`/`to_feather` to use correct WKB flavor for 3D geometries (#2654)
+- Fix `read_file` to avoid reading all file bytes prior to calling Fiona or
+  Pyogrio if provided a URL as input (#2796)
 
 Notes on (optional) dependencies:
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -243,26 +243,26 @@ def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs)
 
     filename = _expand_user(filename)
 
-    from_bytes = False
-    if _is_url(filename):
-        req = _urlopen(filename)
-        path_or_bytes = req.read()
-        from_bytes = True
-    elif pd.api.types.is_file_like(filename):
-        data = filename.read()
-        path_or_bytes = data.encode("utf-8") if isinstance(data, str) else data
-        from_bytes = True
-    else:
-        path_or_bytes = filename
+    if engine == "pyogrio":
+        return _read_file_pyogrio(filename, bbox=bbox, mask=mask, rows=rows, **kwargs)
 
-    if engine == "fiona":
+    elif engine == "fiona":
+        from_bytes = False
+        if _is_url(filename):
+            req = _urlopen(filename)
+            path_or_bytes = req.read()
+            from_bytes = True
+        elif pd.api.types.is_file_like(filename):
+            data = filename.read()
+            path_or_bytes = data.encode("utf-8") if isinstance(data, str) else data
+            from_bytes = True
+        else:
+            path_or_bytes = filename
+
         return _read_file_fiona(
             path_or_bytes, from_bytes, bbox=bbox, mask=mask, rows=rows, **kwargs
         )
-    elif engine == "pyogrio":
-        return _read_file_pyogrio(
-            path_or_bytes, bbox=bbox, mask=mask, rows=rows, **kwargs
-        )
+
     else:
         raise ValueError(f"unknown engine '{engine}'")
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -14,8 +14,6 @@ from shapely.geometry.base import BaseGeometry
 from geopandas import GeoDataFrame, GeoSeries
 
 # Adapted from pandas.io.common
-from urllib.request import urlopen as _urlopen
-from urllib.parse import urlparse as parse_url
 from urllib.parse import uses_netloc, uses_params, uses_relative
 
 
@@ -151,14 +149,6 @@ def _expand_user(path):
     return path
 
 
-def _is_url(url):
-    """Check to see if *url* has a valid protocol."""
-    try:
-        return parse_url(url).scheme in _VALID_URLS
-    except Exception:
-        return False
-
-
 def _is_zip(path):
     """Check if a given path is a zipfile"""
     parsed = fiona.path.ParsedPath.from_uri(path)
@@ -248,11 +238,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs)
 
     elif engine == "fiona":
         from_bytes = False
-        if _is_url(filename):
-            req = _urlopen(filename)
-            path_or_bytes = req.read()
-            from_bytes = True
-        elif pd.api.types.is_file_like(filename):
+        if pd.api.types.is_file_like(filename):
             data = filename.read()
             path_or_bytes = data.encode("utf-8") if isinstance(data, str) else data
             from_bytes = True


### PR DESCRIPTION
Addresses issues related to pyogrio engine noted in [#2795 comment](https://github.com/geopandas/geopandas/issues/2795#issuecomment-1435264056)

This skips preprocessing of the file path or bytes passed to `read_file` and instead delegates that to `pyogrio` to parse.

Since this was the simpler case, I moved it to the first condition.

Tested manually with the remote file referenced in #2795 and it yields the same performance as using `pyogrio` directly.