### PR TITLE
DOC: Remove redundant sentence in documentation of the `explore` method

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2096,8 +2096,8 @@ individually so that features may have different properties
 
     plot = CachedAccessor("plot", geopandas.plotting.GeoplotAccessor)
     
+    @doc(_explore)
     def explore(self, *args, **kwargs):
-        """Interactive map based on folium/leaflet.js"""
         return _explore(self, *args, **kwargs)
 
     def sjoin(self, df, *args, **kwargs):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2095,7 +2095,7 @@ individually so that features may have different properties
         return self.geometry.difference(other)
 
     plot = CachedAccessor("plot", geopandas.plotting.GeoplotAccessor)
-    
+
     @doc(_explore)
     def explore(self, *args, **kwargs):
         return _explore(self, *args, **kwargs)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2095,8 +2095,7 @@ individually so that features may have different properties
         return self.geometry.difference(other)
 
     plot = CachedAccessor("plot", geopandas.plotting.GeoplotAccessor)
-
-    @doc(_explore)
+    
     def explore(self, *args, **kwargs):
         """Interactive map based on folium/leaflet.js"""
         return _explore(self, *args, **kwargs)


### PR DESCRIPTION
The `explore` method already has a `docstring`.  Decorating the `explore` methods with `@doc` docerator is causing the documentation to show the docstring twice (here: https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.explore.html)