### PR TITLE
BUG: Avoid numpy invalid warning in Hilbert distance for points with constant x or y values

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -131,7 +131,7 @@ def data_missing_for_sorting():
     This should be three items [B, NA, A] with
     A < B and NA missing.
     """
-    return from_shapely([Point(0, 1), None, Point(0, 0)])
+    return from_shapely([Point(1, 2), None, Point(0, 0)])
 
 
 @pytest.fixture

--- a/geopandas/tools/hilbert_curve.py
+++ b/geopandas/tools/hilbert_curve.py
@@ -103,6 +103,8 @@ def _continuous_to_discrete(vals, val_range, n):
 
     """
     width = val_range[1] - val_range[0]
+    if width == 0:
+        return np.zeros_like(vals, dtype=np.uint32)
     res = (vals - val_range[0]) * (n / width)
 
     np.clip(res, 0, n, out=res)

--- a/geopandas/tools/tests/test_hilbert_curve.py
+++ b/geopandas/tools/tests/test_hilbert_curve.py
@@ -1,3 +1,4 @@
+import numpy as np
 from shapely.geometry import Point
 from shapely.wkt import loads
 
@@ -63,3 +64,12 @@ def test_empty(geoseries_points, empty):
         ValueError, match="cannot be computed on a GeoSeries with empty"
     ):
         s.hilbert_distance()
+
+
+def test_zero_width():
+    # special case of all points on the same line -> avoid warnings because
+    # of division by 0 and introducing NaN
+    s = geopandas.GeoSeries([Point(0, 0), Point(0, 2), Point(0, 1)])
+    with np.errstate(all="raise"):
+        result = s.hilbert_distance()
+    assert np.array(result).argsort().tolist() == [0, 2, 1]


### PR DESCRIPTION
It's a bit a specific corner case, but so when having all your center points for the Hilbert curve calculation on a horizontal or vertical line (i.e. with constant x values or constant y values), we would do a division by zero (from the range of x or y values).

I added a check for a width of zero to avoid this warning. 
But also updated the extension array test to use different data, to avoid this brittleness in the tests we inherit from pandas, and added a dedicated test.

This should fix the current failure for `test_extension_array.py::TestMethods::test_argsort_missing` (which was failing because pandas upstream added a `assert_produces_warning` that isn't expecting additional warnings from numpy).