### PR TITLE
COMPAT: add pandas blockmanager alternative apis for _constructor like things

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,6 +88,13 @@ jobs:
         run: |
           pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
 
+      - name: Test with Copy-on-Write
+        if: ${{ always() && matrix.dev }}
+        env:
+          PANDAS_COPY_ON_WRITE: '1'
+        run: |
+          pytest -v -r a -n auto --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/
+
       - name: Test with PostGIS
         if: (contains(matrix.env, '310-pd20-conda-forge.yaml') || contains(matrix.env, '311-latest-conda-forge.yaml'))
           && contains(matrix.os, 'ubuntu')

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1593,6 +1593,12 @@ individually so that features may have different properties
     def _constructor(self):
         return _geodataframe_constructor_with_fallback
 
+    def _constructor_from_mgr(self, mgr, axes):
+        # TODO maybe need conditional logic for dev pandas only
+        if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
+            return pd.DataFrame._from_mgr(mgr, axes)
+        return GeoDataFrame._from_mgr(mgr, axes)
+
     @property
     def _constructor_sliced(self):
         def _geodataframe_constructor_sliced(*args, **kwargs):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1612,7 +1612,7 @@ individually so that features may have different properties
               checking the identity of the index)
             """
             srs = pd.Series(*args, **kwargs)
-            is_row_proxy = srs.index is self.columns
+            is_row_proxy = srs.index.is_(self.columns)
             if is_geometry_type(srs) and not is_row_proxy:
                 srs = GeoSeries(srs)
             return srs

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1595,7 +1595,6 @@ individually so that features may have different properties
         return _geodataframe_constructor_with_fallback
 
     def _constructor_from_mgr(self, mgr, axes):
-        # this is unused for pandas <2.2
         if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
             return pd.DataFrame._from_mgr(mgr, axes)
         return GeoDataFrame._from_mgr(mgr, axes)
@@ -1631,10 +1630,8 @@ individually so that features may have different properties
 
         assert isinstance(mgr, SingleBlockManager)
         if isinstance(mgr.blocks[0].dtype, GeometryDtype) and not is_row_proxy:
-            klass = GeoSeries
-        else:
-            klass = Series
-        return klass._from_mgr(mgr, axes)
+            return GeoSeries._from_mgr(mgr, axes)
+        return Series.from_mgr(mgr, axes)
 
     def __finalize__(self, other, method=None, **kwargs):
         """propagate metadata from other to self"""

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1594,7 +1594,7 @@ individually so that features may have different properties
         return _geodataframe_constructor_with_fallback
 
     def _constructor_from_mgr(self, mgr, axes):
-        # TODO maybe need conditional logic for dev pandas only
+        # this is unused for pandas <2.2
         if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
             return pd.DataFrame._from_mgr(mgr, axes)
         return GeoDataFrame._from_mgr(mgr, axes)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -6,7 +6,6 @@ import pandas as pd
 import shapely.errors
 from pandas import DataFrame, Series
 from pandas.core.accessor import CachedAccessor
-from pandas.core.internals import SingleBlockManager
 
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
@@ -1595,6 +1594,7 @@ individually so that features may have different properties
         return _geodataframe_constructor_with_fallback
 
     def _constructor_from_mgr(self, mgr, axes):
+        # analogous logic to _geodataframe_constructor_with_fallback
         if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
             return pd.DataFrame._from_mgr(mgr, axes)
         return GeoDataFrame._from_mgr(mgr, axes)
@@ -1628,10 +1628,9 @@ individually so that features may have different properties
     def _constructor_sliced_from_mgr(self, mgr, axes):
         is_row_proxy = mgr.index.is_(self.columns)
 
-        assert isinstance(mgr, SingleBlockManager)
         if isinstance(mgr.blocks[0].dtype, GeometryDtype) and not is_row_proxy:
             return GeoSeries._from_mgr(mgr, axes)
-        return Series.from_mgr(mgr, axes)
+        return Series._from_mgr(mgr, axes)
 
     def __finalize__(self, other, method=None, **kwargs):
         """propagate metadata from other to self"""

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -3,6 +3,8 @@ import warnings
 import pandas as pd
 import pyproj
 import pytest
+
+from geopandas._compat import PANDAS_GE_22
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_index_equal
 
@@ -178,10 +180,18 @@ class TestMerging:
         # https://github.com/geopandas/geopandas/issues/1230
         # Expect that concat should fail gracefully if duplicate column names belonging
         # to geometry columns are introduced.
-        expected_err = (
-            "Concat operation has resulted in multiple columns using the geometry "
-            "column name 'geometry'."
-        )
+        if PANDAS_GE_22:
+            # _constructor_from_mgr changes mean we now get the concat specific error
+            # message in this case too
+            expected_err = (
+                "Concat operation has resulted in multiple columns using the geometry "
+                "column name 'geometry'."
+            )
+        else:
+            expected_err = (
+                "GeoDataFrame does not support multiple columns using the geometry"
+                " column name 'geometry'"
+            )
         with pytest.raises(ValueError, match=expected_err):
             pd.concat([self.gdf, self.gdf], axis=1)
 

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -179,8 +179,8 @@ class TestMerging:
         # Expect that concat should fail gracefully if duplicate column names belonging
         # to geometry columns are introduced.
         expected_err = (
-            "GeoDataFrame does not support multiple columns using the geometry"
-            " column name 'geometry'"
+            "Concat operation has resulted in multiple columns using the geometry "
+            "column name 'geometry'."
         )
         with pytest.raises(ValueError, match=expected_err):
             pd.concat([self.gdf, self.gdf], axis=1)

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pyproj
 import pytest
 
-from geopandas._compat import PANDAS_GE_22
+from geopandas._compat import PANDAS_GE_21
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_index_equal
 
@@ -180,7 +180,7 @@ class TestMerging:
         # https://github.com/geopandas/geopandas/issues/1230
         # Expect that concat should fail gracefully if duplicate column names belonging
         # to geometry columns are introduced.
-        if PANDAS_GE_22:
+        if PANDAS_GE_21:
             # _constructor_from_mgr changes mean we now get the concat specific error
             # message in this case too
             expected_err = (


### PR DESCRIPTION
xref #3060

With [6b4857e](https://github.com/geopandas/geopandas/pull/3080/commits/6b4857ec8d1bcccb52984d2af1b9685349d37ed7) we are down to a mere 34992 warnings (commits after are fixes for old pandas).

With [5d7d146](https://github.com/geopandas/geopandas/pull/3080/commits/5d7d14672255a6fdededc1b92416f8011adfd450) we are down to 346

[482c989](https://github.com/geopandas/geopandas/pull/3080/commits/482c98926c37d6d2dab7c4c4fd950815a81a50d0) is a bit more convoluted than the others. Originally I didn't think we needed this, but there are warnings about this in e.g. test_clip.py (and with it we are down to 311). Since we have quite some logic for `GeoSeries._constructor_expanddim`, I opted to directly construct the dataframe (and fortunately we can actually do this in the DataFrame case as the `Series._name` being undefined as part of `from_mgr` is not an issue)

Would not surprise me if this is not the 'right' way of doing some of this, I've kept some tabs on some of the relevant pandas PRs but not across it all.