### PR TITLE
REGR: fix read_file from urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ Bug fixes:
 
 Bug fix:
 
-- Restore ability to use ``geopandas.read_file`` with URLs (#2908).
+- Fix the a regression in reading from URLs using ``geopandas.read_file`` (#2908). This
+  restores the behaviour to download all data up-front before passing it to the
+  underlying engine (fiona or pyogrio), except if the server supports partial requests
+  (to support reading a subset of a large file).
 
 ## Version 0.13 (May 6, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ New features and improvements:
 
 Bug fixes:
 
+## Version 0.13.1 (Jun 5, 2023)
+
+Bug fix:
+
+- Restore ability to use ``geopandas.read_file`` with URLs (#2908).
 
 ## Version 0.13 (May 6, 2023)
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -250,8 +250,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs)
         # otherwise still download manually because pyogrio/fiona don't support
         # all types of urls (https://github.com/geopandas/geopandas/issues/2908)
         request = urllib.request.urlopen(filename)
-        headers = dict(request.getheaders())
-        if not headers.get("Accept-Ranges") == "bytes":
+        if not request.getheader("Accept-Ranges") == "bytes":
             filename = request.read()
             from_bytes = True
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -238,6 +238,17 @@ def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs)
     The format drivers will attempt to detect the encoding of your data, but
     may fail. In this case, the proper encoding can be specified explicitly
     by using the encoding keyword parameter, e.g. ``encoding='utf-8'``.
+
+    When specifying a URL, geopandas will check if the server supports reading
+    partial data and in that case pass the URL as is to the underlying engine,
+    which will then use the network file system handler of GDAL to read from
+    the URL. Otherwise geopandas will download the data from the URL and pass
+    all data in-memory to the underlying engine.
+    If you need more control over how the URL is read, you can specify the
+    GDAL virtual filesystem manually (e.g. ``/vsicurl/https://...``). See the
+    GDAL documentation on filesystems for more details
+    (https://gdal.org/user/virtual_file_systems.html#vsicurl-http-https-ftp-files-random-access).
+
     """
     engine = _check_engine(engine, "'read_file' function")
 
@@ -246,7 +257,7 @@ def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs)
     from_bytes = False
     if _is_url(filename):
         # if it is a url that supports random access -> pass through to
-        # pyogrio/fiona as is (to supports downloading only part of the file)
+        # pyogrio/fiona as is (to support downloading only part of the file)
         # otherwise still download manually because pyogrio/fiona don't support
         # all types of urls (https://github.com/geopandas/geopandas/issues/2908)
         request = urllib.request.urlopen(filename)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -557,21 +557,22 @@ def test_read_file(engine):
 
 
 @pytest.mark.web
-def test_read_file_remote_geojson_url(engine):
-    url = (
+@pytest.mark.parametrize(
+    "url",
+    [
+        # geojson url
         "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "main/geopandas/tests/data/null_geom.geojson"
-    )
-    gdf = read_file(url, engine=engine)
-    assert isinstance(gdf, geopandas.GeoDataFrame)
-
-
-@pytest.mark.web
-def test_read_file_remote_zipfile_url(engine):
-    url = (
+        "main/geopandas/tests/data/null_geom.geojson",
+        # url to zip file
         "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "main/geopandas/datasets/nybb_16a.zip"
-    )
+        "main/geopandas/datasets/nybb_16a.zip",
+        # url to zipfile without extension
+        "https://geonode.goosocean.org/download/480",
+        # url to web service
+        "https://demo.pygeoapi.io/stable/collections/obs/items",
+    ],
+)
+def test_read_file_url(engine, url):
     gdf = read_file(url, engine=engine)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 


### PR DESCRIPTION
Fixes https://github.com/geopandas/geopandas/issues/2908

Alternative for https://github.com/geopandas/geopandas/pull/2912, since that didn't fix all cases of urls that no longer work. 
The approach in this PR is to only _not_ download the data ourselves ~if the url has an extension~ if the url indicates to support reading ranges (and in that case we assume the /vsicurl/ filesystem will work), and in all other cases still download the data as we did before, passing the raw bytes to pyogrio/fiona. 
If later pyogrio/fiona have better support for urls, we could again consider passing through all urls.
