### PR TITLE
MAINT: reduce warnings in the tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,7 +77,6 @@ jobs:
 
       - name: Check and Log Environment
         run: |
-          micromamba install azure-core-cpp=1.10
           python -V
           python -c "import geopandas; geopandas.show_versions();"
           micromamba info

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Check and Log Environment
         run: |
+          micromamba install azure-core-cpp=1.10
           python -V
           python -c "import geopandas; geopandas.show_versions();"
           micromamba info

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -191,6 +191,9 @@ eastern = pytz.timezone("America/New_York")
 datetime_type_tests = (TEST_DATE, eastern.localize(TEST_DATE))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Non-conformant content for record 1 in column b:RuntimeWarning"
+)  # for GPKG, GDAL writes the tz data but warns on reading (see DATETIME_FORMAT option)
 @pytest.mark.parametrize(
     "time", datetime_type_tests, ids=("naive_datetime", "datetime_with_timezone")
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:pandas.*",
     "ignore:distutils Version classes are deprecated.*:DeprecationWarning:numpy.*",
     "ignore:The geopandas.dataset module is deprecated",
+    # pytest-xdist incompatibility with pytest-cov
+    "ignore:The --rsyncdir command line argument:DeprecationWarning",
+    # dateutil incompatibility with python 3.12 (https://github.com/dateutil/dateutil/issues/1284)
+    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil",
 ]
 
 [tool.black]


### PR DESCRIPTION
A next batch of warning fixes. This ignores a few external warnings we can't do anything about.