### PR TITLE
COMPAT: ensure GeoSeries fallback to Series for construction from mgr

### DIFF
--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -152,8 +152,6 @@ class GeoSeries(GeoPandasBase, Series):
 
     """
 
-    _metadata = ["name"]
-
     def __init__(self, data=None, index=None, crs: Optional[Any] = None, **kwargs):
         if hasattr(data, "crs") and crs:
             if not data.crs:
@@ -618,6 +616,14 @@ class GeoSeries(GeoPandasBase, Series):
     @property
     def _constructor(self):
         return _geoseries_constructor_with_fallback
+
+    def _constructor_from_mgr(self, mgr, axes):
+        assert isinstance(mgr, SingleBlockManager)
+
+        if not isinstance(mgr.blocks[0].dtype, GeometryDtype):
+            return Series._from_mgr(mgr, axes)
+
+        return GeoSeries._from_mgr(mgr, axes)
 
     @property
     def _constructor_expanddim(self):


### PR DESCRIPTION
Addresses https://github.com/geopandas/geopandas/issues/2948

In recent pandas, internal construction from a Manager object no longer goes through `_constructor`, but there is now a `_constructor_from_mgr`. Overriding this so we can implement our "_geoseries_constructor_with_fallback" logic that we have for `_constructor` there as well.

Our `GeoSeries._constructor` is `_geoseries_constructor_with_fallback`, which does:

https://github.com/geopandas/geopandas/blob/49c208ab95fa7cebd8553cba264ea3dc65e272fd/geopandas/geoseries.py#L40-L51

and currently the `GeoSeries(..)` init will raise that TypeError if being passed a manager that is not of geometry dtype.
