### PR TITLE
DOC/RLS: add 0.14.2 changelog to main branch as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,12 @@ Bug fixes:
   geometry column (#2933).
 - Fix bug in `pandas.concat` CRS consistency checking where CRS differing by WKT
   whitespace only were treated as incompatible (#3023).
-- Fix `explore()` method when the active geometry contains missing and empty geometries (#3094)
+
+## Version 0.14.2 (Jan 4, 2024)
+
+- Fix regression in `overlay` where using `buffer(0)` instead of `make_valid` internally
+  produced invalid results (#3074).
+- Fix `explore()` method when the active geometry contains missing and empty geometries (#3094).
 
 ## Version 0.14.1 (Nov 11, 2023)
 


### PR DESCRIPTION
This is the changelog entry as it exists on the 0.14.x branch (from merging https://github.com/geopandas/geopandas/pull/3074, cherry-picking https://github.com/geopandas/geopandas/pull/3094 (https://github.com/geopandas/geopandas/commit/7c8fa85963273a17dee76a7d19b7a3c8a6b8aeee), and the release commit). 
Adding it to the main branch as well (for this specific case where we merged directly to the release branch)so we correctly keep track of it in the main branch / stable docs.