### PR TITLE
TST: update new url for nybb dataset

### DIFF
--- a/geopandas/conftest.py
+++ b/geopandas/conftest.py
@@ -34,7 +34,7 @@ def naturalearth_cities() -> str:
 @pytest.fixture(scope="session")
 def nybb_filename() -> str:
     # skip if data missing, unless on github actions
-    if os.path.isfile(_NYBB) or os.getenv("GITHUB_ACTIONS"):
+    if os.path.isfile(_NYBB[len("zip://") :]) or os.getenv("GITHUB_ACTIONS"):
         return _NYBB
     else:
         pytest.skip("NYBB dataset not found")

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -586,7 +586,7 @@ def test_read_file(engine, nybb_filename):
         "main/geopandas/tests/data/null_geom.geojson",
         # url to zip file
         "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "main/geopandas/datasets/nybb_16a.zip",
+        "main/geopandas/tests/data/nybb_16a.zip",
         # url to zipfile without extension
         "https://geonode.goosocean.org/download/480",
         # url to web service


### PR DESCRIPTION
After merging https://github.com/geopandas/geopandas/pull/3084, the nybb zip file changed directory, but we were using that url for testing reading from url. 