### PR TITLE
TST: read_file with pyogrio and pandas>=2 gives datetime64 with ms unit

### DIFF
--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -221,6 +221,8 @@ def test_to_file_datetime(tmpdir, driver, ext, time, engine):
             df["b"].dt.tz_convert(pytz.utc), df_read["b"].dt.tz_convert(pytz.utc)
         )
     else:
+        if engine == "pyogrio" and PANDAS_GE_20:
+            df["b"] = df["b"].astype("datetime64[ms]")
         assert_series_equal(df["b"], df_read["b"])
 
 


### PR DESCRIPTION
Starting with pandas 2.0, it preserves the non-ns resolution of datetime64 input. And pyogrio creates datetime64[ms] data (that's the accuracy that GDAL supports)