### PR TITLE
API: Fiona engine: return a Pandas DataFrame when no geometry available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ New methods:
 
 - Added ``minimum_clearance`` method from shapely to GeoSeries/GeoDataframe (#2989).
 
+API changes:
+- reading a data source that does not have a geometry field using ``read_file``
+  now returns a Pandas DataFrame instead of a GeoDataFrame with an empty
+  ``geometry`` column.
+
 Bug fixes:
-- Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a 
+- Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a
   `GeoDataFrame` when the `suffixes` argument is applied to the active
   geometry column (#2933).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ New methods:
 
 - Added ``minimum_clearance`` method from shapely to GeoSeries/GeoDataframe (#2989).
 
-API changes:
+Potentially breaking changes:
 - reading a data source that does not have a geometry field using ``read_file``
   now returns a Pandas DataFrame instead of a GeoDataFrame with an empty
   ``geometry`` column.

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -387,7 +387,10 @@ def _read_file_fiona(
             datetime_fields = [
                 k for (k, v) in features.schema["properties"].items() if v == "datetime"
             ]
-            if kwargs.get("ignore_geometry", False):
+            if (
+                kwargs.get("ignore_geometry", False)
+                or features.schema["geometry"] == "None"
+            ):
                 df = pd.DataFrame(
                     [record["properties"] for record in f_filt], columns=columns
                 )

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -805,7 +805,6 @@ def test_read_file_missing_geometry(tmpdir, engine):
     expected = pd.DataFrame(
         {"col1": np.array([1, 2, 3], dtype="int64"), "col2": ["a", "b", "c"]}
     )
-    print(expected.dtypes)
     expected.to_csv(filename, index=False)
 
     df = geopandas.read_file(filename, engine=engine)

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -11,7 +11,7 @@ import pytest
 import pytz
 from packaging.version import Version
 from pandas.api.types import is_datetime64_any_dtype
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_series_equal, assert_frame_equal
 from shapely.geometry import Point, Polygon, box
 
 import geopandas
@@ -797,6 +797,25 @@ def test_read_file__ignore_all_fields(engine):
         engine="fiona",
     )
     assert gdf.columns.tolist() == ["geometry"]
+
+
+def test_read_file_missing_geometry(tmpdir, engine):
+    filename = str(tmpdir / "test.csv")
+
+    expected = pd.DataFrame(
+        {"col1": np.array([1, 2, 3], dtype="int64"), "col2": ["a", "b", "c"]}
+    )
+    print(expected.dtypes)
+    expected.to_csv(filename, index=False)
+
+    df = geopandas.read_file(filename, engine=engine)
+    # both engines read integers as strings; force back to original type
+    df["col1"] = df["col1"].astype("int64")
+
+    assert isinstance(df, pd.DataFrame)
+    assert not isinstance(df, geopandas.GeoDataFrame)
+
+    assert_frame_equal(df, expected)
 
 
 def test_read_file__where_filter(engine):


### PR DESCRIPTION
Resolves #3055 

This makes reading a data source that lacks geometry the same between the Fiona and Pyogrio engines by returning a Pandas DataFrame instead of a GeoDataFrame; this is also the same as the result when using the `ignore_geometry` keyword.

I have this listed as an API change; should this be a potentially-breaking change instead?