### PR TITLE
Make sure gdf.plot() triggers drawing the figure of the used plot-axes

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -491,7 +491,7 @@ def plot_series(
             ax, points, values_, color=color_, cmap=cmap, **style_kwds
         )
 
-    plt.draw()
+    ax.figure.canvas.draw_idle()
     return ax
 
 
@@ -964,7 +964,7 @@ def plot_dataframe(
             n_cmap.set_array(np.array([]))
             ax.get_figure().colorbar(n_cmap, **legend_kwds)
 
-    plt.draw()
+    ax.figure.canvas.draw_idle()
     return ax
 
 


### PR DESCRIPTION
Current plotting methods simply call `plt.draw()`  at the end. 
This assumes that the figure to which the plot-axes belongs to is managed by `pyplot` and that it is also the currently active figure. 

If a custom axes is provided (e.g. using `gdf.plot(ax=ax)`) and the associated figure is not properly recognized by `pyplot`, then the final call to `plt.draw()` will trigger the creation **of a new figure** rather than drawing the figure to which the axes belong to.

Since `plt.draw()` defaults to `plt.gcf().canvas.draw_idle()`, I suggest replacing it with `ax.figure.canvas.draw_idle()` to ensure that the correct figure is triggered.


To give a quick example where the current implementation can cause problems: If you initialize a figure in a jupyter-notebook cell and call `gdf.plot()` in a subsequent cell.

![grafik](https://github.com/geopandas/geopandas/assets/22773387/79a14b89-44bd-4446-a871-9bd3b0b2e850)





