### PR TITLE
Fix non CRS incompatibility when saving to postgis

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -411,9 +411,7 @@ def _write_postgis(
 
     # Replace SRID from -1 (geopandas pattern) to 0 (PostGIS pattern)
     if srid == -1:
-        gdf[geom_name] = gdf[geom_name].apply(
-            lambda x: x.replace('SRID=-1', 'SRID=0')
-        )
+        gdf[geom_name] = gdf[geom_name].apply(lambda x: x.replace("SRID=-1", "SRID=0"))
 
     if schema is not None:
         schema_name = schema

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -393,6 +393,10 @@ def _write_postgis(
     # Get srid
     srid = _get_srid_from_crs(gdf)
 
+    # Replace SRID from -1 (geoalchemy pattern) to 0 (PostGIS pattern)
+    if srid == -1:
+        srid = 0
+
     # Get geometry type and info whether data contains LinearRing.
     geometry_type, has_curve = _get_geometry_type(gdf)
 
@@ -408,10 +412,6 @@ def _write_postgis(
 
     # Convert geometries to EWKB
     gdf = _convert_to_ewkb(gdf, geom_name, srid)
-
-    # Replace SRID from -1 (geopandas pattern) to 0 (PostGIS pattern)
-    if srid == -1:
-        gdf[geom_name] = gdf[geom_name].apply(lambda x: x.replace("SRID=-1", "SRID=0"))
 
     if schema is not None:
         schema_name = schema

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -467,7 +467,6 @@ class TestIO:
         df_nybb.crs = None
         with pytest.warns(UserWarning, match="Could not parse CRS from the GeoDataF"):
             write_postgis(df_nybb, con=engine, name=table, if_exists="replace")
-            write_postgis(df_nybb, con=engine, name=table, if_exists="append")
         # Validate that srid is -1
         sql = text(
             "SELECT Find_SRID('{schema}', '{table}', '{geom_col}');".format(
@@ -479,6 +478,10 @@ class TestIO:
         with engine.connect() as conn:
             target_srid = conn.execute(sql).fetchone()[0]
         assert target_srid == 0, "SRID should be 0, found %s" % target_srid
+
+        # Testing when append table
+        with pytest.warns(UserWarning, match="Could not parse CRS from the GeoDataF"):
+            write_postgis(df_nybb, con=engine, name=table, if_exists="append")
 
     def test_write_postgis_with_esri_authority(self, engine_postgis, df_nybb):
         """

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -15,8 +15,7 @@ import geopandas._compat as compat
 from geopandas import GeoDataFrame, read_file, read_postgis
 from geopandas.io.sql import _get_conn as get_conn
 from geopandas.io.sql import _write_postgis as write_postgis
-from geopandas.tests.util import (create_postgis, create_spatialite,
-                                  validate_boro_df)
+from geopandas.tests.util import create_postgis, create_spatialite, validate_boro_df
 
 try:
     from sqlalchemy import text


### PR DESCRIPTION
Before this fix, when the user tries to write a non CRS geometry on a PostGIS database, the action fails because the SRID was converted to -1 (Geopandas pattern), not 0 (PostGIS pattern).

Well, one important observation: I also think that the test related to the last commit on this issue was not executed, because the test was correctly implemented and it must fail on the previous implementation.