### PR TITLE
CI: install whole 3.12 env from conda-forge

### DIFF
--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -16,20 +16,16 @@ dependencies:
   - fsspec
   # optional
   - pyogrio
-  # - matplotlib
+  - matplotlib
   - mapclassify
   - folium
   - xyzservices
   - scipy
   - geopy
-  # - pointpats
+  - pointpats
   - geodatasets
   # - SQLalchemy>=2
   # - psycopg2
   # - libspatialite
   # - geoalchemy2
   - pyarrow
-  - pip
-  - pip:
-    - matplotlib
-    - pointpats


### PR DESCRIPTION
No need for pip install of pointpats and matplotlib anymore (at least on a macOS).