### PR TITLE
BUG: fix pygeos compat for concave hull

### DIFF
--- a/geopandas/_vectorized.py
+++ b/geopandas/_vectorized.py
@@ -620,7 +620,7 @@ def concave_hull(data, **kwargs):
             "thus using Shapely and not PyGEOS for calculating the concave_hull.",
             stacklevel=4,
         )
-        return shapely.concave_hull(to_shapely(data), **kwargs)
+        return pygeos.from_shapely(shapely.concave_hull(to_shapely(data), **kwargs))
     else:
         raise NotImplementedError(
             f"shapely >= 2.0 is required, "


### PR DESCRIPTION
Just adding in the fact that when we use shapely over pygeos when pygeos is the selected engine, we need to convert the result back to pygeos (as originally noted here). This will all go away in 1.0 anyway, but still a bug for now.
https://github.com/geopandas/geopandas/pull/2940#discussion_r1273415232
