### PR TITLE
Added integer_object_nulls parameter to table.to_pandas() call, since…

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -399,7 +399,7 @@ def _arrow_to_geopandas(table, metadata=None):
     """
     Helper function with main, shared logic for read_parquet/read_feather.
     """
-    df = table.to_pandas()
+    df = table.to_pandas(integer_object_nulls=True)
 
     metadata = metadata or table.schema.metadata
 


### PR DESCRIPTION
Added integer_object_nulls parameter to table.to_pandas() call, since table is of type pyarrow.parquet and can process columns this way.

Change was so small and covered by existing tests that no new ones were created.