### PR TITLE
DOC: Clarify that file databases can also be written using to_file

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1206,7 +1206,7 @@ individually so that features may have different properties
 
         Keyword arguments can be used to create e.g. a spatialite file:
 
-        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # doctest: +SKIP noqa: E501
+        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # noqa: E501 doctest: +SKIP
 
         """
         from geopandas.io.file import _to_file

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1206,7 +1206,9 @@ individually so that features may have different properties
 
         Keyword arguments can be used to create e.g. a spatialite file:
 
-        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # noqa: E501, doctest: +SKIP
+        >>> gdf.to_file(
+        ...     'dataframe.sqlite', driver='SQLite', layer='test', spatialite=True
+        ... )  # doctest: +SKIP
 
         """
         from geopandas.io.file import _to_file

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1910,8 +1910,9 @@ individually so that features may have different properties
         This method requires SQLAlchemy and GeoAlchemy2, and a PostgreSQL
         Python driver (e.g. psycopg2) to be installed.
 
-        To write to file databases like GeoPackage or SpatiaLite it is typically easier
-        to use :meth:`~GeoDataFrame.to_file`.
+        It is also possible to use :meth:`~GeoDataFrame.to_file` to write to a database.
+        Especially for file geodatabases like GeoPackage or SpatiaLite this can be
+        easier.
 
         Parameters
         ----------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1911,7 +1911,7 @@ individually so that features may have different properties
         Python driver (e.g. psycopg2) to be installed.
 
         To write to file databases like GeoPackage or SpatiaLite it is typically easier
-        to use GeoDataFrame.to_file.
+        to use :meth:`~GeoDataFrame.to_file`.
 
         Parameters
         ----------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1204,10 +1204,11 @@ individually so that features may have different properties
 
         >>> gdf.to_file('dataframe.shp', mode="a")  # doctest: +SKIP
 
-        Keyword arguments can be used to create e.g. a spatialite file:
+        Using the engine-specific keyword arguments it is possible to e.g. create a
+        spatialite file with a custom layer name:
 
         >>> gdf.to_file(
-        ...     'dataframe.sqlite', driver='SQLite', layer='test', spatialite=True
+        ...     'dataframe.sqlite', driver='SQLite', spatialite=True, layer='test'
         ... )  # doctest: +SKIP
 
         """

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1206,7 +1206,7 @@ individually so that features may have different properties
 
         Keyword arguments can be used to create e.g. a spatialite file:
 
-        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # noqa: E501 doctest: +SKIP
+        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # noqa: E501, doctest: +SKIP
 
         """
         from geopandas.io.file import _to_file

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1206,7 +1206,7 @@ individually so that features may have different properties
 
         Keyword arguments can be used to create e.g. a spatialite file:
 
-        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # doctest: +SKIP
+        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # doctest: +SKIP noqa: E501
 
         """
         from geopandas.io.file import _to_file

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1203,6 +1203,11 @@ individually so that features may have different properties
         With selected drivers you can also append to a file with `mode="a"`:
 
         >>> gdf.to_file('dataframe.shp', mode="a")  # doctest: +SKIP
+
+        Keyword arguments can be used to create e.g. a spatialite file:
+
+        >>> gdf.to_file('dataframe.sqlite', driver='SQLite', spatialite=True)  # doctest: +SKIP
+
         """
         from geopandas.io.file import _to_file
 
@@ -1901,6 +1906,9 @@ individually so that features may have different properties
 
         This method requires SQLAlchemy and GeoAlchemy2, and a PostgreSQL
         Python driver (e.g. psycopg2) to be installed.
+
+        To write to file databases like GeoPackage or SpatiaLite it is typically easier
+        to use GeoDataFrame.to_file.
 
         Parameters
         ----------

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -112,6 +112,9 @@ def _read_postgis(
     Returns a GeoDataFrame corresponding to the result of the query
     string, which must contain a geometry column in WKB representation.
 
+    It is also possible to use :meth:`~GeoDataFrame.read_file` to read from a database.
+    Especially for file geodatabases like GeoPackage or SpatiaLite this can be easier.
+
     Parameters
     ----------
     sql : string
@@ -149,7 +152,7 @@ def _read_postgis(
 
     SpatiaLite
 
-    >>> sql = "SELECT ST_Binary(geom) AS geom, highway FROM roads"
+    >>> sql = "SELECT ST_AsBinary(geom) AS geom, highway FROM roads"
     >>> df = geopandas.read_postgis(sql, con)  # doctest: +SKIP
     """
 


### PR DESCRIPTION
Some extra clarification in doc based on the comment here: #2799 :
- an example of GeoDataFrame.to_file using some engine-specific keyword arguments. Based on the issue above the example is related to the creation of a spatialite file.
  - **QST**: if the example is OK, should it also be added to GeoSeries.to_file ? In geoseries.to_file is now already an example less, not sure if this is on purpose.
- clarify in to_postgis that file databases are easier to write using to_file.