### PR TITLE
TST: temporary skip test_legend for matplotlib 3.8.0.dev

### DIFF
--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1,4 +1,5 @@
 import itertools
+from packaging.version import Version
 import warnings
 
 import numpy as np
@@ -223,6 +224,13 @@ class TestPointPlotting:
                 np.linspace(0, 0.0, 1.0, self.N), ax.collections[0].get_alpha()
             )
 
+    # TODO temporary skip for mpl 3.8.0.dev
+    # (https://github.com/matplotlib/matplotlib/issues/25162)
+    @pytest.mark.skipif(
+        Version(matplotlib.__version__) >= Version("3.8.0.dev")
+        and Version(matplotlib.__version__) < Version("3.8.0"),
+        reason="failing with matplotlib dev",
+    )
     def test_legend(self):
         with warnings.catch_warnings(record=True) as _:  # don't print warning
             # legend ignored if color is given.


### PR DESCRIPTION
The matplotlib failures in the dev build are known and the change might be reverted on the matplotlib side: https://github.com/matplotlib/matplotlib/issues/25162 (and if not, it's also easy to solve with adding some `squeeze()` calls to remove the extra dimension of length 1 in the color array). 

For now, assuming this will be changed back in matplotlib, skipping the tests just for mpl 3.8.0.dev, to get a green CI build.