### PR TITLE
TST: Add tests for to_file/read_file for spatialite format

### DIFF
--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -274,7 +274,7 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
                 pytest.skip("SQLite driver only available from version 1.8.20")
 
         # If only 3D Points, geometry_type needs to be specified for spatialite at the
-        # monent. This if can be removed once the following PR is released:
+        # moment. This if can be removed once the following PR is released:
         # https://github.com/geopandas/pyogrio/pull/223
         if (
             engine == "pyogrio"

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -264,7 +264,13 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
     write_kwargs = {}
     if ogr_driver == "SQLite":
         write_kwargs["spatialite"] = True
-        if geodataframe.geometry.type.to_list() == [None, "Point"]:
+        # If only 3D Points, geometry_type needs to be specified for spatialite
+        if (
+            len(geodataframe == 2)
+            and geodataframe.geometry[0] is None
+            and geodataframe.geometry[1] is not None
+            and len(geodataframe.geometry[1].coords[0]) > 2
+        ):
             write_kwargs["geometry_type"] = "Point Z"
 
     expected_error = _expected_error_on(geodataframe, ogr_driver)

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -267,6 +267,7 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
         if engine == "fiona":
             import fiona
             from packaging.version import Version
+
             if Version(fiona.__version__) < Version("1.8.20"):
                 pytest.skip("SQLite driver only available from version 1.8.20")
         write_kwargs["spatialite"] = True

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -263,6 +263,12 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
     output_file = os.path.join(str(tmpdir), "output_file")
     write_kwargs = {}
     if ogr_driver == "SQLite":
+        # This if statment can be removed once minimal fiona version >= 1.8.20
+        if engine == "fiona":
+            import fiona
+            from packaging.version import Version
+            if Version(fiona.__version__) < Version("1.8.20"):
+                pytest.skip("SQLite driver only available from version 1.8.20")
         write_kwargs["spatialite"] = True
         # If only 3D Points, geometry_type needs to be specified for spatialite
         if (

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -263,6 +263,8 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
     output_file = os.path.join(str(tmpdir), "output_file")
     write_kwargs = {}
     if ogr_driver == "SQLite":
+        write_kwargs["spatialite"] = True
+
         # This if statment can be removed once minimal fiona version >= 1.8.20
         if engine == "fiona":
             import fiona
@@ -270,10 +272,13 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
 
             if Version(fiona.__version__) < Version("1.8.20"):
                 pytest.skip("SQLite driver only available from version 1.8.20")
-        write_kwargs["spatialite"] = True
-        # If only 3D Points, geometry_type needs to be specified for spatialite
+
+        # If only 3D Points, geometry_type needs to be specified for spatialite at the
+        # monent. This if can be removed once the following PR is released:
+        # https://github.com/geopandas/pyogrio/pull/223
         if (
-            len(geodataframe == 2)
+            engine == "pyogrio"
+            and len(geodataframe == 2)
             and geodataframe.geometry[0] is None
             and geodataframe.geometry[1] is not None
             and len(geodataframe.geometry[1].coords[0]) > 2

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -281,7 +281,7 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
             and len(geodataframe == 2)
             and geodataframe.geometry[0] is None
             and geodataframe.geometry[1] is not None
-            and len(geodataframe.geometry[1].coords[0]) > 2
+            and geodataframe.geometry[1].has_z
         ):
             write_kwargs["geometry_type"] = "Point Z"
 

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -265,7 +265,7 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
     if ogr_driver == "SQLite":
         write_kwargs["spatialite"] = True
 
-        # This if statment can be removed once minimal fiona version >= 1.8.20
+        # This if statement can be removed once minimal fiona version >= 1.8.20
         if engine == "fiona":
             import fiona
             from packaging.version import Version


### PR DESCRIPTION
Because writing to spatialite is now added as an example in to_file, it was mentioned in #2821 that it would be better to add a test on it as well...