### PR TITLE
BUG: ensure proper metadata for 3D geometry types in to_parquet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Bug fixes:
 - Fix regression preventing reading from file paths containing hashes in `read_file`
   with the fiona engine (#3280). An analgous fix for pyogrio is included in
   pyogrio 0.8.1.
+- Fix `to_parquet` to write correct metadata in case of 3D geometries (#2824).
 
 Deprecations and compatibility notes:
 

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -109,12 +109,10 @@ def _create_metadata(df, schema_version=None):
         # https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#geometry_types
         # Instead of going through the `_vectorized.geometry_type_values`
         # that do not include the "Z" varieties.
-        geometry_types = set(
-            [
-                f"{geom} Z" if has_z else geom
-                for geom, has_z in zip(series.geom_type, series.has_z)
-            ]
-        )
+        geometry_types = {
+            f"{geom} Z" if has_z else geom
+            for geom, has_z in zip(series.geom_type, series.has_z)
+        }
         geometry_types = sorted(Series(list(geometry_types)).dropna())
         # geometry_types = sorted(Series(series.geom_type.unique()).dropna())
 

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -704,6 +704,7 @@ def _read_feather(path, columns=None, **kwargs):
     )
     # TODO move this into `import_optional_dependency`
     import pyarrow
+    import geopandas.io._pyarrow_hotfix  # noqa: F401
 
     if Version(pyarrow.__version__) < Version("0.17.0"):
         raise ImportError("pyarrow >= 0.17 required for Feather support")

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -109,18 +109,13 @@ def _create_metadata(df, schema_version=None):
         # https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#geometry_types
         # Instead of going through the `_vectorized.geometry_type_values`
         # that do not include the "Z" varieties.
-        geometry_types = sorted(
-            Series(
-                list(
-                    set(
-                        [
-                            f"{geom} Z" if has_z else geom
-                            for geom, has_z in zip(series.geom_type, series.has_z)
-                        ]
-                    )
-                )
-            ).dropna()
+        geometry_types = set(
+            [
+                f"{geom} Z" if has_z else geom
+                for geom, has_z in zip(series.geom_type, series.has_z)
+            ]
         )
+        geometry_types = sorted(Series(list(geometry_types)).dropna())
         # geometry_types = sorted(Series(series.geom_type.unique()).dropna())
 
         if schema_version[0] == "0":

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -109,10 +109,7 @@ def _create_metadata(df, schema_version=None):
         # https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#geometry_types
         # Instead of going through the `_vectorized.geometry_type_values`
         # that do not include the "Z" varieties.
-        geometry_types = {
-            f"{geom} Z" if has_z else geom
-            for geom, has_z in zip(series.geom_type, series.has_z)
-        }
+        geometry_types = set([f"{geom} Z" if has_z else geom for geom, has_z in zip(series.geom_type, series.has_z)])
         geometry_types = sorted(Series(list(geometry_types)).dropna())
         # geometry_types = sorted(Series(series.geom_type.unique()).dropna())
 

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -105,16 +105,12 @@ def _create_metadata(df, schema_version=None):
     for col in df.columns[df.dtypes == "geometry"]:
         series = df[col]
 
-        # Defines geometry_types according to the geoparquet standard:
-        # https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#geometry_types
-        # Instead of going through the `_vectorized.geometry_type_values`
-        # that do not include the "Z" varieties.
+        # ensure to include "... Z" for 3D geometries
         geometry_types = {
             f"{geom} Z" if has_z else geom
             for geom, has_z in zip(series.geom_type, series.has_z)
         }
         geometry_types = sorted(Series(list(geometry_types)).dropna())
-        # geometry_types = sorted(Series(series.geom_type.unique()).dropna())
 
         if schema_version[0] == "0":
             geometry_types_name = "geometry_type"

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -109,7 +109,10 @@ def _create_metadata(df, schema_version=None):
         # https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md#geometry_types
         # Instead of going through the `_vectorized.geometry_type_values`
         # that do not include the "Z" varieties.
-        geometry_types = set([f"{geom} Z" if has_z else geom for geom, has_z in zip(series.geom_type, series.has_z)])
+        geometry_types = {
+            f"{geom} Z" if has_z else geom
+            for geom, has_z in zip(series.geom_type, series.has_z)
+        }
         geometry_types = sorted(Series(list(geometry_types)).dropna())
         # geometry_types = sorted(Series(series.geom_type.unique()).dropna())
 
@@ -701,7 +704,6 @@ def _read_feather(path, columns=None, **kwargs):
     )
     # TODO move this into `import_optional_dependency`
     import pyarrow
-    import geopandas.io._pyarrow_hotfix  # noqa: F401
 
     if Version(pyarrow.__version__) < Version("0.17.0"):
         raise ImportError("pyarrow >= 0.17 required for Feather support")

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 from itertools import product
-import os
 import json
 from packaging.version import Version
+import os
 import pathlib
 
 import pytest
@@ -11,14 +11,13 @@ from pandas import DataFrame, read_parquet as pd_read_parquet
 from pandas.testing import assert_frame_equal
 import numpy as np
 import shapely
-from shapely.geometry import box, Point, MultiPolygon
+from shapely.geometry import box, Point, LineString, MultiPolygon, Polygon
 
 
 import geopandas
 from geopandas import GeoDataFrame, read_file, read_parquet, read_feather
 from geopandas.array import to_wkb
 from geopandas.io.arrow import (
-    METADATA_VERSION,
     SUPPORTED_VERSIONS,
     _create_metadata,
     _decode_metadata,
@@ -28,10 +27,12 @@ from geopandas.io.arrow import (
     _remove_id_from_member_of_ensembles,
     _validate_dataframe,
     _validate_metadata,
+    METADATA_VERSION,
 )
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import mock
 from geopandas._compat import HAS_PYPROJ
+
 
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
@@ -535,7 +536,7 @@ def test_parquet_invalid_metadata(tmpdir, geo_meta, error, naturalearth_lowres):
     control the metadata that is written for this test.
     """
 
-    from pyarrow import Table, parquet
+    from pyarrow import parquet, Table
 
     df = read_file(naturalearth_lowres)
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
 from itertools import product
+import os
 import json
 from packaging.version import Version
-import os
 import pathlib
 
 import pytest
@@ -18,6 +18,7 @@ import geopandas
 from geopandas import GeoDataFrame, read_file, read_parquet, read_feather
 from geopandas.array import to_wkb
 from geopandas.io.arrow import (
+    METADATA_VERSION,
     SUPPORTED_VERSIONS,
     _create_metadata,
     _decode_metadata,
@@ -27,12 +28,10 @@ from geopandas.io.arrow import (
     _remove_id_from_member_of_ensembles,
     _validate_dataframe,
     _validate_metadata,
-    METADATA_VERSION,
 )
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import mock
 from geopandas._compat import HAS_PYPROJ
-
 
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
@@ -82,6 +81,66 @@ def test_create_metadata(naturalearth_lowres):
         metadata["columns"]["geometry"]["bbox"], df.geometry.total_bounds
     )
 
+    assert metadata["creator"]["library"] == "geopandas"
+    assert metadata["creator"]["version"] == geopandas.__version__
+
+
+def test_create_metadata_with_z_geometries():
+    geometry_types = [
+        "Point",
+        "Point Z",
+        "LineString",
+        "LineString Z",
+        "Polygon",
+        "Polygon Z",
+        "MultiPolygon",
+        "MultiPolygon Z",
+    ]
+    df = geopandas.GeoDataFrame(
+        {
+            "geo_type": geometry_types,
+            "geometry": [
+                Point(1, 2),
+                Point(1, 2, 3),
+                LineString([(0, 0), (1, 1), (2, 2)]),
+                LineString([(0, 0, 1), (1, 1, 2), (2, 2, 3)]),
+                Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+                Polygon([(0, 0, 0), (0, 1, 0.5), (1, 1, 1), (1, 0, 0.5)]),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+                        Polygon([(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5)]),
+                    ]
+                ),
+                MultiPolygon(
+                    [
+                        Polygon([(0, 0, 0), (0, 1, 0.5), (1, 1, 1), (1, 0, 0.5)]),
+                        Polygon(
+                            [
+                                (0.5, 0.5, 1),
+                                (0.5, 1.5, 1.5),
+                                (1.5, 1.5, 2),
+                                (1.5, 0.5, 1.5),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+        },
+    )
+    metadata = _create_metadata(df)
+    assert isinstance(metadata, dict)
+    assert metadata["version"] == METADATA_VERSION
+    assert metadata["primary_column"] == "geometry"
+    assert "geometry" in metadata["columns"]
+
+    assert sorted(metadata["columns"]["geometry"]["geometry_types"]) == sorted(
+        geometry_types
+    )
+
+    assert np.array_equal(
+        metadata["columns"]["geometry"]["bbox"], df.geometry.total_bounds
+    )
     assert metadata["creator"]["library"] == "geopandas"
     assert metadata["creator"]["version"] == geopandas.__version__
 
@@ -476,7 +535,7 @@ def test_parquet_invalid_metadata(tmpdir, geo_meta, error, naturalearth_lowres):
     control the metadata that is written for this test.
     """
 
-    from pyarrow import parquet, Table
+    from pyarrow import Table, parquet
 
     df = read_file(naturalearth_lowres)
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -130,20 +130,15 @@ def test_create_metadata_with_z_geometries():
         },
     )
     metadata = _create_metadata(df)
-    assert isinstance(metadata, dict)
-    assert metadata["version"] == METADATA_VERSION
-    assert metadata["primary_column"] == "geometry"
-    assert "geometry" in metadata["columns"]
-
     assert sorted(metadata["columns"]["geometry"]["geometry_types"]) == sorted(
         geometry_types
     )
-
-    assert np.array_equal(
-        metadata["columns"]["geometry"]["bbox"], df.geometry.total_bounds
+    # only 3D geometries
+    metadata = _create_metadata(df.iloc[1::2])
+    assert all(
+        geom_type.endswith(" Z")
+        for geom_type in metadata["columns"]["geometry"]["geometry_types"]
     )
-    assert metadata["creator"]["library"] == "geopandas"
-    assert metadata["creator"]["version"] == geopandas.__version__
 
 
 def test_crs_metadata_datum_ensemble():


### PR DESCRIPTION
Attempts to fix `.to_parquet` not respecting "Z" geometries.

Closes #2824