### PR TITLE
DOC: remove Stamen tiles from docs

### DIFF
--- a/doc/source/docs/user_guide/interactive_mapping.ipynb
+++ b/doc/source/docs/user_guide/interactive_mapping.ipynb
@@ -121,7 +121,7 @@
                 "    name=\"groceries\",  # name of the layer in the map\n",
                 ")\n",
                 "\n",
-                "folium.TileLayer(\"Stamen Toner\", show=False).add_to(\n",
+                "folium.TileLayer(\"OpenStreetMap.HOT\", show=False).add_to(\n",
                 "    m\n",
                 ")  # use folium to add alternative tiles\n",
                 "folium.LayerControl().add_to(m)  # use folium to add layer control\n",

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -10,7 +10,7 @@
     "This example shows how you can add a background basemap to plots created\n",
     "with the geopandas ``.plot()`` method. This makes use of the\n",
     "[contextily](https://github.com/geopandas/contextily) package to retrieve\n",
-    "web map tiles from several sources (OpenStreetMap, Stamen). Also have a\n",
+    "web map tiles from several sources (OpenStreetMap, CartoDB). Also have a\n",
     "look at contextily's \n",
     "[introduction guide](https://contextily.readthedocs.io/en/latest/intro_guide.html#Using-transparent-layers)\n",
     "for possible new features not covered here.\n"

--- a/doc/source/gallery/plotting_with_folium.ipynb
+++ b/doc/source/gallery/plotting_with_folium.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
    "metadata": {},
    "source": [
     "## Create Folium map\n",
-    "Folium has a number of built-in tilesets from OpenStreetMap, Mapbox, and Stamen. For example:"
+    "Folium has a number of built-in tilesets from OpenStreetMap, Mapbox, and CartoDB. For example:"
    ]
   },
   {
@@ -103,8 +103,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Stamen Terrain\n",
-    "map = folium.Map(location=[13.406, 80.110], tiles=\"Stamen Terrain\", zoom_start=9)\n",
+    "# CartoDB Positron\n",
+    "map = folium.Map(location=[13.406, 80.110], tiles=\"CartoDB Positron\", zoom_start=9)\n",
     "map"
    ]
   },
@@ -120,34 +120,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Stamen Toner\n",
-    "map = folium.Map(location=[13.406, 80.110], tiles=\"Stamen Toner\", zoom_start=9)\n",
-    "map"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This example uses the Stamen Terrain map layer to visualize the volcano terrain."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use terrain map layer to see volcano terrain\n",
-    "map = folium.Map(location=[4, 10], tiles=\"Stamen Terrain\", zoom_start=3)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -157,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Stamen is [deprecating](https://stamen.com/here-comes-the-future-of-stamen-maps/) they're tiles. Removing their usage from our docs. 

They are further mention in `explore` as a reference to folium. There I would wait for https://github.com/python-visualization/folium/issues/1803 to be resolved.

The same issue is in the notebook describing contextily, where we should first resolve https://github.com/geopandas/contextily/issues/220.