### PR TITLE
TST: skip tests with multiindex on win and Py38

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1,4 +1,5 @@
 import string
+import sys
 import warnings
 
 import numpy as np
@@ -1016,6 +1017,10 @@ class TestGeomMethods:
         with pytest.warns(FutureWarning, match="Currently, index_parts defaults"):
             assert_geoseries_equal(expected, s.explode())
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     @pytest.mark.parametrize("index_name", [None, "test"])
     def test_explode_geodataframe(self, index_name):
         s = GeoSeries([MultiPoint([Point(1, 2), Point(2, 3)]), Point(5, 5)])
@@ -1035,6 +1040,10 @@ class TestGeomMethods:
         expected_df = expected_df.set_index(expected_index)
         assert_frame_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     @pytest.mark.parametrize("index_name", [None, "test"])
     def test_explode_geodataframe_level_1(self, index_name):
         # GH1393
@@ -1125,6 +1134,10 @@ class TestGeomMethods:
         exploded_df = gdf.explode(column="col1", ignore_index=True)
         assert_geodataframe_equal(exploded_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     @pytest.mark.parametrize("outer_index", [1, (1, 2), "1"])
     def test_explode_pandas_multi_index(self, outer_index):
         index = MultiIndex.from_arrays(
@@ -1232,6 +1245,10 @@ class TestGeomMethods:
         test_df = df.explode(ignore_index=True, index_parts=True)
         assert_frame_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     def test_explode_order(self):
         df = GeoDataFrame(
             {"vals": [1, 2, 3]},
@@ -1261,6 +1278,10 @@ class TestGeomMethods:
         )
         assert_geodataframe_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     def test_explode_order_no_multi(self):
         df = GeoDataFrame(
             {"vals": [1, 2, 3]},
@@ -1279,6 +1300,10 @@ class TestGeomMethods:
         )
         assert_geodataframe_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     def test_explode_order_mixed(self):
         df = GeoDataFrame(
             {"vals": [1, 2, 3]},
@@ -1307,6 +1332,10 @@ class TestGeomMethods:
         )
         assert_geodataframe_equal(test_df, expected_df)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     def test_explode_duplicated_index(self):
         df = GeoDataFrame(
             {"vals": [1, 2, 3]},
@@ -1429,6 +1458,10 @@ class TestGeomMethods:
         )
         assert_frame_equal(self.g11.get_coordinates(ignore_index=True), expected)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info < (3, 9),
+        reason="Inconsistent int dtype",
+    )
     @pytest.mark.skipif(
         not (compat.USE_PYGEOS or compat.USE_SHAPELY_20),
         reason="get_coordinates not implemented for shapely<2",


### PR DESCRIPTION
This should resolve those failing tests on Windows with Python 3.8. Pandas now support dtypes in Index but int defaults to int32 in that environment causing the failure. Given the issue is only in this one env and Py3.8 will be phased out soon, skipping felt like an appropriate response.