### PR TITLE
pass autolim kwarg to collection plots

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -133,7 +133,8 @@ def _PolygonPatch(polygon, **kwargs):
 
 
 def _plot_polygon_collection(
-    ax, geoms, values=None, color=None, cmap=None, vmin=None, vmax=None, **kwargs
+    ax, geoms, values=None, color=None, cmap=None, vmin=None, vmax=None,
+    autolim=True, **kwargs
 ):
     """
     Plots a collection of Polygon and MultiPolygon geometries to `ax`
@@ -154,6 +155,8 @@ def _plot_polygon_collection(
         Color to fill the polygons. Cannot be used together with `values`.
     color : single color or sequence of `N` colors
         Sets both `edgecolor` and `facecolor`
+    autolim : bool
+        If True, axis limits will be autoscaled to the extent of the geometries.
     **kwargs
         Additional keyword arguments passed to the collection
 
@@ -188,7 +191,7 @@ def _plot_polygon_collection(
         if "norm" not in kwargs:
             collection.set_clim(vmin, vmax)
 
-    ax.add_collection(collection, autolim=True)
+    ax.add_collection(collection, autolim=autolim)
     ax.autoscale_view()
     return collection
 
@@ -197,7 +200,8 @@ plot_polygon_collection = deprecated(_plot_polygon_collection)
 
 
 def _plot_linestring_collection(
-    ax, geoms, values=None, color=None, cmap=None, vmin=None, vmax=None, **kwargs
+    ax, geoms, values=None, color=None, cmap=None, vmin=None, vmax=None,
+    autolim=True, **kwargs
 ):
     """
     Plots a collection of LineString and MultiLineString geometries to `ax`
@@ -213,6 +217,8 @@ def _plot_linestring_collection(
         have 1:1 correspondence with the geometries (not their components).
     color : single color or sequence of `N` colors
         Cannot be used together with `values`.
+    autolim : bool
+        If True, axis limits will be autoscaled to the extent of the geometries.
 
     Returns
     -------
@@ -246,7 +252,7 @@ def _plot_linestring_collection(
         if "norm" not in kwargs:
             collection.set_clim(vmin, vmax)
 
-    ax.add_collection(collection, autolim=True)
+    ax.add_collection(collection, autolim=autolim)
     ax.autoscale_view()
     return collection
 
@@ -321,7 +327,8 @@ plot_point_collection = deprecated(_plot_point_collection)
 
 
 def plot_series(
-    s, cmap=None, color=None, ax=None, figsize=None, aspect="auto", **style_kwds
+    s, cmap=None, color=None, ax=None, figsize=None, aspect="auto",
+    autolim=True, **style_kwds
 ):
     """
     Plot a GeoSeries.
@@ -357,6 +364,9 @@ def plot_series(
         square appears square in the middle of the plot. This implies an
         Equirectangular projection. If None, the aspect of `ax` won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
+    autolim : bool (default True)
+        If True, axis limits will be autoscaled to the extent of the geometries.
+
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
@@ -463,7 +473,8 @@ def plot_series(
 
         values_ = values[poly_idx] if cmap else None
         _plot_polygon_collection(
-            ax, polys, values_, facecolor=facecolor, cmap=cmap, **style_kwds
+            ax, polys, values_, facecolor=facecolor, cmap=cmap, autolim=autolim,
+            **style_kwds
         )
 
     # plot all LineStrings and MultiLineString components in same collection
@@ -473,7 +484,8 @@ def plot_series(
         color_ = expl_color[line_idx] if color_given else color
 
         _plot_linestring_collection(
-            ax, lines, values_, color=color_, cmap=cmap, **style_kwds
+            ax, lines, values_, color=color_, cmap=cmap, autolim=autolim,
+            **style_kwds
         )
 
     # plot all Points in the same collection
@@ -510,6 +522,7 @@ def plot_dataframe(
     classification_kwds=None,
     missing_kwds=None,
     aspect="auto",
+    autolim=True,
     **style_kwds,
 ):
     """
@@ -613,6 +626,8 @@ def plot_dataframe(
         square appears square in the middle of the plot. This implies an
         Equirectangular projection. If None, the aspect of `ax` won't be changed. It can
         also be set manually (float) as the ratio of y-unit to x-unit.
+    autolim : bool (default True)
+        If True, axis limits will be autoscaled to the extent of the geometries.
 
     **style_kwds : dict
         Style options to be passed on to the actual plot function, such
@@ -855,7 +870,8 @@ GON (((-122.84000 49.00000, -120.0000...
     subset = values[poly_idx & np.invert(nan_idx)]
     if not polys.empty:
         _plot_polygon_collection(
-            ax, polys, subset, vmin=mn, vmax=mx, cmap=cmap, **style_kwds
+            ax, polys, subset, vmin=mn, vmax=mx, cmap=cmap, autolim=autolim,
+            **style_kwds
         )
 
     # plot all LineStrings and MultiLineString components in same collection
@@ -863,7 +879,8 @@ GON (((-122.84000 49.00000, -120.0000...
     subset = values[line_idx & np.invert(nan_idx)]
     if not lines.empty:
         _plot_linestring_collection(
-            ax, lines, subset, vmin=mn, vmax=mx, cmap=cmap, **style_kwds
+            ax, lines, subset, vmin=mn, vmax=mx, cmap=cmap, autolim=autolim,
+            **style_kwds
         )
 
     # plot all Points in the same collection


### PR DESCRIPTION
A quick pull-request to pass the `autolim` kwarg to matplotlib collections.

### ❗ NOTE

- This does **NOT work when plotting points** since `plt.scatter()` is used directly which does not (yet?) support disabling autolim


Possible options to address this: (let me know what you'd prefer):
1. Get `autolim` into `plt.scatter()`   
   (might take a while and not sure I'll find the time soon to do this)
2. Print a warning if points are plotted and add `autolim` support for polygons and lines until `plt.scatter` issues are addressed
3. Plot a custom `PathCollection` instead of using `plt.scatter()`  
  (might be a bit of an overkill and requires quite some work)
4. Use a contextmanager to temporarily disable autoscaling if points are plotted  
  (should be easy to implement but somewhat hacky)

The only doable options (for me) that I'd be willing to add here are 2 and 4.


