### PR TITLE
BUG: Fix broken call to ax.legend

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -947,7 +947,9 @@ GON (((-122.84000 49.00000, -120.0000...
                 categories.append(merged_kwds.get("label", "NaN"))
             legend_kwds.setdefault("numpoints", 1)
             legend_kwds.setdefault("loc", "best")
-            ax.legend(patches, categories, **legend_kwds)
+            legend_kwds.setdefault("handles", patches)
+            legend_kwds.setdefault("labels", categories)
+            ax.legend(**legend_kwds)
         else:
             if cax is not None:
                 legend_kwds.setdefault("cax", cax)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -765,9 +765,9 @@ class TestPolygonPlotting:
             categories=categories,
             legend=True,
             legend_kwds={
-                "labels" : [ prefix + str(c) for c in categories ],
+                "labels": [prefix + str(c) for c in categories],
                 "frameon": False,
-            }
+            },
         )
         assert len(categories) == len(ax.get_legend().get_texts())
         assert ax.get_legend().get_texts()[0].get_text().startswith(prefix)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -757,12 +757,20 @@ class TestPolygonPlotting:
             np.testing.assert_array_equal([0.7, 0.2], ax.collections[0].get_alpha())
 
     def test_legend_kwargs(self):
+        categories = list(self.df["values"].unique())
+        prefix = "LABEL_FOR_"
         ax = self.df.plot(
             column="values",
             categorical=True,
+            categories=categories,
             legend=True,
-            legend_kwds={"frameon": False},
+            legend_kwds={
+                "labels" : [ prefix + str(c) for c in categories ],
+                "frameon": False
+            }
         )
+        assert len(categories) == len(ax.get_legend().get_texts())
+        assert ax.get_legend().get_texts()[0].get_text().startswith(prefix)
         assert ax.get_legend().get_frame_on() is False
 
     def test_colorbar_kwargs(self):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -766,7 +766,7 @@ class TestPolygonPlotting:
             legend=True,
             legend_kwds={
                 "labels" : [ prefix + str(c) for c in categories ],
-                "frameon": False
+                "frameon": False,
             }
         )
         assert len(categories) == len(ax.get_legend().get_texts())


### PR DESCRIPTION
It seems we are getting tripped up by ax.legend's rather complex calling convention, resulting in an error: "You have mixed positional and keyword arguments, some input may be discarded."

Simplify the call by integrating all arguments into kwargs.