### PR TITLE
Add support for dtype_backend argument to read_feather and read_postgis

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -2,6 +2,7 @@ import warnings
 from contextlib import contextmanager
 
 import pandas as pd
+from pandas._libs import lib
 
 import shapely
 import shapely.wkb
@@ -110,6 +111,7 @@ def _read_postgis(
     parse_dates=None,
     params=None,
     chunksize=None,
+    dtype_backend=lib.no_default,
 ):
     """
     Returns a GeoDataFrame corresponding to the result of the query
@@ -134,6 +136,13 @@ def _read_postgis(
     chunksize : int, default None
         If specified, return an iterator where chunksize is the number of rows to
         include in each chunk.
+    dtype_backend : {{"numpy _nullable","pyarrow"}}. defaults to NumPy backed DataFrames
+        Which dtype_backend to use, e.g. whether a DataFrame should have NumPy
+        arrays, nullable types are used for all types that have a nullable
+        implementation when "numpy_nullable" is set, pyarrow is used for all
+        dtypes if "pyarrow" is set.
+
+        The dtype backends are still experimential.
 
     See the documentation for pandas.read_sql for further explanation
     of the following parameters:
@@ -169,6 +178,7 @@ def _read_postgis(
             parse_dates=parse_dates,
             params=params,
             chunksize=chunksize,
+            dtype_backend=dtype_backend,
         )
         return _df_to_geodf(df, geom_col=geom_col, crs=crs)
 
@@ -182,6 +192,7 @@ def _read_postgis(
             parse_dates=parse_dates,
             params=params,
             chunksize=chunksize,
+            dtype_backend=dtype_backend,
         )
         return (_df_to_geodf(df, geom_col=geom_col, crs=crs) for df in df_generator)
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -890,3 +890,23 @@ def test_parquet_read_partitioned_dataset_fsspec(tmpdir):
 
     result = read_parquet("memory://partitioned_dataset")
     assert_geodataframe_equal(result, df)
+
+
+def test_read_dtype_backend_pyarrow():
+    expected_dtypes = {
+        "col_str": "string[pyarrow]",
+        "col_int": "int64[pyarrow]",
+        "col_float": "float64[pyarrow]",
+        "geometry": "geometry",
+    }
+    df = geopandas.read_feather(
+        DATA_PATH / "arrow" / "test_data_gdal350.arrow", dtype_backend="pyarrow"
+    )
+    assert df.dtypes.to_dict() == expected_dtypes
+
+
+def test_read_invalid_dtype_backend():
+    with pytest.raises(ValueError):
+        geopandas.read_feather(
+            DATA_PATH / "arrow" / "test_data_gdal350.arrow", dtype_backend="FOO"
+        )


### PR DESCRIPTION
[Pandas 2.0.0](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html) added support for a `dtype_backend` argument to many IO functions. This PR adds support for this argument to `read_feather`, `read_parquet` and `read_postgis`.
This is my first contribution to this project, so there are still some things I'm not sure about that needs to be solved for this PR to be ready:

- How to handle previous previsions of pandas where functions wouldn't accept this argument more safely ?
- Ideally, how to add this option to `read_file` ?
- Add more tests ?