### PR TITLE
ENH: expose greedy colouring from mapclassify

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1,5 +1,4 @@
 import warnings
-from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -772,15 +771,9 @@ GON (((-122.84000 49.00000, -120.0000...
             classification_kwds = {}
 
         if scheme == "greedy":
-            colors = mapclassify.greedy(df, **classification_kwds)
-            num_colors = colors.max() + 1
-            bins = np.arange(num_colors)
-            binning = SimpleNamespace(
-                k=num_colors,
-                counts=list(colors.value_counts().sort_index()),
-                yb=np.asarray(colors),
-                bins=bins,
-            )
+            values = mapclassify.greedy(df, **classification_kwds)
+            labels = np.arange(values.max() + 1)
+            categorical = True
         else:
             if "k" not in classification_kwds:
                 classification_kwds["k"] = k
@@ -806,8 +799,6 @@ GON (((-122.84000 49.00000, -120.0000...
 
             if scheme != "greedy":
                 labels = binning.get_legend_classes(fmt)
-            else:
-                labels = [str(b) for b in binning.bins]
             if legend_kwds is not None:
                 show_interval = legend_kwds.pop("interval", False)
             else:
@@ -815,12 +806,13 @@ GON (((-122.84000 49.00000, -120.0000...
             if not show_interval and scheme != "greedy":
                 labels = [c[1:-1] for c in labels]
 
-        values = pd.Categorical(
-            [np.nan] * len(values), categories=binning.bins, ordered=True
-        )
-        values[~nan_idx] = pd.Categorical.from_codes(
-            binning.yb, categories=binning.bins, ordered=True
-        )
+        if scheme != "greedy":
+            values = pd.Categorical(
+                [np.nan] * len(values), categories=binning.bins, ordered=True
+            )
+            values[~nan_idx] = pd.Categorical.from_codes(
+                binning.yb, categories=binning.bins, ordered=True
+            )
         if cmap is None:
             cmap = "viridis"
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -812,7 +812,7 @@ GON (((-122.84000 49.00000, -120.0000...
                 show_interval = legend_kwds.pop("interval", False)
             else:
                 show_interval = False
-            if not show_interval:
+            if not show_interval and scheme != "greedy":
                 labels = [c[1:-1] for c in labels]
 
         values = pd.Categorical(

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1226,6 +1226,11 @@ class TestMapclassifyPlotting:
         for scheme in self.classifiers:
             self.df.plot(column="pop_est", scheme=scheme, legend=True)
 
+    def test_greedy_mapclassifier(self):
+        # test if greedy classifier passes
+        pytest.importorskip("libpysal")
+        self.df.plot(column="pop_est", scheme="greedy", legend=True)
+
     def test_classification_kwds(self):
         ax = self.df.plot(
             column="pop_est",


### PR DESCRIPTION
For https://github.com/geopandas/geopandas/issues/2818 to add support for topological colouring via `scheme="greedy"`. Looking for some feedback on this approach before doing the equivalent changes for `explore` as well.