### PR TITLE
COMPAT: Remove base.equals override

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -4105,34 +4105,6 @@ GeometryCollection
         """
         return _CoordinateIndexer(self)
 
-    def equals(self, other):
-        """
-        Test whether two objects contain the same elements.
-
-        This function allows two GeoSeries or GeoDataFrames to be compared
-        against each other to see if they have the same shape and elements.
-        Missing values in the same location are considered equal. The
-        row/column index do not need to have the same type (as long as the
-        values are still considered equal), but the dtypes of the respective
-        columns must be the same.
-
-        Parameters
-        ----------
-        other : GeoSeries or GeoDataFrame
-            The other GeoSeries or GeoDataFrame to be compared with the first.
-
-        Returns
-        -------
-        bool
-            True if all elements are the same in both objects, False
-            otherwise.
-        """
-        # we override this because pandas is using `self._constructor` in the
-        # isinstance check (https://github.com/geopandas/geopandas/issues/1420)
-        if not isinstance(other, type(self)):
-            return False
-        return self._data.equals(other._data)
-
     def get_coordinates(self, include_z=False, ignore_index=False, index_parts=False):
         """Gets coordinates from a :class:`GeoSeries` as a :class:`~pandas.DataFrame` of
         floats.


### PR DESCRIPTION
Our custom equals implementation uses `_data` which is deprecated and triggers a warning on pandas >=2.1, but it looks like we only have this to work around a pandas issue. Just running on CI to see what removing this does.

Seems not to cause any issues.