### PR TITLE
Issue 2882 | Adding dwithin predicate for sindex and sjoin 

### DIFF
--- a/benchmarks/sjoin.py
+++ b/benchmarks/sjoin.py
@@ -7,7 +7,7 @@ import numpy as np
 
 class Bench:
     param_names = ["op"]
-    params = [("intersects", "contains", "within")]
+    params = [("intersects", "contains", "within", "dwithin")]
 
     def setup(self, *args):
         triangles = GeoSeries(
@@ -31,5 +31,5 @@ class Bench:
 
         self.df1, self.df2 = df1, df2
 
-    def time_sjoin(self, predicate):
-        sjoin(self.df1, self.df2, predicate=predicate)
+    def time_sjoin(self, predicate, distance=None):
+        sjoin(self.df1, self.df2, predicate=predicate, distance=distance)

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -67,9 +67,9 @@ class BaseSpatialIndex:
         (equivalent to the ``bounds`` property of a geometry); any Z values
         present in input geometries are ignored when querying the tree.
 
-        If a distance is provided, all tree geometries within the specified 
-        distance of the input geometry will be returned. The distance value 
-        is set to the same units as the GeoSeries CRS. 
+        If a distance is provided, all tree geometries within the specified
+        distance of the input geometry will be returned. The distance value
+        is set to the same units as the GeoSeries CRS.
 
         Any input geometry that is None or empty will never match geometries in
         the tree.
@@ -98,8 +98,8 @@ class BaseSpatialIndex:
             If False, no additional sorting is applied (results are often
             sorted but there is no guarantee).
         distance : float, optional
-            If a distance is provided, all tree geometries are queried 
-            within the specified distance of the input geometry.  
+            If a distance is provided, all tree geometries are queried
+            within the specified distance of the input geometry.
 
         Returns
         -------
@@ -529,7 +529,10 @@ if compat.HAS_RTREE:
         @doc(BaseSpatialIndex.query)
         def query(self, geometry, predicate=None, sort=False, distance=None):
             # handle invalid predicates
-            if predicate not in self.valid_query_predicates and not predicate=="dwithin":
+            if (
+                predicate not in self.valid_query_predicates
+                and not predicate == "dwithin"
+            ):
                 raise ValueError(
                     "Got `predicate` = `{}`, `predicate` must be one of {}".format(
                         predicate, self.valid_query_predicates
@@ -603,7 +606,7 @@ if compat.HAS_RTREE:
                     "covered_by",
                     "covers",
                     "contains_properly",
-                    "dwithin"
+                    "dwithin",
                 ):
                     # prepare this input geometry
                     geometry = prep(geometry)
@@ -779,7 +782,10 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
 
         @doc(BaseSpatialIndex.query)
         def query(self, geometry, predicate=None, sort=False, distance=None):
-            if predicate not in self.valid_query_predicates and not predicate == 'dwithin':
+            if (
+                predicate not in self.valid_query_predicates
+                and not predicate == "dwithin"
+            ):
                 raise ValueError(
                     "Got `predicate` = `{}`; ".format(predicate)
                     + "`predicate` must be one of {}".format(
@@ -794,12 +800,18 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
             geometry = self._as_geometry_array(geometry)
 
             if compat.USE_SHAPELY_20:
-                indices = self._tree.query(geometry, predicate=predicate, distance=distance)
+                indices = self._tree.query(
+                    geometry, predicate=predicate, distance=distance
+                )
             else:
                 if isinstance(geometry, np.ndarray):
-                    indices = self._tree.query_bulk(geometry, predicate=predicate, distance=distance)
+                    indices = self._tree.query_bulk(
+                        geometry, predicate=predicate, distance=distance
+                    )
                 else:
-                    indices = self._tree.query(geometry, predicate=predicate, distance=distance)
+                    indices = self._tree.query(
+                        geometry, predicate=predicate, distance=distance
+                    )
 
             if sort:
                 if indices.ndim == 1:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -786,6 +786,10 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
                         self.valid_query_predicates
                     )
                 )
+            if predicate == "dwithin" and not isinstance(distance, (int, float)):
+                raise ValueError(
+                    "Got `predicate` = `dwithin` but no `distance` was provided."
+                )
 
             geometry = self._as_geometry_array(geometry)
 
@@ -793,9 +797,9 @@ if compat.SHAPELY_GE_20 or compat.HAS_PYGEOS:
                 indices = self._tree.query(geometry, predicate=predicate, distance=distance)
             else:
                 if isinstance(geometry, np.ndarray):
-                    indices = self._tree.query_bulk(geometry, predicate=predicate)
+                    indices = self._tree.query_bulk(geometry, predicate=predicate, distance=distance)
                 else:
-                    indices = self._tree.query(geometry, predicate=predicate)
+                    indices = self._tree.query(geometry, predicate=predicate, distance=distance)
 
             if sort:
                 if indices.ndim == 1:

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -413,6 +413,14 @@ class TestPygeosInterface:
         test_geom = box(-1, -1, -0.5, -0.5)
         with pytest.raises(ValueError):
             self.df.sindex.query(test_geom, predicate="test")
+    
+    def test_dwithin_predicate(self):
+        """Testing basic function for dwithin predicate on sindex query"""
+        test_geom = GeoSeries(box(1, 2, 2, 3))
+        ind_box, ind_df = self.df.sindex.query(test_geom, predicate="dwithin", distance=3.)
+        assert_array_equal(ind_df, [0, 1, 2, 3, 4])
+        assert_array_equal(ind_box, np.zeros(5))
+
 
     @pytest.mark.parametrize(
         "sort, expected",

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -413,14 +413,15 @@ class TestPygeosInterface:
         test_geom = box(-1, -1, -0.5, -0.5)
         with pytest.raises(ValueError):
             self.df.sindex.query(test_geom, predicate="test")
-    
+
     def test_dwithin_predicate(self):
         """Testing basic function for dwithin predicate on sindex query"""
         test_geom = GeoSeries(box(1, 2, 2, 3))
-        ind_box, ind_df = self.df.sindex.query(test_geom, predicate="dwithin", distance=3.)
+        ind_box, ind_df = self.df.sindex.query(
+            test_geom, predicate="dwithin", distance=3.0
+        )
         assert_array_equal(ind_df, [0, 1, 2, 3, 4])
         assert_array_equal(ind_box, np.zeros(5))
-
 
     @pytest.mark.parametrize(
         "sort, expected",

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -16,6 +16,7 @@ def sjoin(
     predicate="intersects",
     lsuffix="left",
     rsuffix="right",
+    distance=None,
     **kwargs,
 ):
     """Spatial join of two GeoDataFrames.
@@ -43,6 +44,8 @@ def sjoin(
         Suffix to apply to overlapping column names (left GeoDataFrame).
     rsuffix : string, default 'right'
         Suffix to apply to overlapping column names (right GeoDataFrame).
+    distance : float, default None
+        Proximity distance to use to match geometry features.
 
     Examples
     --------
@@ -91,6 +94,8 @@ def sjoin(
     -----
     Every operation in GeoPandas is planar, i.e. the potential third
     dimension is not taken into account.
+
+    The "distance" parameter and search option requires GEOS >= 3.10.
     """
     if "op" in kwargs:
         op = kwargs.pop("op")

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -158,10 +158,8 @@ def _basic_checks(left_df, right_df, how, lsuffix, rsuffix, distance):
         raise ValueError(
             "'right_df' should be GeoDataFrame, got {}".format(type(right_df))
         )
-    if not distance is None and not isinstance(distance, float):
-        raise ValueError(
-            "'distance' should be float, got {}".format(type(distance))
-        )
+    if distance is not None and not isinstance(distance, float):
+        raise ValueError("'distance' should be float, got {}".format(type(distance)))
 
     allowed_hows = ["left", "right", "inner"]
     if how not in allowed_hows:
@@ -226,8 +224,9 @@ def _geom_predicate_query(left_df, right_df, predicate, distance=None):
             sindex = right_df.sindex
             input_geoms = left_df.geometry
     if sindex:
-        l_idx, r_idx = sindex.query(input_geoms, predicate=predicate, 
-                                    distance=distance, sort=False)
+        l_idx, r_idx = sindex.query(
+            input_geoms, predicate=predicate, distance=distance, sort=False
+        )
         indices = pd.DataFrame({"_key_left": l_idx, "_key_right": r_idx})
     else:
         # when sindex is empty / has no valid geometries


### PR DESCRIPTION
- Added support to geometry sindex attribute for query() function by predicate "dwithin".  
- Also enabled similar functionality for "sjoin" function, both with new optional parameter "distance".  
- Added "dwithin" predicate support with distance parameter for benchmark.sjoin.Bench.time_sjoin().
- Added pytest case for executing this function.  Can be executed with `pytest geopandas\tests\test_sindex.py -k test_dwithin_predicate`
- Did not add dwithin predicate to query_bulk() method due to deprecation.
- _PYGEOS_PREDICATES sourced from shapely.strtree.BinaryPredicates do NOT include value for dwithin predicate, so predicate check includes additional comparison operation against string "dwithin", along with other keys from BinaryPredicates (overlaps, contains, etc.).

[SOURCE ISSUE](https://github.com/geopandas/geopandas/issues/2882)
