### PR TITLE
BUG: fix interiors when no interior is present

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -590,7 +590,9 @@ class GeometryArray(ExtensionArray):
                 "geometry types, None is returned.",
                 stacklevel=2,
             )
-        data = np.array(inner_rings, dtype=object)
+        # need to allocate empty first in case of all empty lists in inner_rings
+        data = np.empty(len(inner_rings), dtype=object)
+        data[:] = inner_rings
         return data
 
     def remove_repeated_points(self, tolerance=0.0):

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -964,6 +964,10 @@ class TestGeomMethods:
         expected = LinearRing(self.inner_sq.boundary)
         assert original.interiors[1][0].equals(expected)
 
+        no_interiors = GeoSeries([self.t1, self.sq])
+        assert no_interiors.interiors[0] == []
+        assert no_interiors.interiors[1] == []
+
     def test_interpolate(self):
         expected = GeoSeries([Point(0.5, 1.0), Point(0.75, 1.0)])
         self._test_binary_topological(


### PR DESCRIPTION
When doing #3013, when @m-richards pointed out that we may need to keep the allocation of an empty array and then its population, we thought we don't since we thought it is shapely 1.8 related. Well, it was not :D. When there is no actual interior, this is now failing on main.

Fixed. No need for changelog as it fixed unreleased #3013.