### PR TITLE
TST: selecting multiple columns copies GeometryArray with pandas >= 2.0, losing sindex

### DIFF
--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -169,11 +169,19 @@ class TestFrameSindex:
     def test_rebuild_on_multiple_col_selection(self):
         """Selecting a subset of columns preserves the index."""
         original_index = self.df.sindex
-        # Selecting a subset of columns preserves the index
+        # Selecting a subset of columns preserves the index for pandas < 2.0
+        # with pandas 2.0, the column is now copied, losing the index (although
+        # with Copy-on-Write, this will again be preserved)
         subset1 = self.df[["geom", "A"]]
-        assert subset1.sindex is original_index
+        if compat.PANDAS_GE_20:
+            assert subset1.sindex is not original_index
+        else:
+            assert subset1.sindex is original_index
         subset2 = self.df[["A", "geom"]]
-        assert subset2.sindex is original_index
+        if compat.PANDAS_GE_20:
+            assert subset2.sindex is not original_index
+        else:
+            assert subset2.sindex is original_index
 
     def test_rebuild_on_update_inplace(self):
         gdf = self.df.copy()


### PR DESCRIPTION
Normally, selecting multiple columns in pandas returns a copy, but that was not done for extension dtype columns. This is fixed in 2.0 (https://github.com/pandas-dev/pandas/pull/51197), so we have to update one of our tests accordingly (this should fix one of the failing tests in the dev build).

This is somewhat a regression from the point of view of geopandas (adding an extra copy), but with the experimental Copy-on-Write feature of pandas, this will go back to not copying (unless you would afterwards mutate the column).