### PR TITLE
DOC: Fix typos in comments of code examples for "Geometric Manipulations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Examples
 
 ![Example 1](doc/source/gallery/test.png)
 
-Some geographic operations return normal pandas object.  The `area` property of a `GeoSeries` will return a `pandas.Series` containing the area of each item in the `GeoSeries`:
+Some geographic operations return normal pandas objects.  The `area` property of a `GeoSeries` will return a `pandas.Series` containing the area of each item in the `GeoSeries`:
 
     >>> print(g.area)
     0    0.5

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Other operations return GeoPandas objects:
 ![Example 2](doc/source/gallery/test_buffer.png)
 
 GeoPandas objects also know how to plot themselves. GeoPandas uses
-[matplotlib](http://matplotlib.org) for plotting. To generate a plot of our
+[matplotlib](http://matplotlib.org) for plotting. To generate a plot of a
 `GeoSeries`, use:
 
     >>> g.plot()

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Other operations return GeoPandas objects:
 
 GeoPandas objects also know how to plot themselves. GeoPandas uses
 [matplotlib](http://matplotlib.org) for plotting. To generate a plot of our
-GeoSeries, use:
+`GeoSeries`, use:
 
     >>> g.plot()
 

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -114,7 +114,7 @@ Other operations return GeoPandas objects:
 
 .. image:: ../../_static/test_buffer.png
 
-GeoPandas objects also know how to plot themselves. GeoPandas uses `matplotlib`_ for plotting. To generate a plot of a GeoSeries, use:
+GeoPandas objects also know how to plot themselves. GeoPandas uses `matplotlib`_ for plotting. To generate a plot of a :class:`~geopandas.GeoSeries`, use:
 
 .. sourcecode:: python
 

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -92,7 +92,7 @@ Examples of geometric manipulations
 
 .. image:: ../../_static/test.png
 
-Some geographic operations return normal pandas object.  The :attr:`~geopandas.GeoSeries.area` property of a :class:`~geopandas.GeoSeries` will return a :class:`pandas.Series` containing the area of each item in the :class:`~geopandas.GeoSeries`:
+Some geographic operations return normal pandas objects.  The :attr:`~geopandas.GeoSeries.area` property of a :class:`~geopandas.GeoSeries` will return a :class:`pandas.Series` containing the area of each item in the :class:`~geopandas.GeoSeries`:
 
 .. sourcecode:: python
 


### PR DESCRIPTION
This PR contains a few improvements of the comments in the code examples for [Geometric Manipulations](https://geopandas.org/en/latest/docs/user_guide/geometric_manipulations.html#examples-of-geometric-manipulations). Partly, this is also relevant for the main README:
- Fix typo "object" to "objects"
- Add highlighting of `geopandas.GeoSeries` 
- Add change "our" to "a" corresponding to PR #2650