### PR TITLE
MAINT: use ruff instead of flake8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ geopandas/datasets/ne_110m_admin_0_countries.zip
 
 .asv
 doc/source/getting_started/my_file.geojson
+
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       hooks:
           - id: black
             language_version: python3
-    - repo: https://github.com/charliermarsh/ruff-pre-commit
+    - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: "v0.0.271"
       hooks:
         - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,7 @@ repos:
       hooks:
           - id: black
             language_version: python3
-    - repo: https://github.com/pycqa/flake8
-      rev: 5.0.4
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: "v0.0.271"
       hooks:
-          - id: flake8
-            language: python_venv
+        - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Style
 - GeoPandas follows [the PEP 8
   standard](http://www.python.org/dev/peps/pep-0008/) and uses
   [Black](https://black.readthedocs.io/en/stable/) and
-  [Flake8](http://flake8.pycqa.org/en/latest/) to ensure a consistent
+  [ruff](https://beta.ruff.rs/docs/) to ensure a consistent
   code format throughout the project.
 
 - Imports should be grouped with standard library imports first,
@@ -57,7 +57,7 @@ Style
   imports when necessary in tests.
 
 - You can set up [pre-commit hooks](https://pre-commit.com/) to
-  automatically run `black` and `flake8` when you make a git
+  automatically run `black` and `ruff` when you make a git
   commit. This can be done by installing `pre-commit`:
 
     $ python -m pip install pre-commit
@@ -67,7 +67,7 @@ Style
 
     $ pre-commit install
 
-  Then `black` and `flake8` will be run automatically each time you
+  Then `black` and `ruff` will be run automatically each time you
   commit changes. You can skip these checks with `git commit
   --no-verify`. You can also configure your local git clone to have
   `git blame` ignore the commits that introduced large formatting-only

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -33,8 +33,8 @@ In particular, when submitting a pull request:
   return values should be documented explicitly.
 
 - Follow PEP 8 when possible. We use `Black
-  <https://black.readthedocs.io/en/stable/>`_ and `Flake8
-  <http://flake8.pycqa.org/en/latest/>`_ to ensure a consistent code
+  <https://black.readthedocs.io/en/stable/>`_ and `ruff
+  <https://beta.ruff.rs/docs/>`_ to ensure a consistent code
   format throughout the project. For more details see
   :ref:`below <contributing_style>`.
 
@@ -324,7 +324,7 @@ Style Guide & Linting
 
 GeoPandas follows the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ standard
 and uses `Black <https://black.readthedocs.io/en/stable/>`_ and
-`Flake8 <http://flake8.pycqa.org/en/latest/>`_ to ensure a consistent code
+`ruff <https://beta.ruff.rs/docs/>`_ to ensure a consistent code
 format throughout the project.
 
 Continuous Integration (GitHub Actions) will run those tools and
@@ -332,13 +332,13 @@ report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself::
 
    black geopandas
-   git diff upstream/main -u -- "*.py" | flake8 --diff
+   git diff upstream/main -u -- "*.py" | ruff .
 
 to auto-format your code. Additionally, many editors have plugins that will
 apply ``black`` as you edit files.
 
 Optionally (but recommended), you can setup `pre-commit hooks <https://pre-commit.com/>`_
-to automatically run ``black`` and ``flake8`` when you make a git commit. If you did not
+to automatically run ``black`` and ``ruff`` when you make a git commit. If you did not
 use the provided development environment in ``environment-dev.yml``, you must first install ``pre-commit``::
 
    $ python -m pip install pre-commit
@@ -348,7 +348,7 @@ From the root of the geopandas repository, you should then install the
 
    $ pre-commit install
 
-Then ``black`` and ``flake8`` will be run automatically
+Then ``black`` and ``ruff`` will be run automatically
 each time you commit changes. You can skip these checks with
 ``git commit --no-verify``.
 

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -1,27 +1,27 @@
-from geopandas._config import options  # noqa: F401
+from geopandas._config import options
 
-from geopandas.geoseries import GeoSeries  # noqa: F401: F401
-from geopandas.geodataframe import GeoDataFrame  # noqa: F401
-from geopandas.array import points_from_xy  # noqa: F401
+from geopandas.geoseries import GeoSeries
+from geopandas.geodataframe import GeoDataFrame
+from geopandas.array import points_from_xy
 
-from geopandas.io.file import _read_file as read_file  # noqa: F401
-from geopandas.io.arrow import _read_parquet as read_parquet  # noqa: F401
-from geopandas.io.arrow import _read_feather as read_feather  # noqa: F401
-from geopandas.io.sql import _read_postgis as read_postgis  # noqa: F401
-from geopandas.tools import sjoin, sjoin_nearest  # noqa: F401
-from geopandas.tools import overlay  # noqa: F401
-from geopandas.tools._show_versions import show_versions  # noqa: F401
-from geopandas.tools import clip  # noqa: F401
+from geopandas.io.file import _read_file as read_file
+from geopandas.io.arrow import _read_parquet as read_parquet
+from geopandas.io.arrow import _read_feather as read_feather
+from geopandas.io.sql import _read_postgis as read_postgis
+from geopandas.tools import sjoin, sjoin_nearest
+from geopandas.tools import overlay
+from geopandas.tools._show_versions import show_versions
+from geopandas.tools import clip
 
 
-import geopandas.datasets  # noqa: F401
+import geopandas.datasets
 
 
 # make the interactive namespace easier to use
 # for `from geopandas import *` demos.
-import geopandas as gpd  # noqa: F401
-import pandas as pd  # noqa: F401
-import numpy as np  # noqa: F401
+import geopandas as gpd
+import pandas as pd
+import numpy as np
 
 from . import _version
 

--- a/geopandas/__init__.py
+++ b/geopandas/__init__.py
@@ -1,27 +1,27 @@
-from geopandas._config import options  # noqa
+from geopandas._config import options  # noqa: F401
 
-from geopandas.geoseries import GeoSeries  # noqa
-from geopandas.geodataframe import GeoDataFrame  # noqa
-from geopandas.array import points_from_xy  # noqa
+from geopandas.geoseries import GeoSeries  # noqa: F401: F401
+from geopandas.geodataframe import GeoDataFrame  # noqa: F401
+from geopandas.array import points_from_xy  # noqa: F401
 
-from geopandas.io.file import _read_file as read_file  # noqa
-from geopandas.io.arrow import _read_parquet as read_parquet  # noqa
-from geopandas.io.arrow import _read_feather as read_feather  # noqa
-from geopandas.io.sql import _read_postgis as read_postgis  # noqa
-from geopandas.tools import sjoin, sjoin_nearest  # noqa
-from geopandas.tools import overlay  # noqa
-from geopandas.tools._show_versions import show_versions  # noqa
-from geopandas.tools import clip  # noqa
+from geopandas.io.file import _read_file as read_file  # noqa: F401
+from geopandas.io.arrow import _read_parquet as read_parquet  # noqa: F401
+from geopandas.io.arrow import _read_feather as read_feather  # noqa: F401
+from geopandas.io.sql import _read_postgis as read_postgis  # noqa: F401
+from geopandas.tools import sjoin, sjoin_nearest  # noqa: F401
+from geopandas.tools import overlay  # noqa: F401
+from geopandas.tools._show_versions import show_versions  # noqa: F401
+from geopandas.tools import clip  # noqa: F401
 
 
-import geopandas.datasets  # noqa
+import geopandas.datasets  # noqa: F401
 
 
 # make the interactive namespace easier to use
 # for `from geopandas import *` demos.
-import geopandas as gpd  # noqa
-import pandas as pd  # noqa
-import numpy as np  # noqa
+import geopandas as gpd  # noqa: F401
+import pandas as pd  # noqa: F401
+import numpy as np  # noqa: F401
 
 from . import _version
 

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -61,6 +61,7 @@ try:
             "The installed version of PyGEOS is too old ({0} installed, 0.8 required),"
             " and thus GeoPandas will not use PyGEOS.".format(pygeos.__version__),
             UserWarning,
+            stacklevel=2,
         )
         HAS_PYGEOS = False
 except ImportError:
@@ -103,7 +104,8 @@ def set_use_pygeos(val=None):
                     USE_PYGEOS = False
                     warnings.warn(
                         "The PyGEOS version is too old, and Shapely >= 2 is installed, "
-                        "thus using Shapely by default and not PyGEOS."
+                        "thus using Shapely by default and not PyGEOS.",
+                        stacklevel=2,
                     )
                 else:
                     raise ImportError(
@@ -126,7 +128,8 @@ def set_use_pygeos(val=None):
                     "version PyGEOS was compiled with ({}). Conversions between both "
                     "will be slow.".format(
                         shapely_geos_version, geos_capi_version_string
-                    )
+                    ),
+                    stacklevel=2,
                 )
                 PYGEOS_SHAPELY_COMPAT = False
             else:
@@ -248,7 +251,7 @@ def import_optional_dependency(name: str, extra: str = ""):
 HAS_RTREE = None
 RTREE_GE_094 = False
 try:
-    import rtree  # noqa
+    import rtree  # noqa: F401
 
     HAS_RTREE = True
 except ImportError:

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -49,7 +49,7 @@ INSTALL_PYGEOS_ERROR = "To use PyGEOS within GeoPandas, you need to install PyGE
 'conda install pygeos' or 'pip install pygeos'"
 
 try:
-    import pygeos  # noqa
+    import pygeos
 
     # only automatically use pygeos if version is high enough
     if Version(pygeos.__version__) >= Version("0.8"):
@@ -95,7 +95,7 @@ def set_use_pygeos(val=None):
     # validate the pygeos version
     if USE_PYGEOS:
         try:
-            import pygeos  # noqa
+            import pygeos
 
             # validate the pygeos version
             if not Version(pygeos.__version__) >= Version("0.8"):

--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -654,7 +654,8 @@ def interiors(data):
     if has_non_poly:
         warnings.warn(
             "Only Polygon objects have interior rings. For other "
-            "geometry types, None is returned."
+            "geometry types, None is returned.",
+            stacklevel=2,
         )
     data = np.empty(len(data), dtype=object)
     with compat.ignore_shapely2_warnings():

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1486,7 +1486,8 @@ def _get_common_crs(arr_seq):
             warnings.warn(
                 "CRS not set for some of the concatenation inputs. "
                 f"Setting output's CRS as {names[0]} "
-                "(the single non-null crs provided)."
+                "(the single non-null crs provided).",
+                stacklevel=1,
             )
         return crs_not_none[0]
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1487,7 +1487,7 @@ def _get_common_crs(arr_seq):
                 "CRS not set for some of the concatenation inputs. "
                 f"Setting output's CRS as {names[0]} "
                 "(the single non-null crs provided).",
-                stacklevel=1,
+                stacklevel=2
             )
         return crs_not_none[0]
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1487,7 +1487,7 @@ def _get_common_crs(arr_seq):
                 "CRS not set for some of the concatenation inputs. "
                 f"Setting output's CRS as {names[0]} "
                 "(the single non-null crs provided).",
-                stacklevel=2
+                stacklevel=2,
             )
         return crs_not_none[0]
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -3257,7 +3257,7 @@ GeometryCollection
         2    POLYGON ((8.00000 4.00000, 13.00000 10.00000, ...
         dtype: geometry
 
-        """  # noqa (E501 link is longer than max line length)
+        """  # (E501 link is longer than max line length)
         return _delegate_geo_method("affine_transform", self, matrix)
 
     def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
@@ -3295,7 +3295,7 @@ GeometryCollection
         2    POLYGON ((5.00000 2.00000, 6.00000 3.00000, 5....
         dtype: geometry
 
-        """  # noqa (E501 link is longer than max line length)
+        """  # (E501 link is longer than max line length)
         return _delegate_geo_method("translate", self, xoff, yoff, zoff)
 
     def rotate(self, angle, origin="center", use_radians=False):

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -30,7 +30,7 @@ def _delegate_binary_method(op, this, other, align, *args, **kwargs):
         if align and not this.index.equals(other.index):
             warn(
                 "The indices of the two GeoSeries are different.",
-                stacklevel=1,
+                stacklevel=4,
             )
             this, other = this.align(other.geometry)
         else:
@@ -3825,7 +3825,7 @@ class _CoordinateIndexer(object):
         if xs.step is not None or ys.step is not None:
             warn(
                 "Ignoring step - full interval is used.",
-                stacklevel=1,
+                stacklevel=2,
             )
         if xs.start is None or xs.stop is None or ys.start is None or ys.stop is None:
             xmin, ymin, xmax, ymax = obj.total_bounds

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -28,7 +28,10 @@ def _delegate_binary_method(op, this, other, align, *args, **kwargs):
     this = this.geometry
     if isinstance(other, GeoPandasBase):
         if align and not this.index.equals(other.index):
-            warn("The indices of the two GeoSeries are different.")
+            warn(
+                "The indices of the two GeoSeries are different.",
+                stacklevel=1,
+            )
             this, other = this.align(other.geometry)
         else:
             other = other.geometry
@@ -3820,7 +3823,10 @@ class _CoordinateIndexer(object):
             ys = slice(ys, ys)
         # don't know how to handle step; should this raise?
         if xs.step is not None or ys.step is not None:
-            warn("Ignoring step - full interval is used.")
+            warn(
+                "Ignoring step - full interval is used.",
+                stacklevel=1,
+            )
         if xs.start is None or xs.stop is None or ys.start is None or ys.stop is None:
             xmin, ymin, xmax, ymax = obj.total_bounds
         bbox = box(

--- a/geopandas/datasets/naturalearth_creation.py
+++ b/geopandas/datasets/naturalearth_creation.py
@@ -4,7 +4,7 @@ and 'naturalearth_cities.shp'.
 
 Raw data: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip
 Current version used: see code
-"""  # (E501 link is longer than max line length)
+"""
 
 import geopandas as gpd
 import requests

--- a/geopandas/datasets/naturalearth_creation.py
+++ b/geopandas/datasets/naturalearth_creation.py
@@ -4,7 +4,7 @@ and 'naturalearth_cities.shp'.
 
 Raw data: https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip
 Current version used: see code
-"""  # noqa (E501 link is longer than max line length)
+"""  # (E501 link is longer than max line length)
 
 import geopandas as gpd
 import requests

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -282,7 +282,7 @@ def _explore(
         import folium
         import re
         import matplotlib
-        import matplotlib.colors as colors
+        from matplotlib import colors
         import matplotlib.pyplot as plt
         from mapclassify import classify
 
@@ -291,7 +291,7 @@ def _explore(
         if MPL_361:
             from matplotlib import colormaps as cm
         else:
-            import matplotlib.cm as cm
+            from matplotlib import cm
 
     except (ImportError, ModuleNotFoundError):
         raise ImportError(
@@ -449,7 +449,7 @@ def _explore(
 
         elif callable(cmap):
             # List of colors based on Branca colormaps or self-defined functions
-            color = list(map(lambda x: cmap(x), df[column]))
+            color = [cmap(x) for x in df[column]]
 
         else:
             vmin = gdf[column].min() if vmin is None else vmin

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -938,7 +938,7 @@ individually so that features may have different properties
                         if not na
                     }
                 else:
-                    properties_items = {k: v for k, v in zip(properties_cols, row)}
+                    properties_items = dict(zip(properties_cols, row))
 
                 if drop_id:
                     feature = {}
@@ -1770,9 +1770,13 @@ individually so that features may have different properties
         if by is None and level is None:
             by = np.zeros(len(self), dtype="int64")
 
-        groupby_kwargs = dict(
-            by=by, level=level, sort=sort, observed=observed, dropna=dropna
-        )
+        groupby_kwargs = {
+            "by": by,
+            "level": level,
+            "sort": sort,
+            "observed": observed,
+            "dropna": dropna,
+        }
 
         # Process non-spatial component
         data = self.drop(labels=self.geometry.name, axis=1)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1534,7 +1534,10 @@ individually so that features may have different properties
                 if key == "geometry":
                     self._persist_old_default_geometry_colname()
             except TypeError:
-                warnings.warn("Geometry column does not contain geometry.")
+                warnings.warn(
+                    "Geometry column does not contain geometry.",
+                    stacklevel=1,
+                )
         super().__setitem__(key, value)
 
     #
@@ -2178,7 +2181,7 @@ individually so that features may have different properties
         GeoDataFrame.sjoin_nearest : nearest neighbor join
         sjoin : equivalent top-level function
         """
-        return geopandas.sjoin(left_df=self, right_df=df, *args, **kwargs)
+        return geopandas.sjoin(left_df=self, right_df=df, *args, **kwargs)  # noqa: B026
 
     def sjoin_nearest(
         self,

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1536,7 +1536,7 @@ individually so that features may have different properties
             except TypeError:
                 warnings.warn(
                     "Geometry column does not contain geometry.",
-                    stacklevel=1,
+                    stacklevel=2,
                 )
         super().__setitem__(key, value)
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -915,7 +915,7 @@ class GeoSeries(GeoPandasBase, Series):
                     self.values._data, return_index=True
                 )
             else:
-                import pygeos  # noqa
+                import pygeos
 
                 geometries, outer_idx = pygeos.get_parts(
                     self.values._data, return_index=True

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -259,7 +259,7 @@ def _geopandas_to_arrow(df, index=None, schema_version=None):
 
     kwargs = {}
     if compat.USE_SHAPELY_20:
-        kwargs = dict(flavor="iso")
+        kwargs = {"flavor": "iso"}
     else:
         for col in df.columns[df.dtypes == "geometry"]:
             series = df[col]

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -439,7 +439,8 @@ def _arrow_to_geopandas(table, metadata=None):
         if len(geometry_columns) > 1:
             warnings.warn(
                 "Multiple non-primary geometry columns read from Parquet/Feather "
-                "file. The first column read was promoted to the primary geometry."
+                "file. The first column read was promoted to the primary geometry.",
+                stacklevel=3,
             )
 
     # Convert the WKB columns that are present back to geometry.

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -558,7 +558,7 @@ def _to_file(
     if driver is None:
         driver = _detect_driver(filename)
 
-    if driver == "ESRI Shapefile" and any([len(c) > 10 for c in df.columns.tolist()]):
+    if driver == "ESRI Shapefile" and any(len(c) > 10 for c in df.columns.tolist()):
         warnings.warn(
             "Column names longer than 10 characters will be truncated when saved to "
             "ESRI Shapefile.",

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -8,7 +8,7 @@ import shapely.wkb
 
 from geopandas import GeoDataFrame
 
-from .. import _compat as compat
+from geopandas import _compat as compat
 
 
 @contextmanager
@@ -469,5 +469,3 @@ def _write_postgis(
             dtype=dtype,
             method=_psql_insert_copy,
         )
-
-    return

--- a/geopandas/io/tests/generate_legacy_storage_files.py
+++ b/geopandas/io/tests/generate_legacy_storage_files.py
@@ -45,7 +45,7 @@ def create_pickle_data():
         crs="EPSG:4326",
     )
 
-    return dict(gdf_the_geom=gdf_the_geom, gdf_crs=gdf_crs)
+    return {"gdf_the_geom": gdf_the_geom, "gdf_crs": gdf_crs}
 
 
 def platform_name():
@@ -80,7 +80,7 @@ def write_legacy_pickles(output_dir):
 
 def main():
     if len(sys.argv) != 3:
-        exit(
+        sys.exit(
             "Specify output directory and storage type: generate_legacy_"
             "storage_files.py <output_dir> <storage_type> "
         )
@@ -91,7 +91,7 @@ def main():
     if storage_type == "pickle":
         write_legacy_pickles(output_dir=output_dir)
     else:
-        exit("storage_type must be one of {'pickle'}")
+        sys.exit("storage_type must be one of {'pickle'}")
 
 
 if __name__ == "__main__":

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -631,7 +631,7 @@ def test_fsspec_url():
     with memfs.open("data.parquet", "wb") as f:
         df.to_parquet(f)
 
-    result = read_parquet("memory://data.parquet", storage_options=dict(is_set=True))
+    result = read_parquet("memory://data.parquet", storage_options={"is_set": True})
     assert_geodataframe_equal(result, df)
 
     result = read_parquet("memory://data.parquet", filesystem=memfs)

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -834,8 +834,8 @@ def test_read_versioned_file(version):
         geometry=[MultiPolygon([box(0, 0, 1, 1), box(2, 2, 3, 3)]), box(4, 4, 5,5)],
         crs="EPSG:4326",
     )
-    df.to_feather(DATA_PATH / 'arrow' / f'test_data_v{METADATA_VERSION}.feather')  # noqa: E501
-    df.to_parquet(DATA_PATH / 'arrow' / f'test_data_v{METADATA_VERSION}.parquet')  # noqa: E501
+    df.to_feather(DATA_PATH / 'arrow' / f'test_data_v{METADATA_VERSION}.feather')
+    df.to_parquet(DATA_PATH / 'arrow' / f'test_data_v{METADATA_VERSION}.parquet')
     """
     expected = geopandas.GeoDataFrame(
         {"col_str": ["a", "b"], "col_int": [1, 2], "col_float": [0.1, 0.2]},
@@ -867,8 +867,8 @@ def test_read_gdal_files():
     df.to_file("test_data.gpkg", GEOMETRY_NAME="geometry")
     and then the gpkg file is converted to Parquet/Arrow with:
     $ ogr2ogr -f Parquet -lco FID= test_data_gdal350.parquet test_data.gpkg
-    $ ogr2ogr -f Arrow -lco FID= -lco GEOMETRY_ENCODING=WKB test_data_gdal350.arrow test_data.gpkg  # noqa: E501
-    """
+    $ ogr2ogr -f Arrow -lco FID= -lco GEOMETRY_ENCODING=WKB test_data_gdal350.arrow test_data.gpkg
+    """  # noqa: E501
     expected = geopandas.GeoDataFrame(
         {"col_str": ["a", "b"], "col_int": [1, 2], "col_float": [0.1, 0.2]},
         geometry=[MultiPolygon([box(0, 0, 1, 1), box(2, 2, 3, 3)]), box(4, 4, 5, 5)],

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -354,10 +354,10 @@ def test_to_file_types(tmpdir, df_points, engine):
         np.uint64,
     ]
     geometry = df_points.geometry
-    data = dict(
-        (str(i), np.arange(len(geometry), dtype=dtype))
+    data = {
+        str(i): np.arange(len(geometry), dtype=dtype)
         for i, dtype in enumerate(int_types)
-    )
+    }
     df = GeoDataFrame(data, geometry=geometry)
     df.to_file(tempfilename, engine=engine)
 
@@ -918,7 +918,7 @@ def test_read_file_empty_shapefile(tmpdir, engine):
     fname = str(tmpdir.join("test_empty.shp"))
 
     with fiona_env():
-        with fiona.open(fname, "w", **meta) as _:  # noqa
+        with fiona.open(fname, "w", **meta) as _:
             pass
 
     empty = read_file(fname, engine=engine)
@@ -1027,8 +1027,6 @@ def test_write_index_to_file(tmpdir, df_points, driver, ext, engine):
         df.geometry.to_file(tempfilename, driver=driver, index=False, engine=engine)
         df_check = read_file(tempfilename, engine=engine)
         assert list(df_check.columns) == driver_col + ["geometry"]
-
-        return
 
     #
     # Checks where index is not used/saved

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -371,6 +371,7 @@ def plot_series(
             "'colormap' is deprecated, please use 'cmap' instead "
             "(for consistency with matplotlib)",
             FutureWarning,
+            stacklevel=3,
         )
         cmap = style_kwds.pop("colormap")
     if "axes" in style_kwds:
@@ -378,6 +379,7 @@ def plot_series(
             "'axes' is deprecated, please use 'ax' instead "
             "(for consistency with pandas)",
             FutureWarning,
+            stacklevel=3,
         )
         ax = style_kwds.pop("axes")
 
@@ -410,6 +412,7 @@ def plot_series(
             "The GeoSeries you are attempting to plot is "
             "empty. Nothing has been displayed.",
             UserWarning,
+            stacklevel=3,
         )
         return ax
 
@@ -418,6 +421,7 @@ def plot_series(
             "The GeoSeries you are attempting to plot is "
             "composed of empty geometries. Nothing has been displayed.",
             UserWarning,
+            stacklevel=3,
         )
         return ax
 
@@ -645,6 +649,7 @@ def plot_dataframe(
             "'colormap' is deprecated, please use 'cmap' instead "
             "(for consistency with matplotlib)",
             FutureWarning,
+            stacklevel=3,
         )
         cmap = style_kwds.pop("colormap")
     if "axes" in style_kwds:
@@ -652,11 +657,14 @@ def plot_dataframe(
             "'axes' is deprecated, please use 'ax' instead "
             "(for consistency with pandas)",
             FutureWarning,
+            stacklevel=3,
         )
         ax = style_kwds.pop("axes")
     if column is not None and color is not None:
         warnings.warn(
-            "Only specify one of 'column' or 'color'. Using 'color'.", UserWarning
+            "Only specify one of 'column' or 'color'. Using 'color'.",
+            UserWarning,
+            stacklevel=3,
         )
         column = None
 
@@ -696,6 +704,7 @@ def plot_dataframe(
             "The GeoDataFrame you are attempting to plot is "
             "empty. Nothing has been displayed.",
             UserWarning,
+            stacklevel=3,
         )
         return ax
 
@@ -975,4 +984,4 @@ class GeoplotAccessor(PlotAccessor):
             raise ValueError(f"{kind} is not a valid plot kind")
 
     def geo(self, *args, **kwargs):
-        return self(kind="geo", *args, **kwargs)
+        return self(kind="geo", *args, **kwargs)  # noqa: B026

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -420,9 +420,9 @@ geometries}
 
 
 if compat.HAS_RTREE:
-    import rtree.index  # noqa
-    from rtree.core import RTreeError  # noqa
-    from shapely.prepared import prep  # noqa
+    import rtree.index
+    from rtree.core import RTreeError
+    from shapely.prepared import prep
 
     class SpatialIndex(rtree.index.Index, BaseSpatialIndex):
         """Original rtree wrapper, kept for backwards compatibility."""
@@ -701,17 +701,17 @@ if compat.HAS_RTREE:
 
 
 if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
-    from . import geoseries  # noqa
-    from . import array  # noqa
+    from . import geoseries
+    from . import array
 
     if compat.USE_SHAPELY_20:
-        import shapely as mod  # noqa
+        import shapely as mod
 
-        _PYGEOS_PREDICATES = {p.name for p in mod.strtree.BinaryPredicate} | set([None])
+        _PYGEOS_PREDICATES = {p.name for p in mod.strtree.BinaryPredicate} | {None}
     else:
-        import pygeos as mod  # noqa
+        import pygeos as mod
 
-        _PYGEOS_PREDICATES = {p.name for p in mod.strtree.BinaryPredicate} | set([None])
+        _PYGEOS_PREDICATES = {p.name for p in mod.strtree.BinaryPredicate} | {None}
 
     class PyGEOSSTRTreeIndex(BaseSpatialIndex):
         """A simple wrapper around pygeos's STRTree.

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -669,6 +669,7 @@ if compat.HAS_RTREE:
                 "PyGEOSSTRTreeIndex.nearest for details). This behavior will be "
                 "updated in a future release.",
                 FutureWarning,
+                stacklevel=2,
             )
             return super().nearest(
                 coordinates, num_results=num_results, objects=objects

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -2,7 +2,6 @@ import random
 
 import numpy as np
 import pandas as pd
-import six
 
 from pyproj import CRS
 import shapely
@@ -192,17 +191,10 @@ def test_to_wkb():
 @pytest.mark.parametrize("string_type", ["str", "bytes"])
 def test_from_wkt(string_type):
     if string_type == "str":
-        f = six.text_type
-    else:
-        if six.PY3:
+        f = str
 
-            def f(x):
-                return bytes(x, "utf8")
-
-        else:
-
-            def f(x):
-                return x
+    def f(x):
+        return bytes(x, "utf8")
 
     # list
     L_wkt = [f(p.wkt) for p in points_no_missing]
@@ -468,7 +460,7 @@ def test_unary_predicates(attr):
     na_value = False
     if attr == "is_simple" and geos_version < (3, 8) and not compat.USE_PYGEOS:
         # poly.is_simple raises an error for empty polygon for GEOS < 3.8
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             T.is_simple
         vals = triangle_no_missing
         V = from_shapely(vals)
@@ -627,10 +619,10 @@ def test_binary_project(normalized):
 
     result = L.project(P, normalized=normalized)
     expected = [
-        l.project(p, normalized=normalized)
-        if l is not None and p is not None
+        line.project(p, normalized=normalized)
+        if line is not None and p is not None
         else na_value
-        for p, l in zip(points, lines)
+        for p, line in zip(points, lines)
     ]
     np.testing.assert_allclose(result, expected)
 

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -192,9 +192,10 @@ def test_to_wkb():
 def test_from_wkt(string_type):
     if string_type == "str":
         f = str
+    else:
 
-    def f(x):
-        return bytes(x, "utf8")
+        def f(x):
+            return bytes(x, "utf8")
 
     # list
     L_wkt = [f(p.wkt) for p in points_no_missing]

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -112,8 +112,8 @@ def test_to_crs_dimension_mixed():
 )
 def epsg4326(request):
     if isinstance(request.param, int):
-        return dict(epsg=request.param)
-    return dict(crs=request.param)
+        return {"epsg": request.param}
+    return {"crs": request.param}
 
 
 @pytest.fixture(
@@ -130,8 +130,8 @@ def epsg4326(request):
 )
 def epsg26918(request):
     if isinstance(request.param, int):
-        return dict(epsg=request.param)
-    return dict(crs=request.param)
+        return {"epsg": request.param}
+    return {"crs": request.param}
 
 
 @pytest.mark.filterwarnings("ignore:'\\+init:DeprecationWarning")
@@ -650,7 +650,7 @@ class TestGeometryArrayCRS:
         arr = from_shapely(self.geoms, crs=27700)
         df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
 
-        df["geometry"] = [g for g in df.geometry]
+        df["geometry"] = list(df.geometry)
         assert df.geometry.values.crs == self.osgb
 
         df2 = GeoDataFrame({"col1": [0, 1]}, geometry=arr)

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -120,7 +120,7 @@ def test_dissolve_emits_other_warnings(nybb_polydf):
     # we only do something special for pandas 1.5.x, but expect this
     # test to be true on any version
     def sum_and_warn(group):
-        warnings.warn("foo")
+        warnings.warn("foo")  # noqa: B028
         if PANDAS_GE_20:
             return group.sum(numeric_only=False)
         else:

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -9,8 +9,8 @@ branca = pytest.importorskip("branca")
 matplotlib = pytest.importorskip("matplotlib")
 mapclassify = pytest.importorskip("mapclassify")
 
-import matplotlib.cm as cm  # noqa
-import matplotlib.colors as colors  # noqa
+from matplotlib import cm
+from matplotlib import colors
 from branca.colormap import StepColormap
 
 BRANCA_05 = Version(branca.__version__) > Version("0.4.2")

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -11,7 +11,7 @@ mapclassify = pytest.importorskip("mapclassify")
 
 import matplotlib.cm as cm  # noqa
 import matplotlib.colors as colors  # noqa
-from branca.colormap import StepColormap  # noqa
+from branca.colormap import StepColormap
 
 BRANCA_05 = Version(branca.__version__) > Version("0.4.2")
 FOLIUM_G_014 = Version(folium.__version__) > Version("0.14.0")
@@ -325,11 +325,11 @@ class TestExplore:
     def test_style_kwds(self):
         """Style keywords"""
         m = self.world.explore(
-            style_kwds=dict(fillOpacity=0.1, weight=0.5, fillColor="orange")
+            style_kwds={"fillOpacity": 0.1, "weight": 0.5, "fillColor": "orange"}
         )
         out_str = self._fetch_map_string(m)
         assert '"fillColor":"orange","fillOpacity":0.1,"weight":0.5' in out_str
-        m = self.world.explore(column="pop_est", style_kwds=dict(color="black"))
+        m = self.world.explore(column="pop_est", style_kwds={"color": "black"})
         assert '"color":"black"' in self._fetch_map_string(m)
 
         # custom style_function - geopandas/issues/2350
@@ -348,14 +348,12 @@ class TestExplore:
         # two lines with formatting instructions from style_function.
         # make sure each passes test
         assert all(
-            [
-                ('"fillColor":"green"' in t and '"color":"white"' in t)
-                or ('"fillColor":"red"' in t and '"color":"black"' in t)
-                for t in [
-                    "".join(line.split())
-                    for line in m._parent.render().split("\n")
-                    if "return" in line and "color" in line
-                ]
+            ('"fillColor":"green"' in t and '"color":"white"' in t)
+            or ('"fillColor":"red"' in t and '"color":"black"' in t)
+            for t in [
+                "".join(line.split())
+                for line in m._parent.render().split("\n")
+                if "return" in line and "color" in line
             ]
         )
 
@@ -426,7 +424,7 @@ class TestExplore:
         m = self.world.explore(
             tooltip=True,
             popup=False,
-            tooltip_kwds=dict(aliases=[0, 1, 2, 3, 4, 5], sticky=False),
+            tooltip_kwds={"aliases": [0, 1, 2, 3, 4, 5], "sticky": False},
         )
         out_str = self._fetch_map_string(m)
         assert (
@@ -440,7 +438,7 @@ class TestExplore:
         m = self.world.explore(
             tooltip=False,
             popup=True,
-            popup_kwds=dict(aliases=[0, 1, 2, 3, 4, 5]),
+            popup_kwds={"aliases": [0, 1, 2, 3, 4, 5]},
         )
         out_str = self._fetch_map_string(m)
         assert (
@@ -454,8 +452,8 @@ class TestExplore:
         m = self.world.explore(
             tooltip=True,
             popup=True,
-            tooltip_kwds=dict(labels=False),
-            popup_kwds=dict(labels=False),
+            tooltip_kwds={"labels": False},
+            popup_kwds={"labels": False},
         )
         out_str = self._fetch_map_string(m)
         assert "<th>${aliases[i]" not in out_str
@@ -483,7 +481,7 @@ class TestExplore:
         for s in strings:
             assert s in out_str
 
-        m = self.cities.explore(marker_kwds=dict(radius=5, fill=False))
+        m = self.cities.explore(marker_kwds={"radius": 5, "fill": False})
         strings = ['"radius":5', '"fill":false', "CircleMarker(latlng,opts)"]
         out_str = self._fetch_map_string(m)
         for s in strings:
@@ -556,10 +554,10 @@ class TestExplore:
         m = self.missing.explore("pop_est")
         assert '"fillColor":null' in self._fetch_map_string(m)
 
-        m = self.missing.explore("pop_est", missing_kwds=dict(color="red"))
+        m = self.missing.explore("pop_est", missing_kwds={"color": "red"})
         assert '"fillColor":"red"' in self._fetch_map_string(m)
 
-        m = self.missing.explore("continent", missing_kwds=dict(color="red"))
+        m = self.missing.explore("continent", missing_kwds={"color": "red"})
         assert '"fillColor":"red"' in self._fetch_map_string(m)
 
     def test_categorical_legend(self):
@@ -590,13 +588,13 @@ class TestExplore:
         assert quoted_in("text('range')", out_str)
 
         m = self.world.explore(
-            "range", legend=True, legend_kwds=dict(caption="my_caption")
+            "range", legend=True, legend_kwds={"caption": "my_caption"}
         )
         out_str = self._fetch_map_string(m)
         assert "attr(\"id\",'legend')" in out_str
         assert quoted_in("text('my_caption')", out_str)
 
-        m = self.missing.explore("pop_est", legend=True, missing_kwds=dict(color="red"))
+        m = self.missing.explore("pop_est", legend=True, missing_kwds={"color": "red"})
         out_str = self._fetch_map_string(m)
         assert "red'></span>NaN" in out_str
 
@@ -604,7 +602,7 @@ class TestExplore:
         m = self.world.explore(
             "pop_est",
             legend=True,
-            legend_kwds=dict(scale=False),
+            legend_kwds={"scale": False},
             scheme="Headtailbreaks",
         )
         out_str = self._fetch_map_string(m)
@@ -645,7 +643,7 @@ class TestExplore:
         import re
 
         # linear
-        m = self.world.explore("pop_est", legend_kwds=dict(max_labels=3))
+        m = self.world.explore("pop_est", legend_kwds={"max_labels": 3})
         out_str = self._fetch_map_string(m)
         tick_str = re.search(r"tickValues\(\[[\',\,\.,0-9]*\]\)", out_str).group(0)
         assert (
@@ -655,13 +653,13 @@ class TestExplore:
 
         # scheme
         m = self.world.explore(
-            "pop_est", scheme="headtailbreaks", legend_kwds=dict(max_labels=3)
+            "pop_est", scheme="headtailbreaks", legend_kwds={"max_labels": 3}
         )
         out_str = self._fetch_map_string(m)
         assert "tickValues([140.0,'',184117213.1818182,'',1382066377.0,''])" in out_str
 
         # short cmap
-        m = self.world.explore("pop_est", legend_kwds=dict(max_labels=3), cmap="tab10")
+        m = self.world.explore("pop_est", legend_kwds={"max_labels": 3}, cmap="tab10")
         out_str = self._fetch_map_string(m)
 
         tick_str = re.search(r"tickValues\(\[[\',\,\.,0-9]*\]\)", out_str).group(0)
@@ -746,8 +744,8 @@ class TestExplore:
             column="pop_est",
             legend=True,
             scheme="naturalbreaks",
-            missing_kwds=dict(color="red", label="missing"),
-            legend_kwds=dict(colorbar=False, interval=True),
+            missing_kwds={"color": "red", "label": "missing"},
+            legend_kwds={"colorbar": False, "interval": True},
         )
         out_str = self._fetch_map_string(m)
 
@@ -767,8 +765,8 @@ class TestExplore:
             column="pop_est",
             legend=True,
             scheme="naturalbreaks",
-            missing_kwds=dict(color="red", label="missing"),
-            legend_kwds=dict(colorbar=False, interval=False),
+            missing_kwds={"color": "red", "label": "missing"},
+            legend_kwds={"colorbar": False, "interval": False},
         )
         out_str = self._fetch_map_string(m)
 
@@ -789,7 +787,7 @@ class TestExplore:
             legend=True,
             scheme="naturalbreaks",
             k=5,
-            legend_kwds=dict(colorbar=False, labels=["s", "m", "l", "xl", "xxl"]),
+            legend_kwds={"colorbar": False, "labels": ["s", "m", "l", "xl", "xxl"]},
         )
         out_str = self._fetch_map_string(m)
 
@@ -802,8 +800,8 @@ class TestExplore:
             column="pop_est",
             legend=True,
             scheme="naturalbreaks",
-            missing_kwds=dict(color="red", label="missing"),
-            legend_kwds=dict(colorbar=False, fmt="{:.0f}"),
+            missing_kwds={"color": "red", "label": "missing"},
+            legend_kwds={"colorbar": False, "fmt": "{:.0f}"},
         )
         out_str = self._fetch_map_string(m)
 
@@ -836,7 +834,7 @@ class TestExplore:
         assert '"fillOpacity":0.75' in out_str
 
         m = self.nybb.explore(
-            highlight=True, highlight_kwds=dict(fillOpacity=1, color="red")
+            highlight=True, highlight_kwds={"fillOpacity": 1, "color": "red"}
         )
         out_str = self._fetch_map_string(m)
 
@@ -914,12 +912,16 @@ class TestExplore:
 
         # check that folium and leaflet Map() parameters can be passed
         m = self.world.explore(
-            zoom_control=False, map_kwds=dict(dragging=False, scrollWheelZoom=False)
+            zoom_control=False, map_kwds={"dragging": False, "scrollWheelZoom": False}
         )
         check()
         with pytest.raises(
             ValueError, match="'zoom_control' cannot be specified in 'map_kwds'"
         ):
             self.world.explore(
-                map_kwds=dict(dragging=False, scrollWheelZoom=False, zoom_control=False)
+                map_kwds={
+                    "dragging": False,
+                    "scrollWheelZoom": False,
+                    "zoom_control": False,
+                }
             )

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -479,12 +479,12 @@ class TestComparisonOps(extension_tests.BaseComparisonOpsTests):
         expected = s.combine(other, op)
         self.assert_series_equal(result, expected)
 
-    def test_compare_scalar(self, data, all_compare_operators):  # noqa
+    def test_compare_scalar(self, data, all_compare_operators):
         op_name = all_compare_operators
         s = pd.Series(data)
         self._compare_other(s, data, op_name, data[0])
 
-    def test_compare_array(self, data, all_compare_operators):  # noqa
+    def test_compare_array(self, data, all_compare_operators):
         op_name = all_compare_operators
         s = pd.Series(data)
         other = pd.Series([data[0]] * len(data))

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -918,7 +918,7 @@ class TestGeomMethods:
         assert geom_almost_equals(expected, calculated)
 
     def test_buffer_args(self):
-        args = dict(cap_style=3, join_style=2, mitre_limit=2.5)
+        args = {"cap_style": 3, "join_style": 2, "mitre_limit": 2.5}
         calculated_series = self.g0.buffer(10, **args)
         for original, calculated in zip(self.g0, calculated_series):
             if original is None:

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -514,7 +514,7 @@ def test_overlay_strict(how, keep_geom_type, geom_types):
         # so we sort the resultant dataframes to get a consistent order
         # independently of the spatial index implementation
         assert all(expected.columns == result.columns), "Column name mismatch"
-        cols = list(set(result.columns) - set(["geometry"]))
+        cols = list(set(result.columns) - {"geometry"})
         expected = expected.sort_values(cols, axis=0).reset_index(drop=True)
         result = result.sort_values(cols, axis=0).reset_index(drop=True)
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1875,9 +1875,9 @@ def _check_colors(N, actual_colors, expected_colors, alpha=None):
     actual_colors = map(tuple, actual_colors)
     all_actual_colors = list(itertools.islice(itertools.cycle(actual_colors), N))
 
-    assert len(all_actual_colors) == len(expected_colors), (
-        "Different " "lengths of actual and expected colors!"
-    )
+    assert len(all_actual_colors) == len(
+        expected_colors
+    ), "Different lengths of actual and expected colors!"
 
     for actual, expected in zip(all_actual_colors, expected_colors):
         assert actual == conv.to_rgba(expected, alpha=alpha), "{} != {}".format(
@@ -1911,8 +1911,7 @@ def _get_ax(fig, label):
     for ax in fig.axes:
         if ax.get_label() == label:
             return ax
-    else:
-        raise ValueError("no ax found with label {0}".format(label))
+    raise ValueError("no ax found with label {0}".format(label))
 
 
 def _get_colorbar_ax(fig):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -23,6 +23,7 @@ from shapely.geometry import (
 from geopandas import GeoDataFrame, GeoSeries, read_file
 from geopandas.datasets import get_path
 import geopandas._compat as compat
+from geopandas.plotting import GeoplotAccessor
 
 import pytest
 
@@ -1739,7 +1740,7 @@ class TestGeoplotAccessor:
         ax_geopandas_2 = fig_ref.subplots()
         getattr(self.gdf.plot, kind)(ax=ax_geopandas_2, **kwargs)
 
-    _pandas_kinds = []
+    _pandas_kinds = GeoplotAccessor._pandas_kinds
 
     if MPL_DECORATORS:
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -23,13 +23,12 @@ from shapely.geometry import (
 from geopandas import GeoDataFrame, GeoSeries, read_file
 from geopandas.datasets import get_path
 import geopandas._compat as compat
-from geopandas.plotting import GeoplotAccessor
 
 import pytest
 
 matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt  # noqa
+import matplotlib.pyplot as plt
 
 try:  # skipif and importorskip do not work for decorators
     from matplotlib.testing.decorators import check_figures_equal
@@ -1137,7 +1136,7 @@ class TestMapclassifyPlotting:
     @classmethod
     def setup_class(cls):
         try:
-            import mapclassify  # noqa
+            import mapclassify
         except ImportError:
             pytest.importorskip("mapclassify")
         cls.mc = mapclassify
@@ -1313,10 +1312,8 @@ class TestMapclassifyPlotting:
             ]
         )
         assert all(
-            [
-                (z == expected).all(axis=1).any()
-                for z in ax.collections[0].get_facecolors()
-            ]
+            (z == expected).all(axis=1).any()
+            for z in ax.collections[0].get_facecolors()
         )
         labels = [
             "0.00, 0.10",
@@ -1366,10 +1363,8 @@ class TestMapclassifyPlotting:
             ]
         )
         assert all(
-            [
-                (z == expected).all(axis=1).any()
-                for z in ax2.collections[0].get_facecolors()
-            ]
+            (z == expected).all(axis=1).any()
+            for z in ax2.collections[0].get_facecolors()
         )
 
         labels = [
@@ -1404,10 +1399,8 @@ class TestMapclassifyPlotting:
             ]
         )
         assert all(
-            [
-                (z == expected).all(axis=1).any()
-                for z in ax3.collections[0].get_facecolors()
-            ]
+            (z == expected).all(axis=1).any()
+            for z in ax3.collections[0].get_facecolors()
         )
 
         legend = [t.get_text() for t in ax3.get_legend().get_texts()]
@@ -1434,7 +1427,7 @@ class TestMapclassifyPlotting:
         assert labels == expected
 
         ax2 = self.nybb.plot(
-            "vals", scheme="quantiles", legend=True, legend_kwds=dict(fmt="{:.3f}")
+            "vals", scheme="quantiles", legend=True, legend_kwds={"fmt": "{:.3f}"}
         )
         labels = [t.get_text() for t in ax2.get_legend().get_texts()]
         expected = [
@@ -1748,8 +1741,6 @@ class TestGeoplotAccessor:
 
     _pandas_kinds = []
 
-    _pandas_kinds = GeoplotAccessor._pandas_kinds
-
     if MPL_DECORATORS:
 
         @pytest.mark.parametrize("kind", _pandas_kinds)
@@ -1876,7 +1867,7 @@ def _check_colors(N, actual_colors, expected_colors, alpha=None):
         `expected_colors`. (Any transparency on the `collection` is assumed
         to be set in its own facecolor RGBA tuples.)
     """
-    import matplotlib.colors as colors
+    from matplotlib import colors
 
     conv = colors.colorConverter
 

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -4,7 +4,7 @@ from pandas import Series
 
 from geopandas import GeoDataFrame
 
-from geopandas.testing import (  # noqa
+from geopandas.testing import (  # noqa: F401
     assert_geoseries_equal,
     geom_almost_equals,
     geom_equals,
@@ -16,9 +16,9 @@ PACKAGE_DIR = os.path.dirname(os.path.dirname(HERE))
 
 # mock not used here, but the import from here is used in other modules
 try:
-    import unittest.mock as mock  # noqa
+    from unittest import mock
 except ImportError:
-    import mock  # noqa
+    import mock  # noqa: F401
 
 
 def validate_boro_df(df, case_sensitive=False):

--- a/geopandas/tools/_random.py
+++ b/geopandas/tools/_random.py
@@ -3,8 +3,8 @@ from warnings import warn
 import numpy
 from shapely.geometry import MultiPoint
 
-from ..array import from_shapely, points_from_xy
-from ..geoseries import GeoSeries
+from geopandas.array import from_shapely, points_from_xy
+from geopandas.geoseries import GeoSeries
 
 
 def uniform(geom, size, seed=None):

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -200,7 +200,8 @@ def clip(gdf, mask, keep_geom_type=False):
         if geomcoll_orig:
             warnings.warn(
                 "keep_geom_type can not be called on a "
-                "GeoDataFrame with GeometryCollection."
+                "GeoDataFrame with GeometryCollection.",
+                stacklevel=2,
             )
         else:
             polys = ["Polygon", "MultiPolygon"]
@@ -230,7 +231,8 @@ def clip(gdf, mask, keep_geom_type=False):
 
             if orig_types_total > 1:
                 warnings.warn(
-                    "keep_geom_type can not be called on a mixed type GeoDataFrame."
+                    "keep_geom_type can not be called on a mixed type GeoDataFrame.",
+                    stacklevel=2,
                 )
             elif new_collection or more_types:
                 orig_type = gdf.geom_type.iloc[0]

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -247,7 +247,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
 
     if isinstance(df1, GeoSeries) or isinstance(df2, GeoSeries):
         raise NotImplementedError(
-            "overlay currently only implemented for " "GeoDataFrames"
+            "overlay currently only implemented for GeoDataFrames"
         )
 
     if not _check_crs(df1, df2):

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -1,6 +1,5 @@
 """Tests for the clip module."""
 
-import warnings
 from packaging.version import Version
 
 import numpy as np
@@ -352,15 +351,6 @@ class TestClipWithSingleRectangleGdf:
             and clipped.geom_type[1] == "Polygon"
             and clipped.geom_type[2] == "LineString"
         )
-
-    def test_clip_warning_no_extra_geoms(self, buffered_locations, mask):
-        """Test a user warning is provided if no new geometry types are found."""
-        with pytest.warns(UserWarning):
-            clip(buffered_locations, mask, True)
-            warnings.warn(
-                "keep_geom_type was called when no extra geometry types existed.",
-                UserWarning,
-            )
 
     def test_clip_with_line_extra_geom(self, sliver_line, mask):
         """When the output of a clipped line returns a geom collection,

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -136,7 +136,7 @@ class TestSpatialJoin:
         if op != predicate:
             warntype = UserWarning
             match = (
-                "`predicate` will be overridden by the value of `op`"
+                "`predicate` will be overridden by the value of `op`"  # noqa: ISC003
                 + r"(.|\s)*"
                 + match
             )

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -111,7 +111,7 @@ class TestSpatialJoin:
         left = GeoDataFrame({"col": [1], "geometry": [Point(0, 0)]})
         right = GeoDataFrame({"col": [1], "geometry": [Point(0, 0)]})
         joined = sjoin(left, right, how=how, lsuffix=lsuffix, rsuffix=rsuffix)
-        assert set(joined.columns) == expected_cols | set(("geometry",))
+        assert set(joined.columns) == expected_cols | {"geometry"}
 
     @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
     def test_crs_mismatch(self, dfs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,13 @@
 [build-system]
-requires = [
-    "setuptools>=61.0.0",
-]
+requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "geopandas"
 dynamic = ["version"]
-authors = [
-    {name = "Kelsey Jordahl", email = "kjordahl@alum.mit.edu"},
-]
-maintainers = [
-    {name = "GeoPandas contributors"},
-]
-license = {text = "BSD 3-Clause"}
+authors = [{ name = "Kelsey Jordahl", email = "kjordahl@alum.mit.edu" }]
+maintainers = [{ name = "GeoPandas contributors" }]
+license = { text = "BSD 3-Clause" }
 description = "Geographic pandas extensions"
 keywords = ["GIS", "cartography", "pandas", "shapely"]
 classifiers = [
@@ -56,10 +50,7 @@ Home = "https://geopandas.org"
 Repository = "https://github.com/geopandas/geopandas"
 
 [tool.setuptools.packages.find]
-include = [
-    "geopandas",
-    "geopandas.*",
-]
+include = ["geopandas", "geopandas.*"]
 
 [tool.setuptools.package-data]
 geopandas = [
@@ -70,13 +61,138 @@ geopandas = [
 ]
 
 [tool.pytest.ini_options]
-markers = [
-    "web: tests that need network connectivity"
-]
+markers = ["web: tests that need network connectivity"]
 xfail_strict = true
 
 filterwarnings = [
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:pandas.*",
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:numpy.*",
-    "ignore:The geopandas.dataset module is deprecated"
+    "ignore:The geopandas.dataset module is deprecated",
 ]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+select = [
+    # pyflakes
+    "F",
+    # pycodestyle
+    "E",
+    "W",
+    # flake8-2020
+    "YTT",
+    # flake8-bugbear
+    "B",
+    # flake8-quotes
+    "Q",
+    # flake8-debugger
+    "T10",
+    # flake8-gettext
+    "INT",
+    # pylint
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    # misc lints
+    "PIE",
+    # flake8-pyi
+    "PYI",
+    # tidy imports
+    "TID",
+    # implicit string concatenation
+    "ISC",
+    # type-checking imports
+    "TCH",
+    # comprehensions
+    "C4",
+    # pygrep-hooks
+    "PGH",
+    # Ruff-specific rules
+    "RUF",
+]
+target-version = "py38"
+ignore = [ # space before : (needed for how black formats slicing)
+    # "E203",  # not yet implemented
+    # module level import not at top of file
+    "E402",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # line break before binary operator
+    # "W503",  # not yet implemented
+    # line break after binary operator
+    # "W504",  # not yet implemented
+    # controversial
+    "B006",
+    # controversial
+    "B007",
+    # controversial
+    "B008",
+    # setattr is used to side-step mypy
+    "B009",
+    # getattr is used to side-step mypy
+    "B010",
+    # tests use assert False
+    "B011",
+    # tests use comparisons but not their returned value
+    "B015",
+    # false positives
+    "B019",
+    # Loop control variable overrides iterable it iterates
+    "B020",
+    # Function definition does not bind loop variable
+    "B023",
+    # Functions defined inside a loop must not use variables redefined in the loop
+    # "B301",  # not yet implemented
+    # Only works with python >=3.10
+    "B905",
+    # Too many arguments to function call
+    "PLR0913",
+    # Too many returns
+    "PLR0911",
+    # Too many branches
+    "PLR0912",
+    # Too many statements
+    "PLR0915",
+    # Redefined loop name
+    "PLW2901",
+    # Global statements are discouraged
+    "PLW0603",
+    # Docstrings should not be included in stubs
+    "PYI021",
+    # No builtin `eval()` allowed
+    "PGH001",
+    # compare-to-empty-string
+    "PLC1901",
+    # Use typing_extensions.TypeAlias for type aliases
+    # "PYI026",  # not yet implemented
+    # Use "collections.abc.*" instead of "typing.*" (PEP 585 syntax)
+    # "PYI027",  # not yet implemented
+    # while int | float can be shortened to float, the former is more explicit
+    # "PYI041",  # not yet implemented
+
+    # Additional checks that don't pass yet
+    # Useless statement
+    "B018",
+    # Within an except clause, raise exceptions with ...
+    "B904",
+    # Magic number
+    "PLR2004",
+    # Consider `elif` instead of `else` then `if` to remove indentation level
+    "PLR5501",
+    # ambiguous-unicode-character-string
+    "RUF001",
+    # ambiguous-unicode-character-docstring
+    "RUF002",
+    # ambiguous-unicode-character-comment
+    "RUF003",
+    # collection-literal-concatenation
+    "RUF005",
+    # pairwise-over-zipped (>=PY310 only)
+    "RUF007",
+    # explicit-f-string-type-conversion
+    "RUF010",
+]
+exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,3 +196,6 @@ ignore = [ # space before : (needed for how black formats slicing)
     "RUF010",
 ]
 exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]
+
+[tool.ruff.per-file-ignores]
+"geopandas/__init__.py" = ["F401"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,12 +9,3 @@ versionfile_source = geopandas/_version.py
 versionfile_build = geopandas/_version.py
 tag_prefix = v
 parentdir_prefix = geopandas-
-
-[flake8]
-# Black enforces 88 characters line length
-max_line_length = 88
-
-ignore =
-    E203,  # Space before : (needed for black formatting of slices)
-    W503,  # Line break before binary operator (needed for black)
-    F821   # TODO: fix F821 issues (see GH #1120) and remove this line

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 # https://github.com/python-versioneer/python-versioneer/issues/193
 sys.path.append(os.path.dirname(__file__))
 
-import versioneer  # noqa: E402
+import versioneer
 
 # see pyproject.toml for static project metadata
 setup(


### PR DESCRIPTION
Setting up `ruff` as a linter alongside `black`, replacing `flake8` and extending the amount of rules we shall follow. 

ruff settings is copied from pandas at the moment. The first commit just switches (and pre-commit will fail). I'll push fixes in subsequent commits to keep better track of changes.