### PR TITLE
DOC: Add new 'How to...' section in User Guide

### DIFF
--- a/doc/source/docs/user_guide.rst
+++ b/doc/source/docs/user_guide.rst
@@ -22,3 +22,4 @@ Advanced topics can be found in the :doc:`Advanced Guide <advanced_guide>` and f
   Merging data <user_guide/mergingdata>
   Geocoding <user_guide/geocoding>
   Sampling points <user_guide/sampling>
+  How to... <user_guide/how_to>

--- a/doc/source/docs/user_guide/how_to.rst
+++ b/doc/source/docs/user_guide/how_to.rst
@@ -21,11 +21,11 @@ and then use the standard :meth:`~pandas.DataFrame.drop_duplicates` method::
 
 The effect of the :meth:`~geopandas.GeoSeries.normalize` method can be seen in the following example::
 
-    geopandas.GeoSeries([
-        shapely.LineString([(0, 0), (1, 0), (2, 0)]),
-        shapely.LineString([(2, 0), (1, 0), (0, 0)]),
-    ]).normalize().to_wkt()
-
+```suggestion
+    >>> geopandas.GeoSeries([
+    ...     shapely.LineString([(0, 0), (1, 0), (2, 0)]),
+    ...     shapely.LineString([(2, 0), (1, 0), (0, 0)]),
+    ... ]).normalize().to_wkt()
     0    LINESTRING (0 0, 1 0, 2 0)
     1    LINESTRING (0 0, 1 0, 2 0)
     dtype: object

--- a/doc/source/docs/user_guide/how_to.rst
+++ b/doc/source/docs/user_guide/how_to.rst
@@ -21,7 +21,6 @@ and then use the standard :meth:`~pandas.DataFrame.drop_duplicates` method::
 
 The effect of the :meth:`~geopandas.GeoSeries.normalize` method can be seen in the following example::
 
-```suggestion
     >>> geopandas.GeoSeries([
     ...     shapely.LineString([(0, 0), (1, 0), (2, 0)]),
     ...     shapely.LineString([(2, 0), (1, 0), (0, 0)]),

--- a/doc/source/docs/user_guide/how_to.rst
+++ b/doc/source/docs/user_guide/how_to.rst
@@ -1,0 +1,31 @@
+.. _how_to:
+
+How to...
+=========
+
+Drop duplicate geometry in all situations
+-----------------------------------------
+
+Using the standard Pandas :meth:`~pandas.DataFrame.drop_duplicates` function on a geometry column can lead to some duplicate
+geometries not being dropped, in certain circumstances. When used on a geometry columnm, the Pandas function compares the
+WKB of each geometry object. This is sensitive to the orders of various components of the geometry - for example, a line
+with co-ordinates in the order left-to-right should be equal to a line with the same co-ordinates in the order right-to-left,
+but the WKB representations will be different. The same applies for the order of rings of polygons and parts in multipart
+geometries.
+
+To deal with this problem, use the :meth:`~geopandas.GeoSeries.normalize` method first to order the co-ordinates in a canonincal form,
+and then use the standard :meth:`~pandas.DataFrame.drop_duplicates` method::
+
+    gdf["geometry"] = gdf.normalize()
+    gdf.drop_duplicates()
+
+The effect of the :meth:`~geopandas.GeoSeries.normalize` method can be seen in the following example::
+
+    geopandas.GeoSeries([
+        shapely.LineString([(0, 0), (1, 0), (2, 0)]),
+        shapely.LineString([(2, 0), (1, 0), (0, 0)]),
+    ]).normalize().to_wkt()
+
+    0    LINESTRING (0 0, 1 0, 2 0)
+    1    LINESTRING (0 0, 1 0, 2 0)
+    dtype: object


### PR DESCRIPTION
This was recommended by @martinfleis in #3098.

It currently contains a tip on dropping duplicate geometries using normalize() before drop_duplicates(). It can be used as an appropriate place in the future for other How To/Hints and Tips content later.