### PR TITLE
Made read_postgis raise ValueError if the geom_col is specified twice (current error is cryptic)

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -67,7 +67,8 @@ def _df_to_geodf(df, geom_col="geom", crs=None):
 
     if df.columns.to_list().count(geom_col) > 1:
         raise ValueError(
-            f"Duplicate geometry column '{geom_col}' detected in SQL query output. Only one geometry column is allowed."
+            f"Duplicate geometry column '{geom_col}' detected in SQL query output. Only"
+            "one geometry column is allowed."
         )
 
     geoms = df[geom_col].dropna()

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -66,8 +66,9 @@ def _df_to_geodf(df, geom_col="geom", crs=None):
         raise ValueError("Query missing geometry column '{}'".format(geom_col))
 
     if df.columns.to_list().count(geom_col) > 1:
-        raise ValueError(f"Duplicate geometry column '{geom_col}' detected in SQL query output. Only one geometry "
-                         "column is allowed.")
+        raise ValueError(
+            f"Duplicate geometry column '{geom_col}' detected in SQL query output. Only one geometry column is allowed."
+        )
 
     geoms = df[geom_col].dropna()
 

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -65,6 +65,10 @@ def _df_to_geodf(df, geom_col="geom", crs=None):
     if geom_col not in df:
         raise ValueError("Query missing geometry column '{}'".format(geom_col))
 
+    if df.columns.to_list().count(geom_col) > 1:
+        raise ValueError(f"Duplicate geometry column '{geom_col}' detected in SQL query output. Only one geometry "
+                         "column is allowed.")
+
     geoms = df[geom_col].dropna()
 
     if not geoms.empty:

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -698,10 +698,13 @@ class TestIO:
         with pytest.raises(ValueError, match="CRS of the target table"):
             write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
 
-    def test_duplicate_geometry_column_fails(self, engine_postgis, df_nybb):
+    def test_duplicate_geometry_column_fails(self, engine_postgis):
         """
-        Tests that a ValueError is raised if an SQL query returns two
+        Tests that a ValueError is raised if an SQL query returns two geometry columns.
         """
         engine = engine_postgis
+
+        sql = "select ST_MakePoint(0, 0) as geom, ST_MakePoint(0, 0) as geom;"
+
         with pytest.raises(ValueError):
-            read_postgis("select ST_MakePoint(0, 0) as geom, ST_MakePoint(0, 0) as geom", engine, geom_col="geom")
+            read_postgis(sql, engine, geom_col="geom")

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -697,3 +697,11 @@ class TestIO:
         # Should raise error when appending
         with pytest.raises(ValueError, match="CRS of the target table"):
             write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
+
+    def test_duplicate_geometry_column_fails(self, engine_postgis, df_nybb):
+        """
+        Tests that a ValueError is raised if an SQL query returns two
+        """
+        engine = engine_postgis
+        with pytest.raises(ValueError):
+            read_postgis("select ST_MakePoint(0, 0) as geom, ST_MakePoint(0, 0) as geom", engine, geom_col="geom")


### PR DESCRIPTION
Closes #2407

I was looking back and realized I said I would make a PR for #2407 but never did. I thought I ought to just tie up that loose end once and for all, because it annoyed me again the other day.