### PR TITLE
RLS: prepare changelog for 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Development version
+## Version 0.14 (Sep 14, 2023)
 
 GeoPandas will use Shapely 2.0 by default instead of PyGEOS when both Shapely >= 2.0 and
 PyGEOS are installed.  PyGEOS will continue to be used by default when PyGEOS is
 installed alongside Shapely < 2.0.  Support for PyGEOS and Shapely < 2.0 will be removed
-in GeoPandas 1.0.
+in GeoPandas 1.0. (#2999)
 
 API changes:
 
@@ -13,17 +13,17 @@ API changes:
 
 New methods:
 
-- Added ``remove_repeated_points`` method from shapely to GeoSeries/GeoDataframe (#2940).
-- Added ``frechet_distance()`` method from shapely to GeoSeries/GeoDataframe (#2929).
-- Added ``segmentize`` method from shapely to GeoSeries/GeoDataFrame (#2910).
-- Added ``extract_unique_points`` method from shapely to GeoSeries/GeoDataframe (#2915).
-- Added ``hausdorff_distance`` method from shapely to GeoSeries/GeoDataframe (#2909).
-- Added ``delaunay_triangles`` method from shapely to GeoSeries/GeoDataframe (#2907).
 - Added ``concave_hull`` method from shapely to GeoSeries/GeoDataframe (#2903).
-- Added ``offset_curve`` method from shapely to GeoSeries/GeoDataframe (#2902).
-- Added ``shortest_line`` method from shapely to GeoSeries/GeoDataframe (#2960).
+- Added ``delaunay_triangles`` method from shapely to GeoSeries/GeoDataframe (#2907).
+- Added ``extract_unique_points`` method from shapely to GeoSeries/GeoDataframe (#2915).
+- Added ``frechet_distance()`` method from shapely to GeoSeries/GeoDataframe (#2929).
+- Added ``hausdorff_distance`` method from shapely to GeoSeries/GeoDataframe (#2909).
 - Added ``minimum_rotated_rectangle`` method from shapely to GeoSeries/GeoDataframe (#2541).
+- Added ``offset_curve`` method from shapely to GeoSeries/GeoDataframe (#2902).
+- Added ``remove_repeated_points`` method from shapely to GeoSeries/GeoDataframe (#2940).
 - Added ``reverse`` method from shapely to GeoSeries/GeoDataframe (#2988).
+- Added ``segmentize`` method from shapely to GeoSeries/GeoDataFrame (#2910).
+- Added ``shortest_line`` method from shapely to GeoSeries/GeoDataframe (#2960).
 
 New features and improvements:
 
@@ -33,13 +33,12 @@ New features and improvements:
 
 Bug fixes:
 
-- Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#2944)
-
+- Fix ambiguous error when GeoDataFrame is initialized with a column called ``"crs"`` (#2944)
 - Fix a color assignment in ``explore`` when using ``UserDefined`` bins (#2923)
-- ``assert_geodataframe_equal`` now handles GeoDataFrames with no active geometry (#2498)
 - Fix bug in `apply` with `axis=1` where the given user defined function returns nested
   data in the geometry column (#2959)
-- Properly infer schema for np.int32 and pd.Int32Dtype columns (#2950)
+- Properly infer schema for ``np.int32`` and ``pd.Int32Dtype`` columns (#2950)
+- ``assert_geodataframe_equal`` now handles GeoDataFrames with no active geometry (#2498)
 
 Notes on (optional) dependencies:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.14 (Sep 14, 2023)
+## Version 0.14 (Sep 15, 2023)
 
 GeoPandas will use Shapely 2.0 by default instead of PyGEOS when both Shapely >= 2.0 and
 PyGEOS are installed.  PyGEOS will continue to be used by default when PyGEOS is
@@ -48,7 +48,8 @@ Notes on (optional) dependencies:
   matplotlib 3.5.0 (#3001)
 
 Deprecations and compatibility notes:
- - `geom_almost_equals()` methods have been deprecated and  
+
+- `geom_almost_equals()` methods have been deprecated and
    `geom_equals_exact()` should be used instead (#2604).
 
 ## Version 0.13.2 (Jun 6, 2023)


### PR DESCRIPTION
I just sorted the list of changes, added missing PR number and fixed formatting. I also went through the list of commits since 0.13.2 and it seems that we have it all included (when relevant).