### PR TITLE
ENH: add exclusive parameter to sjoin_nearest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ geopandas/datasets/ne_110m_admin_0_countries.zip
 
 .asv
 doc/source/getting_started/my_file.geojson
+
+.env

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2165,6 +2165,7 @@ individually so that features may have different properties
         lsuffix="left",
         rsuffix="right",
         distance_col=None,
+        exclusive=False,
     ):
         """
         Spatial join of two GeoDataFrames based on the distance between their
@@ -2202,6 +2203,9 @@ individually so that features may have different properties
         distance_col : string, default None
             If set, save the distances computed between matching geometries under a
             column of this name in the joined GeoDataFrame.
+        exclusive : bool, optional, default False
+            If True, the nearest geometries that are equal to the input geometry
+            will not be returned, default False
 
         Examples
         --------
@@ -2275,6 +2279,7 @@ countries_w_city_data[countries_w_city_data["name_left"] == "Italy"]
             lsuffix=lsuffix,
             rsuffix=rsuffix,
             distance_col=distance_col,
+            exclusive=exclusive,
         )
 
     def clip(self, mask, keep_geom_type=False):

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -839,7 +839,7 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
 
         @doc(BaseSpatialIndex.nearest)
         def nearest(
-            self, geometry, return_all=True, max_distance=None, return_distance=False
+            self, geometry, return_all=True, max_distance=None, return_distance=False, exclusive=False
         ):
             if not (compat.USE_SHAPELY_20 or compat.PYGEOS_GE_010):
                 raise NotImplementedError(
@@ -856,6 +856,7 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
                     max_distance=max_distance,
                     return_distance=return_distance,
                     all_matches=return_all,
+                    exclusive=exclusive
                 )
             else:
                 if not return_all and max_distance is None and not return_distance:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -232,7 +232,12 @@ class BaseSpatialIndex:
         raise NotImplementedError
 
     def nearest(
-        self, geometry, return_all=True, max_distance=None, return_distance=False
+        self,
+        geometry,
+        return_all=True,
+        max_distance=None,
+        return_distance=False,
+        exclusive=False,
     ):
         """
         Return the nearest geometry in the tree for each input geometry in
@@ -281,6 +286,9 @@ geometries}
             Must be greater than 0. By default None, indicating no distance limit.
         return_distance : bool, optional
             If True, will return distances in addition to indexes. By default False
+        exclusive : bool, optional
+            if True, the nearest geometries that are equal to the input geometry will not be returned.
+            By default False 
 
         Returns
         -------
@@ -839,7 +847,12 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
 
         @doc(BaseSpatialIndex.nearest)
         def nearest(
-            self, geometry, return_all=True, max_distance=None, return_distance=False, exclusive=False
+            self,
+            geometry,
+            return_all=True,
+            max_distance=None,
+            return_distance=False,
+            exclusive=False,
         ):
             if not (compat.USE_SHAPELY_20 or compat.PYGEOS_GE_010):
                 raise NotImplementedError(
@@ -856,7 +869,7 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
                     max_distance=max_distance,
                     return_distance=return_distance,
                     all_matches=return_all,
-                    exclusive=exclusive
+                    exclusive=exclusive,
                 )
             else:
                 if not return_all and max_distance is None and not return_distance:

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -834,6 +834,53 @@ class TestPygeosInterface:
         else:
             assert_array_equal(res, expected[0])
 
