### PR TITLE
CI: use the new nightly repo

### DIFF
--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -24,11 +24,11 @@ dependencies:
     - geopy
     - mapclassify>=2.4.0
     # dev versions of packages
-    - --pre --extra-index https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
     - numpy
     - fiona
-    - git+https://github.com/pandas-dev/pandas.git@main
-    - git+https://github.com/matplotlib/matplotlib.git@main
+    - pandas
+    - matplotlib
     - git+https://github.com/shapely/shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@main

--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.10
   - cython
   # required
+  - numpy
   - pyproj
   - geos
   - packaging
@@ -24,7 +25,6 @@ dependencies:
     - mapclassify>=2.4.0
     # dev versions of packages
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
-    - numpy
     - fiona
     - pandas
     - matplotlib

--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -18,7 +18,6 @@ dependencies:
   #- geopy
   - SQLalchemy<2
   - libspatialite
-  - pyarrow
   - pip
   - pip:
     - geopy
@@ -29,6 +28,7 @@ dependencies:
     - fiona
     - pandas
     - matplotlib
+    - pyarrow
     - git+https://github.com/shapely/shapely.git@main
     - git+https://github.com/pygeos/pygeos.git@master
     - git+https://github.com/python-visualization/folium.git@main

--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -23,7 +23,7 @@ dependencies:
     - geopy
     - mapclassify>=2.4.0
     # dev versions of packages
-    - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+    - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
     - numpy
     - fiona
     - pandas


### PR DESCRIPTION
Nightlies of core scientific python projects are now on https://pypi.anaconda.org/scientific-python-nightly-wheels not on https://pypi.anaconda.org/scipy-wheels-nightly/. Changing the repository and switching pandas and matplotlib to install from that nightly wheel rather than building from source.