### PR TITLE
Don't overwrite user-supplied geometry dtype in `to_postgis`

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -419,10 +419,11 @@ def _write_postgis(
 
     # Build dtype with Geometry
     if dtype is not None:
-        dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
+        if geom_name not in dtype:
+            dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
     else:
         dtype = {geom_name: Geometry(geometry_type=geometry_type, srid=srid)}
-
+        
     # Convert LinearRing geometries to LineString
     if has_curve:
         gdf = _convert_linearring_to_linestring(gdf, geom_name)


### PR DESCRIPTION
When writing to PostGIS, I want the option to allow mixed geometries in a table. The current behaviour of `to_postgis` implicitly disallows this by setting the geometry type to whatever the first dataframe type is to populate that table.

This change simply looks to see if the user has defined the geometry dtype first. If not then it continues with the original behaviour of setting the geometry type to the dataframe, otherwise it leaves the dtype untouched and allows the user to specify the target table geometry type.


```python
df.to_postgis(
    con=engine, name=name, if_exists="append",
    dtype={"geometry": Geometry(geometry_type='GEOMETRY', srid=4326)})  # <-- This config persists on table creation and population
```