+    @pytest.mark.skipif(
+        not (compat.USE_SHAPELY_20),
+        reason=(
+            "shapely >= 2.0 is required to test sindex.nearest with parameter exclusive"
+        ),
+    )
+    @pytest.mark.parametrize("return_distance", [True, False])
+    @pytest.mark.parametrize(
+        "return_all,max_distance,exclusive,expected",
+        [
+            (False, None, False, ([[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5 * [0])),
+            (False, None, True, ([[0, 1, 2, 3, 4], [1, 0, 1, 2, 3]], 5 * [sqrt(2)])),
+            (True, None, False, ([[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], 5 * [0])),
+            (
+                True,
+                None,
+                True,
+                ([[0, 1, 1, 2, 2, 3, 3, 4], [1, 0, 2, 1, 3, 2, 4, 3]], 8 * [sqrt(2)]),
+            ),
+            (False, 1.1, True, ([[1, 2, 5], [5, 5, 1]], 3 * [1])),
+            (True, 1.1, True, ([[1, 2, 5, 5], [5, 5, 1, 2]], 4 * [1])),
+        ],
+    )
+    def test_nearest_exclusive(
+        self, expected, max_distance, return_all, return_distance, exclusive
+    ):
+        geoms = mod.points(np.arange(5), np.arange(5))
+        if max_distance:
+            # add a non grid point
+            geoms = np.append(geoms, [Point(1, 2)])
+
+        df = geopandas.GeoDataFrame({"geometry": geoms})
+
+        ps = geoms
+        res = df.sindex.nearest(
+            ps,
+            return_all=return_all,
+            max_distance=max_distance,
+            return_distance=return_distance,
+            exclusive=exclusive,
+        )
+        if return_distance:
+            assert_array_equal(res[0], expected[0])
+            assert_array_equal(res[1], expected[1])
+        else:
+            assert_array_equal(res, expected[0])
+
     # --------------------------- misc tests ---------------------------- #
 
     def test_empty_tree_geometries(self):

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -455,7 +455,8 @@ def sjoin_nearest(
         column of this name in the joined GeoDataFrame.
     exclusive : bool, optional, default False
         If True, the nearest geometries that are equal to the input geometry
-        will not be returned, default False
+        will not be returned, default False.
+        The functionality is only available when Shapley >= 2.0 is used for the backend
 
     Examples
     --------

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -366,10 +366,7 @@ def _nearest_query(
             "Currently, only PyGEOS >= 0.10.0 or Shapely >= 2.0 supports "
             "`nearest_all`. " + compat.INSTALL_PYGEOS_ERROR
         )
-    if not compat.USE_SHAPELY_20:
-        raise NotImplementedError(
-            "Currently, only Shapely >= 2.0 supports the `exclusive` parameter"
-        )
+
     # use the opposite of the join direction for the index
     use_left_as_sindex = how == "right"
     if use_left_as_sindex:

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -959,4 +959,4 @@ class TestNearest:
         mask = cities["name"].isin(cities_right)
         expected = cities[mask]
 
-        assert assert_geodataframe_equal(result, expected, check_like=True)
+        assert_geodataframe_equal(result, expected, check_like=True)

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -928,6 +928,12 @@ class TestNearest:
         assert_geodataframe_equal(result5, result4, check_like=True)
 
     @pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
+    @pytest.mark.skipif(
+        not (compat.USE_SHAPELY_20),
+        reason=(
+            "shapely >= 2.0 is required to run sjoin_nearest with parameter `exclusive` set"
+        ),
+    )
     def test_sjoin_nearest_exclusive(self):
         # check equivalency of left and inner join
 


### PR DESCRIPTION
**Description:**
At the moment `sjoin_nearest` cannot be used to identify the closest neigbour of a set of points since each geometry is matched to itself. This PR adds the `exclusive` parameter in `sjoin_nearest` so that the join excluded identical geometries

However in Shapely2.0 `shapely.query_nearest` exposes the `exclusive` parameter to exclude identical geometries from the join.

**Example:**
```python
cities = read_file(geopandas.datasets.get_path("naturalearth_cities"))
sjoin = gpd.sjoin_nearest(cities, cities) 
```
joins each city with itself

However,
```python
cities = read_file(geopandas.datasets.get_path("naturalearth_cities"))
sjoin = gpd.sjoin_nearest(cities, cities, exclusive=True) 
```
returns the actual closest city pairs (e.g. Rome with Vatican City)
 
**Remarks**
I am still unsure how to enable this functionality for pygeos and whether this would be required. At the moment the `exclusive` parameter is only available if the backend is using Shapely >= 2.0.