### PR TITLE
TST: skip astype(object) check in test for pandas 2.1.0

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -1,4 +1,5 @@
 import os
+from packaging.version import Version
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -249,8 +250,10 @@ def test_astype(s, df):
     assert s.astype(str)[0] == "POINT (0 0)"
 
     res = s.astype(object)
-    assert isinstance(res, pd.Series) and not isinstance(res, GeoSeries)
-    assert res.dtype == object
+    if not Version(pd.__version__) == Version("2.1.0"):
+        # https://github.com/geopandas/geopandas/issues/2948 - bug in pandas 2.1.0
+        assert isinstance(res, pd.Series) and not isinstance(res, GeoSeries)
+        assert res.dtype == object
 
     df = df.rename_geometry("geom_list")
 


### PR DESCRIPTION
Failure with latest pandas release, as described in https://github.com/geopandas/geopandas/issues/2948. I am skipping that part of the test just for pandas 2.1.0, assuming we will fix it by pandas 2.1.1.