### PR TITLE
COMPAT: add fillna copy keyword for pandas 2.1

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -21,7 +21,7 @@ PANDAS_GE_13 = Version(pd.__version__) >= Version("1.3.0")
 PANDAS_GE_14 = Version(pd.__version__) >= Version("1.4.0rc0")
 PANDAS_GE_15 = Version(pd.__version__) >= Version("1.5.0")
 PANDAS_GE_20 = Version(pd.__version__) >= Version("2.0.0")
-PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0.dev0")
+PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0")
 
 
 # -----------------------------------------------------------------------------

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1090,6 +1090,10 @@ class GeometryArray(ExtensionArray):
             maximum number of entries along the entire axis where NaNs will be
             filled.
 
+        copy : bool, default True
+            Whether to make a copy of the data before filling. If False, then
+            the original should be modified and no new memory should be allocated.
+
         Returns
         -------
         GeometryArray

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1066,7 +1066,7 @@ class GeometryArray(ExtensionArray):
         self._data[idx] = value_arr
         return self
 
-    def fillna(self, value=None, method=None, limit=None):
+    def fillna(self, value=None, method=None, limit=None, copy=True):
         """
         Fill NA values with geometry (or geometries) or using the specified method.
 
@@ -1098,7 +1098,10 @@ class GeometryArray(ExtensionArray):
             raise NotImplementedError("fillna with a method is not yet supported")
 
         mask = self.isna()
-        new_values = self.copy()
+        if copy:
+            new_values = self.copy()
+        else:
+            new_values = self
         return new_values._fill(mask, value) if mask.any() else new_values
 
     def astype(self, dtype, copy=True):

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -433,6 +433,14 @@ def test_fillna_series(s):
     assert_geoseries_equal(res, s2)
 
 
+def test_fillna_inplace(s):
+    s2 = GeoSeries([Point(0, 0), None, Point(2, 2)])
+    arr = s2.array
+    s2.fillna(Point(1, 1), inplace=True)
+    assert_geoseries_equal(s2, s)
+    assert s2.array is arr
+
+
 def test_dropna():
     s2 = GeoSeries([Point(0, 0), None, Point(2, 2)])
     res = s2.dropna()

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -438,7 +438,9 @@ def test_fillna_inplace(s):
     arr = s2.array
     s2.fillna(Point(1, 1), inplace=True)
     assert_geoseries_equal(s2, s)
-    assert s2.array is arr
+    if compat.PANDAS_GE_21:
+        # starting from pandas 2.1, there is support to do this actually inplace
+        assert s2.array is arr
 
 
 def test_dropna():


### PR DESCRIPTION
Fixing some of the warnings we have on the dev build:

```
 geopandas/tests/test_extension_array.py::TestMissing::test_fillna_series
  /home/runner/work/geopandas/geopandas/geopandas/tests/test_extension_array.py:372: FutureWarning: ExtensionArray.fillna added a 'copy' keyword in pandas 2.1.0. In a future version, ExtensionArray subclasses will need to implement this keyword or an exception will be raised. In the interim, the keyword is ignored by GeometryArray.
    result = ser.fillna(fill_value)
```

I have to check if this is properly tested in the upstream tests we inherit (maybe not since they were not failing before, only warning)