### PR TITLE
BUG: Overlay regression from incorrect refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.14.2 (Nov xx, 2023)
+ - Fix regression in `overlay` where using `buffer(0)` instead of `make_valid` internally
+   produced invalid results (#3074).
+
 ## Version 0.14.1 (Nov 11, 2023)
 
 - The Parquet and Feather IO functions now support the latest 1.0.0 version

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -4,7 +4,6 @@ from functools import reduce
 import numpy as np
 import pandas as pd
 
-from geopandas import _compat as compat
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import _check_crs, _crs_mismatch_warn
 
@@ -94,10 +93,8 @@ def _overlay_difference(df1, df2):
         new_g.append(new)
     differences = GeoSeries(new_g, index=df1.index, crs=df1.crs)
     poly_ix = differences.geom_type.isin(["Polygon", "MultiPolygon"])
-    if compat.USE_PYGEOS:
-        differences.loc[poly_ix] = differences[poly_ix].make_valid()
-    else:
-        differences.loc[poly_ix] = differences[poly_ix].buffer(0)
+    differences.loc[poly_ix] = differences[poly_ix].make_valid()
+
     geom_diff = differences[~differences.is_empty].copy()
     dfdiff = df1[~differences.is_empty].copy()
     dfdiff[dfdiff._geometry_column_name] = geom_diff


### PR DESCRIPTION
Closes #3069

I suppose ideally this would have a regression test as part of the commit, but I'm not exactly sure how to produce some minimal test where the `buffer(0)` vs `make_valid` difference is present

(and I suppose the changelog for 0.14.2 needs to be added to main as well, I'm not sure how I should have done this best, since the regression is already solved on main)