### PR TITLE
DOC: broken pointpats link in docs

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -270,4 +270,4 @@ More specifically, whether the speedups are used or not is determined by:
 
 .. _packaging: https://packaging.pypa.io/en/latest/
 
-.. _pointpats: https://pointpats.readthedocs.io/en/latest/
+.. _pointpats: https://pysal.org/pointpats/


### PR DESCRIPTION
The GeoPandas docs installation page references the pointpats package and links to https://pointpats.readthedocs.io/en/latest/, which doesn't exist. This trivial PR fixes the link by pointing to the homepage https://pysal.org/pointpats/ instead.