### PR TITLE
DOC: Fix icon_links error in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -154,12 +154,12 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/geopandas/geopandas",
-            "icon": "fab fa-github-square",
+            "icon": "fab fa-github-square fa-xl",
         },
         {
             "name": "Twitter",
             "url": "https://twitter.com/geopandas",
-            "icon": "fab fa-twitter-square",
+            "icon": "fab fa-twitter-square fa-xl",
         },
    ]
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,9 +150,18 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "search_bar_position": "sidebar",
-    "github_url": "https://github.com/geopandas/geopandas",
-    "twitter_url": "https://twitter.com/geopandas",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/geopandas/geopandas",
+            "icon": "fab fa-github-square",
+        },
+        {
+            "name": "Twitter",
+            "url": "https://twitter.com/geopandas",
+            "icon": "fab fa-twitter-square",
+        },
+   ]
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
Building the docs give an error on an "icon_links" key that doesn't exist.

This PR uses the "icon_links" syntax to create the links to github and twitter and this seems to work.

Noticed the problem when building docs failed in #2814