### PR TITLE
Enable writing to parquet with partition_cols

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -993,7 +993,7 @@ individually so that features may have different properties
         return df
 
     def to_parquet(
-        self, path, index=None, compression="snappy", schema_version=None, **kwargs
+        self, path, index=None, compression="snappy", schema_version=None, partition_cols=None, **kwargs
     ):
         """Write a GeoDataFrame to the Parquet format.
 
@@ -1026,6 +1026,10 @@ individually so that features may have different properties
         schema_version : {'0.1.0', '0.4.0', None}
             GeoParquet specification version; if not provided will default to
             latest supported version.
+        partition_cols : str or list, optional, default None
+            Column names by which to partition the dataset. Columns are
+            partitioned in the order they are given. Must be None if path is not
+            a string.
         kwargs
             Additional keyword arguments passed to :func:`pyarrow.parquet.write_table`.
 
@@ -1058,6 +1062,7 @@ individually so that features may have different properties
             compression=compression,
             index=index,
             schema_version=schema_version,
+            partition_cols=partition_cols,
             **kwargs,
         )
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -993,7 +993,13 @@ individually so that features may have different properties
         return df
 
     def to_parquet(
-        self, path, index=None, compression="snappy", schema_version=None, partition_cols=None, **kwargs
+        self,
+        path,
+        index=None,
+        compression="snappy",
+        schema_version=None,
+        partition_cols=None,
+        **kwargs,
     ):
         """Write a GeoDataFrame to the Parquet format.
 

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -276,7 +276,13 @@ def _geopandas_to_arrow(df, index=None, schema_version=None):
 
 
 def _to_parquet(
-    df, path, index=None, compression="snappy", schema_version=None, **kwargs
+    df,
+    path,
+    index=None,
+    compression="snappy",
+    schema_version=None,
+    partition_cols=None,
+    **kwargs,
 ):
     """
     Write a GeoDataFrame to the Parquet format.
@@ -305,6 +311,10 @@ def _to_parquet(
     schema_version : {'0.1.0', '0.4.0', '1.0.0-beta.1', None}
         GeoParquet specification version; if not provided will default to
         latest supported version.
+    partition_cols : str or list, optional, default None
+        Column names by which to partition the dataset. Columns are
+        partitioned in the order they are given. Must be None if path is not
+        a string.
     **kwargs
         Additional keyword arguments passed to pyarrow.parquet.write_table().
     """
@@ -325,7 +335,18 @@ def _to_parquet(
 
     path = _expand_user(path)
     table = _geopandas_to_arrow(df, index=index, schema_version=schema_version)
-    parquet.write_table(table, path, compression=compression, **kwargs)
+    if partition_cols is not None:
+        # write to multiple files under the given path
+        parquet.write_to_dataset(
+            table,
+            path,
+            compression=compression,
+            partition_cols=partition_cols,
+            **kwargs,
+        )
+    else:
+        # write to single output file
+        parquet.write_table(table, path, compression=compression, **kwargs)
 
 
 def _to_feather(df, path, index=None, compression=None, schema_version=None, **kwargs):

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -860,18 +860,19 @@ def test_read_gdal_files():
     assert_geodataframe_equal(df, expected, check_crs=True)
 
 
-def test_parquet_read_partitioned_dataset(tmpdir):
-    # we don't yet explicitly support this (in writing), but for Parquet it
-    # works for reading (by relying on pyarrow.read_table)
+def test_parquet_roundtrip_partitioned_dataset(tmpdir):
     df = read_file(get_path("naturalearth_lowres"))
+    df.continent = df.continent.astype("category")
 
-    # manually create partitioned dataset
+    # write partitioned dataset
     basedir = tmpdir / "partitioned_dataset"
-    basedir.mkdir()
-    df[:100].to_parquet(basedir / "data1.parquet")
-    df[100:].to_parquet(basedir / "data2.parquet")
-
+    df.to_parquet(basedir, partition_cols=["continent"])
     result = read_parquet(basedir)
+
+    # ignore differences in column and row ordering
+    ordered = sorted(df.columns)
+    df = df[ordered].sort_values(by="iso_a3", ignore_index=True)
+    result = result[ordered].sort_values(by="iso_a3", ignore_index=True)
     assert_geodataframe_equal(result, df)
 
 
@@ -879,14 +880,17 @@ def test_parquet_read_partitioned_dataset_fsspec(tmpdir):
     fsspec = pytest.importorskip("fsspec")
 
     df = read_file(get_path("naturalearth_lowres"))
+    df.continent = df.continent.astype("category")
 
-    # manually create partitioned dataset
+    # write partitioned dataset
     memfs = fsspec.filesystem("memory")
     memfs.mkdir("partitioned_dataset")
-    with memfs.open("partitioned_dataset/data1.parquet", "wb") as f:
-        df[:100].to_parquet(f)
-    with memfs.open("partitioned_dataset/data2.parquet", "wb") as f:
-        df[100:].to_parquet(f)
+    basedir = "memory://partitioned_dataset"
+    df.to_parquet(basedir, partition_cols=["continent"], filesystem=memfs)
+    result = read_parquet(basedir)
 
-    result = read_parquet("memory://partitioned_dataset")
+    # ignore differences in column and row ordering
+    ordered = sorted(df.columns)
+    df = df[ordered].sort_values(by="iso_a3", ignore_index=True)
+    result = result[ordered].sort_values(by="iso_a3", ignore_index=True)
     assert_geodataframe_equal(result, df)


### PR DESCRIPTION
Hi - I'm interested in writing partitioned datasets to parquet and saw #2361 

I've only done the easy thing here so far - threading a `partition_cols` argument through the `to_parquet` call so we end up with a call to `parquet.write_to_dataset`.

There's some other relevant discussion:
- https://github.com/geopandas/geopandas/pull/1180/files#r409350933
- #1382
- various issues on `dask-geopandas`

What do you think about this as it stands? Useful enough already? Would updating the bbox metadata for each partition be essential?