### PR TITLE
BUG: Fix crash on constructing gdf with colname `crs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New methods:
 New features and improvements:
 
 Bug fixes:
+- Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#2944)
 
 
 ## Version 0.13.2 (Jun 6, 2023)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1531,7 +1531,7 @@ individually so that features may have different properties
             try:
                 if self._geometry_column_name is not None:
                     crs = getattr(self, "crs", None)
-                else:  # don't use getattr, because a col 'crs' might exist
+                else:  # don't use getattr, because a col "crs" might exist
                     crs = None
                 value = _ensure_geometry(value, crs=crs)
                 if key == "geometry":

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1529,7 +1529,10 @@ individually so that features may have different properties
             if pd.api.types.is_scalar(value) or isinstance(value, BaseGeometry):
                 value = [value] * self.shape[0]
             try:
-                crs = getattr(self, "crs", None)
+                if self._geometry_column_name is not None:
+                    crs = getattr(self, "crs", None)
+                else:  # don't use getattr, because a col 'crs' might exist
+                    crs = None
                 value = _ensure_geometry(value, crs=crs)
                 if key == "geometry":
                     self._persist_old_default_geometry_colname()

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1469,3 +1469,11 @@ def test_geodataframe_crs_nonrepresentable_json(crs):
     ):
         gdf_geojson = json.loads(gdf.to_json())
     assert "crs" not in gdf_geojson
+
+
+def test_geodataframe_crs_colname():
+    # https://github.com/geopandas/geopandas/issues/2942
+    gdf = GeoDataFrame({"crs": [1], "geometry": [Point(1, 1)]})
+    assert gdf.crs is None
+    assert gdf["crs"].iloc[0] == 1
+    assert getattr(gdf, "crs") is None


### PR DESCRIPTION
Closes #2942 