### PR TITLE
CI: use mamba-org/setup-micromamba action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ matrix.env }}
 


### PR DESCRIPTION
`mamba-org/provision-with-micromamba` is [deprecated](https://github.com/mamba-org/provision-with-micromamba) and it is recommended to use `setup-micromamba` instead. 

I will self-merge this once the CI gets green.