### PR TITLE
TST: update groupby test to handle included group columns with pandas >= 2.2 + test with non-default geometry name

### DIFF
--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -684,7 +684,9 @@ def test_groupby_metadata(crs, geometry_name):
 
     df.groupby("value2").apply(func, **kwargs)
     # selecting the non-group columns -> no need to pass the keyword
-    if compat.PANDAS_GE_20 and not compat.PANDAS_GE_22:
+    if (
+        compat.PANDAS_GE_21 if geometry_name == "geometry" else compat.PANDAS_GE_20
+    ) and not compat.PANDAS_GE_22:
         # https://github.com/geopandas/geopandas/pull/2966#issuecomment-1878816712
         # with pandas 2.0 and 2.1 this is failing
         with pytest.raises(AttributeError):

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -683,9 +683,14 @@ def test_groupby_metadata(crs, geometry_name):
         assert group.crs == crs
 
     df.groupby("value2").apply(func, **kwargs)
-    # https://github.com/geopandas/geopandas/pull/2966#issuecomment-1878816712
     # selecting the non-group columns -> no need to pass the keyword
-    df.groupby("value2")[[geometry_name, "value1"]].apply(func)
+    if compat.PANDAS_GE_20 and not compat.PANDAS_GE_22:
+        # https://github.com/geopandas/geopandas/pull/2966#issuecomment-1878816712
+        # with pandas 2.0 and 2.1 this is failing
+        with pytest.raises(AttributeError):
+            df.groupby("value2")[[geometry_name, "value1"]].apply(func)
+    else:
+        df.groupby("value2")[[geometry_name, "value1"]].apply(func)
 
     # actual test with functionality
     res = df.groupby("value2").apply(

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -657,27 +657,40 @@ def test_groupby_groups(df):
 
 
 @pytest.mark.parametrize("crs", [None, "EPSG:4326"])
-def test_groupby_metadata(crs):
+@pytest.mark.parametrize("geometry_name", ["geometry", "geom"])
+def test_groupby_metadata(crs, geometry_name):
     # https://github.com/geopandas/geopandas/issues/2294
     df = GeoDataFrame(
         {
-            "geometry": [Point(0, 0), Point(1, 1), Point(0, 0)],
+            geometry_name: [Point(0, 0), Point(1, 1), Point(0, 0)],
             "value1": np.arange(3, dtype="int64"),
             "value2": np.array([1, 2, 1], dtype="int64"),
         },
         crs=crs,
+        geometry=geometry_name,
     )
+
+    kwargs = {}
+    if compat.PANDAS_GE_22:
+        # pandas is deprecating that the group key is present as column in the
+        # dataframe passed to `func`. To suppress this warning, it introduced
+        # a new include_groups keyword
+        kwargs = dict(include_groups=False)
 
     # dummy test asserting we can access the crs
     def func(group):
         assert isinstance(group, GeoDataFrame)
         assert group.crs == crs
 
-    df.groupby("value2").apply(func)
+    df.groupby("value2").apply(func, **kwargs)
+    # https://github.com/geopandas/geopandas/pull/2966#issuecomment-1878816712
+    # selecting the non-group columns -> no need to pass the keyword
+    df.groupby("value2")[[geometry_name, "value1"]].apply(func)
 
     # actual test with functionality
     res = df.groupby("value2").apply(
-        lambda x: geopandas.sjoin(x, x[["geometry", "value1"]], how="inner")
+        lambda x: geopandas.sjoin(x, x[[geometry_name, "value1"]], how="inner"),
+        **kwargs,
     )
 
     if compat.PANDAS_GE_22:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,8 @@ ignore = [ # space before : (needed for how black formats slicing)
     # "B301",  # not yet implemented
     # Only works with python >=3.10
     "B905",
+    # dict literals
+    "C408",
     # Too many arguments to function call
     "PLR0913",
     # Too many returns


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/geopandas/pull/2966#issuecomment-1878816712:

- Fixes the warning in our tests (by passing the `include_groups=False` keyword if needed instead of selecting the columns)
- Adds an additional test case explicitly selecting columns, and parametrized that with different geometry name (see the mentioned issue, this should fail with latest pandas)