### PR TITLE
CI: include Python 3.12 in the matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,7 @@ jobs:
           - ci/envs/310-pd20-conda-forge.yaml
           - ci/envs/310-latest-conda-forge.yaml
           - ci/envs/311-latest-conda-forge.yaml
+          - ci/envs/312-latest-conda-forge.yaml
         include:
           - env: ci/envs/39-latest-conda-forge_no_fiona.yaml
             os: macos-latest

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -16,7 +16,7 @@ dependencies:
   - fsspec
   # optional
   - pyogrio
-  - matplotlib
+  # - matplotlib
   - mapclassify
   - folium
   - xyzservices
@@ -33,3 +33,6 @@ dependencies:
   - pyarrow
   # doctest testing
   - pytest-doctestplus
+  - pip
+  - pip:
+    - matplotlib

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -1,0 +1,35 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  # required
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  - packaging
+  # testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - fsspec
+  # optional
+  - pyogrio
+  - matplotlib
+  - mapclassify
+  - folium
+  - xyzservices
+  - scipy
+  - geopy
+  - pointpats
+  - geodatasets
+  # installed in tests.yaml, because not available on windows
+  # - postgis
+  - SQLalchemy>=2
+  - psycopg2
+  - libspatialite
+  - geoalchemy2
+  - pyarrow
+  # doctest testing
+  - pytest-doctestplus

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -22,7 +22,7 @@ dependencies:
   - xyzservices
   - scipy
   - geopy
-  - pointpats
+  # - pointpats
   - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
@@ -36,3 +36,4 @@ dependencies:
   - pip
   - pip:
     - matplotlib
+    - pointpats

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -26,10 +26,10 @@ dependencies:
   - geodatasets
   # installed in tests.yaml, because not available on windows
   # - postgis
-  - SQLalchemy>=2
-  - psycopg2
-  - libspatialite
-  - geoalchemy2
+  # - SQLalchemy>=2
+  # - psycopg2
+  # - libspatialite
+  # - geoalchemy2
   - pyarrow
   # doctest testing
   - pytest-doctestplus

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -24,15 +24,11 @@ dependencies:
   - geopy
   # - pointpats
   - geodatasets
-  # installed in tests.yaml, because not available on windows
-  # - postgis
   # - SQLalchemy>=2
   # - psycopg2
   # - libspatialite
   # - geoalchemy2
   - pyarrow
-  # doctest testing
-  - pytest-doctestplus
   - pip
   - pip:
     - matplotlib


### PR DESCRIPTION
I think that matplotlib is breaking it but let's give it a go and get it temporarily from pip if needed.