### PR TITLE
BUG: Infer schema for np.int32 and pd.Int32Dtype columns properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Bug fixes:
 - ``assert_geodataframe_equal`` now handles GeoDataFrames with no active geometry (#2498)
 - Fix bug in `apply` with `axis=1` where the given user defined function returns nested 
   data in the geometry column (#2959)
+- Properly infer schema for np.int32 and pd.Int32Dtype columns (#2950)
 
 ## Version 0.13.2 (Jun 6, 2023)
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -626,7 +626,13 @@ def infer_schema(df):
     from collections import OrderedDict
 
     # TODO: test pandas string type and boolean type once released
-    types = {"Int32": "int32", "Int64": "int", "string": "str", "boolean": "bool"}
+    types = {
+        "Int32": "int32",
+        "int32": "int32",
+        "Int64": "int",
+        "string": "str",
+        "boolean": "bool",
+    }
 
     def convert_type(column, in_type):
         if in_type == object:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -626,7 +626,7 @@ def infer_schema(df):
     from collections import OrderedDict
 
     # TODO: test pandas string type and boolean type once released
-    types = {"Int64": "int", "string": "str", "boolean": "bool"}
+    types = {"Int32": "int32", "Int64": "int", "string": "str", "boolean": "bool"}
 
     def convert_type(column, in_type):
         if in_type == object:

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -377,7 +377,7 @@ def test_to_file_int32(tmpdir, df_points, engine, driver, ext):
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_to_file_int64(tmpdir, df_points, engine, driver, ext):
     skip_pyogrio_not_supported(engine)  # TODO
-    tempfilename = os.path.join(str(tmpdir), f"int32.{ext}")
+    tempfilename = os.path.join(str(tmpdir), f"int64.{ext}")
     geometry = df_points.geometry
     df = GeoDataFrame(geometry=geometry)
     df["data"] = pd.array([1, np.nan] * 5, dtype=pd.Int64Dtype())

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -364,7 +364,6 @@ def test_to_file_types(tmpdir, df_points, engine):
 
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs + [("OGR_GMT", ".gmt")])
 def test_to_file_int32(tmpdir, df_points, engine, driver, ext):
-    skip_pyogrio_not_supported(engine)  # TODO
     tempfilename = os.path.join(str(tmpdir), f"int32.{ext}")
     geometry = df_points.geometry
     df = GeoDataFrame(geometry=geometry)
@@ -372,11 +371,16 @@ def test_to_file_int32(tmpdir, df_points, engine, driver, ext):
     df.to_file(tempfilename, driver=driver, engine=engine)
     df_read = GeoDataFrame.from_file(tempfilename, driver=driver, engine=engine)
     assert_geodataframe_equal(df_read, df, check_dtype=False, check_like=True)
+    if engine == "pyogrio":
+        tempfilename2 = os.path.join(str(tmpdir), f"int32_2.{ext}")
+        df2 = df.dropna()
+        df2.to_file(tempfilename2, driver=driver, engine=engine)
+        df2_read = GeoDataFrame.from_file(tempfilename2, driver=driver, engine=engine)
+        assert df2_read["data"].dtype == "int32"
 
 
 @pytest.mark.parametrize("driver,ext", driver_ext_pairs)
 def test_to_file_int64(tmpdir, df_points, engine, driver, ext):
-    skip_pyogrio_not_supported(engine)  # TODO
     tempfilename = os.path.join(str(tmpdir), f"int64.{ext}")
     geometry = df_points.geometry
     df = GeoDataFrame(geometry=geometry)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -362,14 +362,27 @@ def test_to_file_types(tmpdir, df_points, engine):
     df.to_file(tempfilename, engine=engine)
 
 
-def test_to_file_int64(tmpdir, df_points, engine):
+@pytest.mark.parametrize("driver,ext", driver_ext_pairs + [("OGR_GMT", ".gmt")])
+def test_to_file_int32(tmpdir, df_points, engine, driver, ext):
     skip_pyogrio_not_supported(engine)  # TODO
-    tempfilename = os.path.join(str(tmpdir), "int64.shp")
+    tempfilename = os.path.join(str(tmpdir), f"int32.{ext}")
+    geometry = df_points.geometry
+    df = GeoDataFrame(geometry=geometry)
+    df["data"] = pd.array([1, np.nan] * 5, dtype=pd.Int32Dtype())
+    df.to_file(tempfilename, driver=driver, engine=engine)
+    df_read = GeoDataFrame.from_file(tempfilename, driver=driver, engine=engine)
+    assert_geodataframe_equal(df_read, df, check_dtype=False, check_like=True)
+
+
+@pytest.mark.parametrize("driver,ext", driver_ext_pairs)
+def test_to_file_int64(tmpdir, df_points, engine, driver, ext):
+    skip_pyogrio_not_supported(engine)  # TODO
+    tempfilename = os.path.join(str(tmpdir), f"int32.{ext}")
     geometry = df_points.geometry
     df = GeoDataFrame(geometry=geometry)
     df["data"] = pd.array([1, np.nan] * 5, dtype=pd.Int64Dtype())
-    df.to_file(tempfilename, engine=engine)
-    df_read = GeoDataFrame.from_file(tempfilename, engine=engine)
+    df.to_file(tempfilename, driver=driver, engine=engine)
+    df_read = GeoDataFrame.from_file(tempfilename, driver=driver, engine=engine)
     assert_geodataframe_equal(df_read, df, check_dtype=False, check_like=True)
 
 

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -10,6 +10,7 @@ from shapely.geometry import (
 )
 
 import pandas as pd
+import pytest
 import numpy as np
 from geopandas import GeoDataFrame
 from geopandas.io.file import infer_schema
@@ -278,8 +279,11 @@ def test_infer_schema_null_geometry_all():
     assert infer_schema(df) == {"geometry": "Unknown", "properties": OrderedDict()}
 
 
-def test_infer_schema_int32():
-    int32col = pd.array([1, np.nan], dtype=pd.Int32Dtype())
+@pytest.mark.parametrize(
+    "array_data,dtype", [([1, 2**31 - 1], np.int32), ([1, np.nan], pd.Int32Dtype())]
+)
+def test_infer_schema_int32(array_data, dtype):
+    int32col = pd.array(data=array_data, dtype=dtype)
     df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
     df["int32_column"] = int32col
 

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -278,12 +278,23 @@ def test_infer_schema_null_geometry_all():
     assert infer_schema(df) == {"geometry": "Unknown", "properties": OrderedDict()}
 
 
-def test_infer_schema_int64():
-    int64col = pd.array([1, np.nan], dtype=pd.Int64Dtype())
+def test_infer_schema_int32():
+    int32col = pd.array([1, np.nan], dtype=pd.Int32Dtype())
     df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
-    df["int64"] = int64col
+    df["int32_column"] = int32col
 
     assert infer_schema(df) == {
         "geometry": "Point",
-        "properties": OrderedDict([("int64", "int")]),
+        "properties": OrderedDict([("int32_column", "int32")]),
+    }
+
+
+def test_infer_schema_int64():
+    int64col = pd.array([1, np.nan], dtype=pd.Int64Dtype())
+    df = GeoDataFrame(geometry=[city_hall_entrance, city_hall_balcony])
+    df["int64_column"] = int64col
+
+    assert infer_schema(df) == {
+        "geometry": "Point",
+        "properties": OrderedDict([("int64_column", "int")]),
     }


### PR DESCRIPTION
Let columns of dtype `np.int32` (non-nullable) and `pandas.Int32Dtype()` (nullable) be inferred as int32 columns instead of int(64). Needed for the `OGR_GMT` driver.

Related:
- https://github.com/GenericMappingTools/pygmt/pull/2592
- https://github.com/geopandas/geopandas/issues/967#issuecomment-842999302

Similar PRs in the past:
- https://github.com/geopandas/geopandas/pull/2265
- https://github.com/geopandas/geopandas/pull/2464