### PR TITLE
fix distributing plot kwargs for multi-part geometries

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -163,10 +163,6 @@ def _plot_polygon_collection(
     """
     from matplotlib.collections import PatchCollection
 
-    geoms, multiindex = _sanitize_geoms(geoms)
-    if values is not None:
-        values = np.take(values, multiindex, axis=0)
-
     # PatchCollection does not accept some kwargs.
     kwargs = {
         att: value
@@ -217,10 +213,6 @@ def _plot_linestring_collection(
     collection : matplotlib.collections.Collection that was plotted
     """
     from matplotlib.collections import LineCollection
-
-    geoms, multiindex = _sanitize_geoms(geoms)
-    if values is not None:
-        values = np.take(values, multiindex, axis=0)
 
     # LineCollection does not accept some kwargs.
     kwargs = {
@@ -286,7 +278,6 @@ def _plot_point_collection(
     if values is not None and color is not None:
         raise ValueError("Can only specify one of 'values' and 'color' kwargs")
 
-    geoms, multiindex = _sanitize_geoms(geoms)
     # values are expanded below as kwargs["c"]
 
     x = [p.x if not p.is_empty else None for p in geoms]

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -178,8 +178,6 @@ def _plot_polygon_collection(
     if color is not None:
         kwargs["color"] = color
 
-    _expand_kwargs(kwargs, multiindex)
-
     collection = PatchCollection([_PolygonPatch(poly) for poly in geoms], **kwargs)
 
     if values is not None:
@@ -234,8 +232,6 @@ def _plot_linestring_collection(
     # Add to kwargs for easier checking below.
     if color is not None:
         kwargs["color"] = color
-
-    _expand_kwargs(kwargs, multiindex)
 
     segments = [np.array(linestring.coords)[:, :2] for linestring in geoms]
     collection = LineCollection(segments, **kwargs)
@@ -307,7 +303,6 @@ def _plot_point_collection(
         kwargs["color"] = color
     if marker is not None:
         kwargs["marker"] = marker
-    _expand_kwargs(kwargs, multiindex)
 
     if "norm" not in kwargs:
         collection = ax.scatter(x, y, vmin=vmin, vmax=vmax, cmap=cmap, **kwargs)
@@ -435,6 +430,7 @@ def plot_series(
 
     # decompose GeometryCollections
     geoms, multiindex = _sanitize_geoms(s.geometry, prefix="Geom")
+    _expand_kwargs(style_kwds, multiindex)
     values = np.take(values, multiindex, axis=0) if cmap else None
     # ensure indexes are consistent
     if color_given and isinstance(color, pd.Series):
@@ -837,6 +833,7 @@ GON (((-122.84000 49.00000, -120.0000...
 
     # decompose GeometryCollections
     geoms, multiindex = _sanitize_geoms(df.geometry, prefix="Geom")
+    _expand_kwargs(style_kwds, multiindex)
     values = np.take(values, multiindex, axis=0)
     nan_idx = np.take(nan_idx, multiindex, axis=0)
     expl_series = geopandas.GeoSeries(geoms)


### PR DESCRIPTION
A quick pull-request to fix distributing list-like style kwargs when plotting multi-part geometries.


At the moment, `_expand_kwargs(kwargs, multiindex)` is called twice:
- once **before** the actual plotting functions (e.g. `_plot_polygon_collection` etc.)
- once **inside** the plotting functions (which is obsolete if no multi-geometries exist and causes an error otherwise)

If multi-part geometries exist, the second call to `_expand_kwargs` will result in an  `IndexError` since the `geoms` list passed to the plotting functions is already exploded and so the newly evaluated `multiindex` will be based on the exploded geoms, e.g.:  
 `np.arange( <length of exploded geometries> )` .


---- 

Now this works as expected:

```python
from shapely.geometry import Polygon, GeometryCollection
import geopandas as gpd

poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
poly2 = Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])
poly3 = Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])
gc = GeometryCollection([poly2, poly3])

df = gpd.GeoDataFrame({"geometry": [poly, gc]})
df.plot(facecolor=["r", "g"])
```

<img src=https://user-images.githubusercontent.com/22773387/229220291-49c5db74-7997-4f12-8aed-a0d053a0e9c6.png width=20%>


## fixes
This also fixes #2208


