### PR TITLE
COMPAT: only use ISO WKB flavor in to_parquet for GEOS that supports it

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -258,9 +258,14 @@ def _geopandas_to_arrow(df, index=None, schema_version=None):
     # create geo metadata before altering incoming data frame
     geo_metadata = _create_metadata(df, schema_version=schema_version)
 
-    kwargs = {}
     if shapely.geos_version > (3, 10, 0):
         kwargs = {"flavor": "iso"}
+    else:
+        if any(
+            df[col].array.has_z.any() for col in df.columns[df.dtypes == "geometry"]
+        ):
+            raise ValueError("Cannot write 3D geometries with GEOS<3.10")
+        kwargs = {}
     df = df.to_wkb(**kwargs)
 
     table = Table.from_pandas(df, preserve_index=index)

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -5,6 +5,8 @@ import warnings
 import numpy as np
 from pandas import DataFrame, Series
 
+import shapely
+
 from geopandas._compat import import_optional_dependency
 from geopandas.array import from_wkb
 from geopandas import GeoDataFrame
@@ -256,7 +258,9 @@ def _geopandas_to_arrow(df, index=None, schema_version=None):
     # create geo metadata before altering incoming data frame
     geo_metadata = _create_metadata(df, schema_version=schema_version)
 
-    kwargs = {"flavor": "iso"}
+    kwargs = {}
+    if shapely.geos_version > (3, 10, 0):
+        kwargs = {"flavor": "iso"}
     df = df.to_wkb(**kwargs)
 
     table = Table.from_pandas(df, preserve_index=index)


### PR DESCRIPTION
Related to https://github.com/geopandas/geopandas/issues/3143. 

Do we want to warn if not using ISO?