### PR TITLE
ENH: add on_invalid parameter to from_wkt and from_wkb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ New features and improvements:
 
 - GeoSeries and GeoDataFrame `__repr__` now trims trailing zeros for a more readable
   output (#3087).
+- Add `on_invalid` parameter to `from_wkt` and `from_wkb` (#)
 
 Potentially breaking changes:
 - reading a data source that does not have a geometry field using ``read_file``

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ New features and improvements:
 
 - GeoSeries and GeoDataFrame `__repr__` now trims trailing zeros for a more readable
   output (#3087).
-- Add `on_invalid` parameter to `from_wkt` and `from_wkb` (#3110)
+- Add `on_invalid` parameter to `from_wkt` and `from_wkb` (#3110).
 
 Potentially breaking changes:
 - reading a data source that does not have a geometry field using ``read_file``
@@ -29,7 +29,7 @@ Bug fixes:
   `GeoDataFrame` when the `suffixes` argument is applied to the active
   geometry column (#2933).
 - Fix bug in `pandas.concat` CRS consistency checking where CRS differing by WKT
-  whitespace only were treated as incompatible (#3023)
+  whitespace only were treated as incompatible (#3023).
 
 ## Version 0.14.1 (Nov 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ New features and improvements:
 
 - GeoSeries and GeoDataFrame `__repr__` now trims trailing zeros for a more readable
   output (#3087).
-- Add `on_invalid` parameter to `from_wkt` and `from_wkb` (#)
+- Add `on_invalid` parameter to `from_wkt` and `from_wkb` (#3110)
 
 Potentially breaking changes:
 - reading a data source that does not have a geometry field using ``read_file``

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -192,7 +192,7 @@ def to_shapely(geoms):
     return geoms._data
 
 
-def from_wkb(data, crs=None):
+def from_wkb(data, crs=None, on_invalid="raise"):
     """
     Convert a list or array of WKB objects to a GeometryArray.
 
@@ -204,9 +204,14 @@ def from_wkb(data, crs=None):
         Coordinate Reference System of the geometry objects. Can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
+    on_invalid: {"raise", "warn", "ignore"}, default "raise"
+        - raise: an exception will be raised if a WKB input geometry is invalid.
+        - warn: a warning will be raised and invalid WKB geometries will be returned as
+          None.
+        - ignore: invalid WKB geometries will be returned as None without a warning.
 
     """
-    return GeometryArray(shapely.from_wkb(data), crs=crs)
+    return GeometryArray(shapely.from_wkb(data, on_invalid=on_invalid), crs=crs)
 
 
 def to_wkb(geoms, hex=False, **kwargs):
@@ -218,7 +223,7 @@ def to_wkb(geoms, hex=False, **kwargs):
     return shapely.to_wkb(geoms, hex=hex, **kwargs)
 
 
-def from_wkt(data, crs=None):
+def from_wkt(data, crs=None, on_invalid="raise"):
     """
     Convert a list or array of WKT objects to a GeometryArray.
 
@@ -230,9 +235,14 @@ def from_wkt(data, crs=None):
         Coordinate Reference System of the geometry objects. Can be anything accepted by
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
+    on_invalid : {"raise", "warn", "ignore"}, default "raise"
+        - raise: an exception will be raised if a WKB input geometry is invalid.
+        - warn: a warning will be raised and invalid WKB geometries will be
+          returned as ``None``.
+        - ignore: invalid WKB geometries will be returned as ``None`` without a warning.
 
     """
-    return GeometryArray(shapely.from_wkt(data), crs=crs)
+    return GeometryArray(shapely.from_wkt(data, on_invalid=on_invalid), crs=crs)
 
 
 def to_wkt(geoms, **kwargs):

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -236,10 +236,10 @@ def from_wkt(data, crs=None, on_invalid="raise"):
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
     on_invalid : {"raise", "warn", "ignore"}, default "raise"
-        - raise: an exception will be raised if a WKB input geometry is invalid.
-        - warn: a warning will be raised and invalid WKB geometries will be
+        - raise: an exception will be raised if a WKT input geometry is invalid.
+        - warn: a warning will be raised and invalid WKT geometries will be
           returned as ``None``.
-        - ignore: invalid WKB geometries will be returned as ``None`` without a warning.
+        - ignore: invalid WKT geometries will be returned as ``None`` without a warning.
 
     """
     return GeometryArray(shapely.from_wkt(data, on_invalid=on_invalid), crs=crs)

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -416,10 +416,10 @@ class GeoSeries(GeoPandasBase, Series):
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:4326") or a WKT string.
         on_invalid : {"raise", "warn", "ignore"}, default "raise"
-            - raise: an exception will be raised if a WKB input geometry is invalid.
-            - warn: a warning will be raised and invalid WKB geometries will be
+            - raise: an exception will be raised if a WKT input geometry is invalid.
+            - warn: a warning will be raised and invalid WKT geometries will be
               returned as ``None``.
-            - ignore: invalid WKB geometries will be returned as ``None`` without a
+            - ignore: invalid WKT geometries will be returned as ``None`` without a
               warning.
 
         kwargs

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -392,7 +392,7 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.from_wkt
 
         """
-        return cls._from_wkb_or_wkb(
+        return cls._from_wkb_or_wkt(
             from_wkb, data, index=index, crs=crs, on_invalid=on_invalid, **kwargs
         )
 
@@ -449,7 +449,7 @@ class GeoSeries(GeoPandasBase, Series):
         2    POINT (3 3)
         dtype: geometry
         """
-        return cls._from_wkb_or_wkb(
+        return cls._from_wkb_or_wkt(
             from_wkt, data, index=index, crs=crs, on_invalid=on_invalid, **kwargs
         )
 
@@ -509,7 +509,7 @@ class GeoSeries(GeoPandasBase, Series):
         return cls(points_from_xy(x, y, z, crs=crs), index=index, crs=crs, **kwargs)
 
     @classmethod
-    def _from_wkb_or_wkb(
+    def _from_wkb_or_wkt(
         cls,
         from_wkb_or_wkt_function: Callable,
         data,

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -356,7 +356,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @classmethod
     def from_wkb(
-        cls, data, index=None, crs: Optional[Any] = None, **kwargs
+        cls, data, index=None, crs: Optional[Any] = None, on_invalid="raise", **kwargs
     ) -> GeoSeries:
         """
         Alternate constructor to create a ``GeoSeries``
@@ -373,6 +373,12 @@ class GeoSeries(GeoPandasBase, Series):
             accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:4326") or a WKT string.
+        on_invalid: {"raise", "warn", "ignore"}, default "raise"
+            - raise: an exception will be raised if a WKB input geometry is invalid.
+            - warn: a warning will be raised and invalid WKB geometries will be returned
+              as None.
+            - ignore: invalid WKB geometries will be returned as None without a warning.
+
         kwargs
             Additional arguments passed to the Series constructor,
             e.g. ``name``.
@@ -386,11 +392,13 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.from_wkt
 
         """
-        return cls._from_wkb_or_wkb(from_wkb, data, index=index, crs=crs, **kwargs)
+        return cls._from_wkb_or_wkb(
+            from_wkb, data, index=index, crs=crs, on_invalid=on_invalid, **kwargs
+        )
 
     @classmethod
     def from_wkt(
-        cls, data, index=None, crs: Optional[Any] = None, **kwargs
+        cls, data, index=None, crs: Optional[Any] = None, on_invalid="raise", **kwargs
     ) -> GeoSeries:
         """
         Alternate constructor to create a ``GeoSeries``
@@ -407,6 +415,13 @@ class GeoSeries(GeoPandasBase, Series):
             accepted by
             :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
             such as an authority string (eg "EPSG:4326") or a WKT string.
+        on_invalid : {"raise", "warn", "ignore"}, default "raise"
+            - raise: an exception will be raised if a WKB input geometry is invalid.
+            - warn: a warning will be raised and invalid WKB geometries will be
+              returned as ``None``.
+            - ignore: invalid WKB geometries will be returned as ``None`` without a
+              warning.
+
         kwargs
             Additional arguments passed to the Series constructor,
             e.g. ``name``.
@@ -434,7 +449,9 @@ class GeoSeries(GeoPandasBase, Series):
         2    POINT (3 3)
         dtype: geometry
         """
-        return cls._from_wkb_or_wkb(from_wkt, data, index=index, crs=crs, **kwargs)
+        return cls._from_wkb_or_wkb(
+            from_wkt, data, index=index, crs=crs, on_invalid=on_invalid, **kwargs
+        )
 
     @classmethod
     def from_xy(cls, x, y, z=None, index=None, crs=None, **kwargs) -> GeoSeries:
@@ -498,6 +515,7 @@ class GeoSeries(GeoPandasBase, Series):
         data,
         index=None,
         crs: Optional[Any] = None,
+        on_invalid: str = "raise",
         **kwargs,
     ) -> GeoSeries:
         """Create a GeoSeries from either WKT or WKB values"""
@@ -507,7 +525,11 @@ class GeoSeries(GeoPandasBase, Series):
             else:
                 index = data.index
             data = data.values
-        return cls(from_wkb_or_wkt_function(data, crs=crs), index=index, **kwargs)
+        return cls(
+            from_wkb_or_wkt_function(data, crs=crs, on_invalid=on_invalid),
+            index=index,
+            **kwargs,
+        )
 
     @property
     def __geo_interface__(self) -> Dict:

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -163,24 +163,22 @@ def test_from_wkb_hex():
     assert isinstance(res, GeometryArray)
 
 
-@pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
-def test_from_wkb_on_invalid(on_invalid):
+def test_from_wkb_on_invalid():
     # Single point LineString hex WKB: invalid
     invalid_wkb_hex = "01020000000100000000000000000008400000000000000840"
     message = "point array must contain 0 or >1 elements"
 
-    if on_invalid == "raise":
-        with pytest.raises(Exception, match=message):
-            from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-    elif on_invalid == "warn":
-        with pytest.warns(Warning, match=message):
-            res = from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-            assert res == [None]
-    elif on_invalid == "ignore":
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            res = from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-            assert res == [None]
+    with pytest.raises(Exception, match=message):
+        from_wkb([invalid_wkb_hex], on_invalid="raise")
+
+    with pytest.warns(Warning, match=message):
+        res = from_wkb([invalid_wkb_hex], on_invalid="warn")
+    assert res == [None]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = from_wkb([invalid_wkb_hex], on_invalid="ignore")
+    assert res == [None]
 
 
 def test_to_wkb():
@@ -238,24 +236,22 @@ def test_from_wkt(string_type):
     assert res[0] == multi_poly
 
 
-@pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
-def test_from_wkt_on_invalid(on_invalid):
+def test_from_wkt_on_invalid():
     # Single point LineString WKT: invalid
     invalid_wkt = "LINESTRING(0 0)"
     message = "point array must contain 0 or >1 elements"
 
-    if on_invalid == "raise":
-        with pytest.raises(Exception, match=message):
-            from_wkt([invalid_wkt], on_invalid=on_invalid)
-    elif on_invalid == "warn":
-        with pytest.warns(Warning, match=message):
-            res = from_wkt([invalid_wkt], on_invalid=on_invalid)
-            assert res == [None]
-    elif on_invalid == "ignore":
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            res = from_wkt([invalid_wkt], on_invalid=on_invalid)
-            assert res == [None]
+    with pytest.raises(Exception, match=message):
+        from_wkt([invalid_wkt], on_invalid="raise")
+
+    with pytest.warns(Warning, match=message):
+        res = from_wkt([invalid_wkt], on_invalid="warn")
+    assert res == [None]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = from_wkt([invalid_wkt], on_invalid="ignore")
+    assert res == [None]
 
 
 def test_to_wkt():

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -162,6 +163,26 @@ def test_from_wkb_hex():
     assert isinstance(res, GeometryArray)
 
 
+@pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
+def test_from_wkb_on_invalid(on_invalid):
+    # Single point LineString hex WKB: invalid
+    invalid_wkb_hex = "01020000000100000000000000000008400000000000000840"
+    message = "point array must contain 0 or >1 elements"
+
+    if on_invalid == "raise":
+        with pytest.raises(Exception, match=message):
+            from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+    elif on_invalid == "warn":
+        with pytest.warns(Warning, match=message):
+            res = from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+            assert res == [None]
+    elif on_invalid == "ignore":
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            res = from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+            assert res == [None]
+
+
 def test_to_wkb():
     P = from_shapely(points_no_missing)
     res = to_wkb(P)
@@ -215,6 +236,26 @@ def test_from_wkt(string_type):
     )
     res = from_wkt([f(multi_poly.wkt)])
     assert res[0] == multi_poly
+
+
+@pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
+def test_from_wkt_on_invalid(on_invalid):
+    # Single point LineString WKT: invalid
+    invalid_wkt = "LINESTRING(0 0)"
+    message = "point array must contain 0 or >1 elements"
+
+    if on_invalid == "raise":
+        with pytest.raises(Exception, match=message):
+            from_wkt([invalid_wkt], on_invalid=on_invalid)
+    elif on_invalid == "warn":
+        with pytest.warns(Warning, match=message):
+            res = from_wkt([invalid_wkt], on_invalid=on_invalid)
+            assert res == [None]
+    elif on_invalid == "ignore":
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            res = from_wkt([invalid_wkt], on_invalid=on_invalid)
+            assert res == [None]
 
 
 def test_to_wkt():

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -283,24 +283,22 @@ class TestSeries:
     def test_from_wkb(self):
         assert_geoseries_equal(self.g1, GeoSeries.from_wkb([self.t1.wkb, self.sq.wkb]))
 
-    @pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
-    def test_from_wkb_on_invalid(self, on_invalid):
+    def test_from_wkb_on_invalid(self):
         # Single point LineString hex WKB: invalid
         invalid_wkb_hex = "01020000000100000000000000000008400000000000000840"
         message = "point array must contain 0 or >1 elements"
 
-        if on_invalid == "raise":
-            with pytest.raises(Exception, match=message):
-                GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-        elif on_invalid == "warn":
-            with pytest.warns(Warning, match=message):
-                res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-                assert res[0] is None
-        elif on_invalid == "ignore":
-            with warnings.catch_warnings():
-                warnings.simplefilter("error")
-                res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
-                assert res[0] is None
+        with pytest.raises(Exception, match=message):
+            GeoSeries.from_wkb([invalid_wkb_hex], on_invalid="raise")
+
+        with pytest.warns(Warning, match=message):
+            res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid="warn")
+        assert res[0] is None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid="ignore")
+        assert res[0] is None
 
     def test_from_wkb_series(self):
         s = pd.Series([self.t1.wkb, self.sq.wkb], index=[1, 2])
@@ -317,24 +315,22 @@ class TestSeries:
     def test_from_wkt(self):
         assert_geoseries_equal(self.g1, GeoSeries.from_wkt([self.t1.wkt, self.sq.wkt]))
 
-    @pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
-    def test_from_wkt_on_invalid(self, on_invalid):
+    def test_from_wkt_on_invalid(self):
         # Single point LineString WKT: invalid
         invalid_wkt = "LINESTRING(0 0)"
         message = "point array must contain 0 or >1 elements"
 
-        if on_invalid == "raise":
-            with pytest.raises(Exception, match=message):
-                GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
-        elif on_invalid == "warn":
-            with pytest.warns(Warning, match=message):
-                res = GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
-                assert res[0] is None
-        elif on_invalid == "ignore":
-            with warnings.catch_warnings():
-                warnings.simplefilter("error")
-                res = GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
-                assert res[0] is None
+        with pytest.raises(Exception, match=message):
+            GeoSeries.from_wkt([invalid_wkt], on_invalid="raise")
+
+        with pytest.warns(Warning, match=message):
+            res = GeoSeries.from_wkt([invalid_wkt], on_invalid="warn")
+        assert res[0] is None
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            res = GeoSeries.from_wkt([invalid_wkt], on_invalid="ignore")
+        assert res[0] is None
 
     def test_from_wkt_series(self):
         s = pd.Series([self.t1.wkt, self.sq.wkt], index=[1, 2])

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -283,6 +283,25 @@ class TestSeries:
     def test_from_wkb(self):
         assert_geoseries_equal(self.g1, GeoSeries.from_wkb([self.t1.wkb, self.sq.wkb]))
 
+    @pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
+    def test_from_wkb_on_invalid(self, on_invalid):
+        # Single point LineString hex WKB: invalid
+        invalid_wkb_hex = "01020000000100000000000000000008400000000000000840"
+        message = "point array must contain 0 or >1 elements"
+
+        if on_invalid == "raise":
+            with pytest.raises(Exception, match=message):
+                GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+        elif on_invalid == "warn":
+            with pytest.warns(Warning, match=message):
+                res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+                assert res[0] is None
+        elif on_invalid == "ignore":
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                res = GeoSeries.from_wkb([invalid_wkb_hex], on_invalid=on_invalid)
+                assert res[0] is None
+
     def test_from_wkb_series(self):
         s = pd.Series([self.t1.wkb, self.sq.wkb], index=[1, 2])
         expected = self.g1.copy()
@@ -297,6 +316,25 @@ class TestSeries:
 
     def test_from_wkt(self):
         assert_geoseries_equal(self.g1, GeoSeries.from_wkt([self.t1.wkt, self.sq.wkt]))
+
+    @pytest.mark.parametrize("on_invalid", ["raise", "warn", "ignore"])
+    def test_from_wkt_on_invalid(self, on_invalid):
+        # Single point LineString WKT: invalid
+        invalid_wkt = "LINESTRING(0 0)"
+        message = "point array must contain 0 or >1 elements"
+
+        if on_invalid == "raise":
+            with pytest.raises(Exception, match=message):
+                GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
+        elif on_invalid == "warn":
+            with pytest.warns(Warning, match=message):
+                res = GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
+                assert res[0] is None
+        elif on_invalid == "ignore":
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                res = GeoSeries.from_wkt([invalid_wkt], on_invalid=on_invalid)
+                assert res[0] is None
 
     def test_from_wkt_series(self):
         s = pd.Series([self.t1.wkt, self.sq.wkt], index=[1, 2])


### PR DESCRIPTION
Resolves #2962

Reference #2791

Remark: I noticed a method called `_from_wkb_or_wkb` in `GeoSeries`, I suppose this should be `_from_wkb_or_wkt`? If this is the case, shall I change this in this PR or in a seperate one?