### PR TITLE
BUG: fix a color assignment in ``explore`` when using ``UserDefined`` bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features and improvements:
 
 Bug fixes:
 
+- Fix a color assignment in ``explore`` when using ``UserDefined`` bins (#2923)
 
 ## Version 0.13.2 (Jun 6, 2023)
 

--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -33,3 +33,4 @@ dependencies:
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@main
     - git+https://github.com/geopandas/xyzservices.git@main
+    - git+https://github.com/geopandas/geodatasets.git@main

--- a/ci/envs/310-latest-conda-forge.yaml
+++ b/ci/envs/310-latest-conda-forge.yaml
@@ -24,6 +24,7 @@ dependencies:
   - scipy
   - geopy
   - pointpats
+  - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
   - SQLalchemy<2

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -25,6 +25,7 @@ dependencies:
   - scipy
   - geopy
   - pointpats
+  - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
   - SQLalchemy>=2

--- a/ci/envs/38-latest-conda-forge.yaml
+++ b/ci/envs/38-latest-conda-forge.yaml
@@ -29,3 +29,4 @@ dependencies:
   - pyarrow
   - pyogrio
   - pointpats
+  - geodatasets

--- a/ci/envs/38-latest-defaults.yaml
+++ b/ci/envs/38-latest-defaults.yaml
@@ -29,3 +29,4 @@ dependencies:
       - pyarrow
       - folium
       - xyzservices
+      - geodatasets

--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -23,3 +23,4 @@ dependencies:
   - SQLalchemy
   - libspatialite
   - pyarrow=8.0.0
+  - geodatasets

--- a/ci/envs/38-pd12-defaults.yaml
+++ b/ci/envs/38-pd12-defaults.yaml
@@ -28,3 +28,4 @@ dependencies:
       - geopy
       - mapclassify==2.4.0
       - pyarrow
+      - geodatasets

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -27,6 +27,7 @@ dependencies:
   - scipy
   - geopy
   - pointpats
+  - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
   - SQLalchemy<2

--- a/ci/envs/39-pd13-conda-forge.yaml
+++ b/ci/envs/39-pd13-conda-forge.yaml
@@ -24,6 +24,7 @@ dependencies:
   - xyzservices
   - scipy
   - geopy
+  - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
   - SQLalchemy<2
@@ -33,6 +34,3 @@ dependencies:
   - pyarrow
   # doctest testing
   - pytest-doctestplus
-  - pip
-  - pip:
-      - geodatasets

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -468,7 +468,7 @@ def _explore(
                 color = np.apply_along_axis(
                     colors.to_hex,
                     1,
-                    _colormap_helper(cmap, n_resample=k, idx=binning.yb),
+                    _colormap_helper(cmap, n_resample=binning.k, idx=binning.yb),
                 )
 
             else:

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -174,6 +174,7 @@ class TestExplore:
         assert '"fillColor":"#21918c"' in out_str
         assert '"fillColor":"#5ec962"' in out_str
         assert '"fillColor":"#fde725"' in out_str
+        assert '"fillColor":"#440154"' in out_str
 
         # custom k
         m = self.world.explore(column="pop_est", scheme="naturalbreaks", k=3)

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -3,12 +3,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from packaging.version import Version
-import geodatasets
 
 folium = pytest.importorskip("folium")
 branca = pytest.importorskip("branca")
 matplotlib = pytest.importorskip("matplotlib")
 mapclassify = pytest.importorskip("mapclassify")
+geodatasets = pytest.importorskip("geodatasets")
 
 import matplotlib.cm as cm  # noqa
 import matplotlib.colors as colors  # noqa

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from packaging.version import Version
+import geodatasets
 
 folium = pytest.importorskip("folium")
 branca = pytest.importorskip("branca")
@@ -22,6 +23,7 @@ class TestExplore:
         self.nybb = gpd.read_file(gpd.datasets.get_path("nybb"))
         self.world = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
         self.cities = gpd.read_file(gpd.datasets.get_path("naturalearth_cities"))
+        self.chicago = gpd.read_file(geodatasets.get_path("geoda.chicago_commpop"))
         self.world["range"] = range(len(self.world))
         self.missing = self.world.copy()
         np.random.seed(42)
@@ -172,12 +174,24 @@ class TestExplore:
         assert '"fillColor":"#21918c"' in out_str
         assert '"fillColor":"#5ec962"' in out_str
         assert '"fillColor":"#fde725"' in out_str
-        assert '"fillColor":"#440154"' in out_str
+
         # custom k
         m = self.world.explore(column="pop_est", scheme="naturalbreaks", k=3)
         out_str = self._fetch_map_string(m)
         assert '"fillColor":"#21918c"' in out_str
         assert '"fillColor":"#fde725"' in out_str
+        assert '"fillColor":"#440154"' in out_str
+
+        # UserDefined overriding default k
+        m = self.chicago.explore(
+            column="POP2010",
+            scheme="UserDefined",
+            classification_kwds={"bins": [25000, 50000, 75000, 100000]},
+        )
+        out_str = self._fetch_map_string(m)
+        assert '"fillColor":"#fde725"' in out_str
+        assert '"fillColor":"#35b779"' in out_str
+        assert '"fillColor":"#31688e"' in out_str
         assert '"fillColor":"#440154"' in out_str
 
     def test_categorical(self):


### PR DESCRIPTION
Closes #2922

We need to pass `k` from `binning`, not the one passed as an argument as `mapclassify.classify` may result in different number of bins (esp. with `UserDefined` scheme).