### PR TITLE
Support plotting missing data for any list-like markersize argument

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -874,7 +874,7 @@ def plot_dataframe(
     points = expl_series[point_idx & np.invert(nan_idx)]
     subset = values[point_idx & np.invert(nan_idx)]
     if not points.empty:
-        if isinstance(markersize, np.ndarray):
+        if pd.api.types.is_list_like(markersize):
             markersize = np.take(markersize, multiindex, axis=0)
             markersize = markersize[point_idx & np.invert(nan_idx)]
         _plot_point_collection(


### PR DESCRIPTION
Previously, when plotting GeoDataFrames and NaNs or None values are in the column to be plotted and a numpy array of marker sizes is provided, the alignment between non-NaN column values and marker sizes is ensured by [masking](https://github.com/geopandas/geopandas/blob/b4b10313ab57bf2c55592a28fb99687c9a538fc2/geopandas/plotting.py#L879) the markersize array (as introduced in 6ac19052c811b39fea88b40625c69246f733709d). However, only numpy arrays are supported resulting in unexpectedly different behavior when passing another list-like markersize argument such as a pandas Series or plain list.

To ensure a consistent user experience, this PR adds support for any list-like markersize argument.

Snippet to reproduce the issue:
```
import numpy as np
import pandas as pd
import geopandas as gpd

markercolor = [1, np.nan, None, 4]
markersize = [100, 300, 900, 2700]

df = pd.DataFrame(data={'markercolor': markercolor})
geo = gpd.points_from_xy([1, 2, 3, 4], [1, 2, 3, 4])
gdf = gpd.GeoDataFrame(df, geometry=geo, crs='EPSG:3035')

gdf.plot(markersize=markersize)
gdf.plot(column='markercolor', markersize=markersize)
gdf.plot(column='markercolor', markersize=np.array(markersize))
gdf.plot(column='markercolor', markersize=pd.Series(markersize))
```