### PR TITLE
BUG: fix getting row as Series for CoW

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,14 +83,14 @@ jobs:
           micromamba list
 
       - name: Test
-        continue-on-error: matrix.dev
+        continue-on-error: ${{ matrix.dev }}
         env:
           PANDAS_COPY_ON_WRITE: ${{ matrix.pandas_copy_on_write || '0' }}
         run: |
           pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with Copy-on-Write
-        if: matrix.dev
+        if: ${{ matrix.dev }}
         env:
           PANDAS_COPY_ON_WRITE: '1'
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,7 @@ jobs:
           micromamba list
 
       - name: Test
+        continue-on-error: matrix.dev
         env:
           PANDAS_COPY_ON_WRITE: ${{ matrix.pandas_copy_on_write || '0' }}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,6 +88,13 @@ jobs:
         run: |
           pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
+      - name: Test with Copy-on-Write
+        if: matrix.dev
+        env:
+          PANDAS_COPY_ON_WRITE: '1'
+        run: |
+          pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+
       - name: Test with PostGIS
         if: (contains(matrix.env, '310-pd20-conda-forge.yaml') || contains(matrix.env, '311-latest-conda-forge.yaml'))
           && contains(matrix.os, 'ubuntu')

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,14 +83,13 @@ jobs:
           micromamba list
 
       - name: Test
-        continue-on-error: ${{ matrix.dev }}
         env:
           PANDAS_COPY_ON_WRITE: ${{ matrix.pandas_copy_on_write || '0' }}
         run: |
           pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
       - name: Test with Copy-on-Write
-        if: ${{ matrix.dev }}
+        if: ${{ always() && matrix.dev }}
         env:
           PANDAS_COPY_ON_WRITE: '1'
         run: |

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1612,7 +1612,7 @@ individually so that features may have different properties
               checking the identity of the index)
             """
             srs = pd.Series(*args, **kwargs)
-            is_row_proxy = srs.index is self.columns
+            is_row_proxy = srs.index.is_(self.columns)
             if is_geometry_type(srs) and not is_row_proxy:
                 srs = GeoSeries(srs)
             return srs


### PR DESCRIPTION
With CoW enabled, the index is not necessarily an identical object (in python `is` sence), but it's still identical from pandas' point of view, and pandas has a `Index.is_()` method to check for this. 

This fixes a few of the failures on the dev build (where we test with CoW enabled)