### PR TITLE
REGR: using loc to add rows doesn't preserve dtypes

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1581,6 +1581,25 @@ individually so that features may have different properties
             return pd.DataFrame._from_mgr(mgr, axes)
         return GeoDataFrame._from_mgr(mgr, axes)
 
+    # def _constructor_from_mgr(self, mgr, axes):
+    #     # analogous logic to _geodataframe_constructor_with_fallback
+    #     if not any(isinstance(block.dtype, GeometryDtype) for block in mgr.blocks):
+    #         df= pd.DataFrame._from_mgr(mgr, axes)
+    #         # stuff like concat to append an object row will
+    #         # upcast GeometryDtype blocks
+    #         for c in self.columns[self.dtypes == "geometry"]:
+    #             try:
+    #                 df[c] = _ensure_geometry(df[c], crs=self[c].crs)
+    #             except TypeError:
+    #                 pass
+    #         try:
+    #             df = df.set_geometry(self._geometry_column_name, crs=self.crs)
+    #         except TypeError:
+    #             pass
+    #         return df
+    #
+    #     return GeoDataFrame._from_mgr(mgr, axes)
+
     @property
     def _constructor_sliced(self):
         def _geodataframe_constructor_sliced(*args, **kwargs):

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -1,3 +1,5 @@
+from shapely import Polygon
+
 import pandas as pd
 import pyproj
 import pytest
@@ -142,6 +144,45 @@ def test_loc(df):
     assert_object(df.loc[:, geo_name], GeoSeries, geo_name)
     assert_object(df.loc[:, "geometry2"], GeoSeries, "geometry2", crs=crs_osgb)
     assert_object(df.loc[:, "value1"], pd.Series)
+
+
+@pytest.mark.parametrize("geom_name", ["geometry", "geom"])
+def test_loc_add_row(geom_name):
+    # https://github.com/geopandas/geopandas/issues/3119
+    import geopandas
+    from geodatasets import get_path
+
+    nybb = geopandas.read_file(
+        get_path("nybb"), columns=["BoroCode", "geometry"], engine="pyogrio"
+    )
+    if geom_name != "geometry":
+        nybb = nybb.rename_geometry(geom_name)
+    crs_orig = nybb.crs
+
+    # add a new row
+    nybb.loc[5] = [6, nybb.geometry.iloc[0]]
+    assert nybb.geometry.dtype == "geometry"
+    assert nybb.crs == crs_orig
+
+
+@pytest.mark.parametrize(
+    "geom_name",
+    [
+        pytest.param(
+            "geometry", marks=pytest.mark.xfail(reason="reported but not fixed")
+        ),
+        pytest.param("geom", marks=pytest.mark.xfail(reason="reported but not fixed")),
+    ],
+)
+def test_loc_add_row_empty_start(geom_name):
+    # adding row to empty geodataframe
+    # https://github.com/geopandas/geopandas/issues/3109
+    gdf = GeoDataFrame([], geometry=[], crs=crs_wgs)
+    if geom_name != "geometry":
+        gdf = gdf.rename_geometry(geom_name)
+    gdf.loc[len(gdf)] = [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])]
+    assert gdf.geometry.dtype == "geometry"
+    assert gdf.crs == crs_wgs
 
 
 def test_iloc(df):


### PR DESCRIPTION
Potential ideas for solving this. As implemented, `_constructor_from_mgr` stays nice and clean, but relies too heavily on the pandas internals for my liking (though in an ideal world pandas would expose some way to handle less straightforward dtype concatenation cases). 

I expect we'll end up using something along the lines of the update to `_constructor_from_mgr` which is commented out at the moment.