### PR TITLE
explicitly treat matplotlib abbreviations "fc", "ec" and "ls"

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -87,10 +87,11 @@ def _expand_kwargs(kwargs, multiindex):
         scalar_kwargs = ["marker", "alpha", "path_effects"]
 
     for att, value in kwargs.items():
-        if "color" in att:  # color(s), edgecolor(s), facecolor(s)
+        # color(s), edgecolor(s), facecolor(s), or abbreviations ec, fc
+        if "color" in att or att in ("fc", "ec"):
             if is_color_like(value):
                 continue
-        elif "linestyle" in att:  # linestyle(s)
+        elif "linestyle" in att or att == "ls":  # linestyle(s) or ls
             # A single linestyle can be 2-tuple of a number and an iterable.
             if (
                 isinstance(value, tuple)


### PR DESCRIPTION
Since I'm always puzzled when i run into problems using matplotlib's abbreviation syntax... 

Here's a quick pull-request to add support for the following matplotlib abbreviations:

- `fc` (for `facecolor`)
- `ec` (for `edgecolor`)
- `ls` (for `linestyle`)


Now you can do:
```python
gdf.plot(fc=(1, 0, 0, .5), ec="b", ls="--", lw=4)
```
instead of
```python
gdf.plot(facecolor=(1, 0, 0, .5), edgecolor="b", linestyle="--", lw=4)
```
