### PR TITLE
Add warning for ignoring spherical edges in read_parquet/feather

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -235,6 +235,15 @@ def _validate_metadata(metadata):
         if column_metadata["encoding"] != "WKB":
             raise ValueError("Only WKB geometry encoding is supported")
 
+        if column_metadata.get("edges", "planar") == "spherical":
+            warnings.warn(
+                f"The geo metadata indicate that column '{col}' has spherical edges, "
+                "but GeoPandas ignores this metadata and will interpret the edges of "
+                "the geometries as planar.",
+                UserWarning,
+                stacklevel=4,
+            )
+
 
 def _geopandas_to_arrow(df, index=None, schema_version=None):
     """

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -240,6 +240,19 @@ def test_validate_metadata_invalid(metadata, error):
         _validate_metadata(metadata)
 
 
+def test_validate_metadata_edges():
+    metadata = {
+        "primary_column": "geometry",
+        "columns": {"geometry": {"crs": None, "encoding": "WKB", "edges": "spherical"}},
+        "version": "1.0.0-beta.1",
+    }
+    with pytest.warns(
+        UserWarning,
+        match="The geo metadata indicate that column 'geometry' has spherical edges",
+    ):
+        _validate_metadata(metadata)
+
+
 def test_to_parquet_fails_on_invalid_engine(tmpdir):
     df = GeoDataFrame(data=[[1, 2, 3]], columns=["a", "b", "a"], geometry=[Point(1, 1)])
 


### PR DESCRIPTION
The GeoParquet spec allows this, but we currently don't check for this, and will also just ignore it (since we can't handle spherical edges). If a user explicitly has data with this optional flag set, it seems best to issue a warning.