### PR TITLE
BUG: Preserve geoseries name in gdf constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Bug fixes:
   geometry column (#2933).
 - Fix bug in `pandas.concat` CRS consistency checking where CRS differing by WKT
   whitespace only were treated as incompatible (#3023).
+- Fix bug in `GeoDataFrame` constructor where if `geometry` is given a named 
+  `GeoSeries` the name was not used as the active geometry column name (#3160).
 
 Deprecations and compatibility notes:
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -306,7 +306,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         else:
             frame = self.copy()
 
-        to_remove = None
         geo_column_name = self._geometry_column_name
         if geo_column_name is None:
             geo_column_name = "geometry"
@@ -326,12 +325,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 )
 
             if drop:
-                to_remove = col
+                # remove new column col, keep existing geo_column_name
+                del frame[col]
             else:
                 geo_column_name = col
-
-        if to_remove:
-            del frame[to_remove]
 
         if not crs:
             crs = getattr(level, "crs", None)

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -186,7 +186,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 and not geometry.crs == crs
             ):
                 raise ValueError(crs_mismatch_error)
-
+            # if geometry is a named GeoSeries then, use that name for geometry column
+            if (
+                name := getattr(geometry, "name", None)
+            ) is not None and name != "geometry":
+                self._geometry_column_name = name
             self.set_geometry(geometry, inplace=True, crs=crs)
 
         if geometry is None and crs:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -333,13 +333,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if not crs:
             crs = getattr(level, "crs", None)
 
-        if isinstance(level, (GeoSeries, GeometryArray)) and level.crs != crs:
-            # Avoids caching issues/crs sharing issues
-            level = level.copy()
-            level.crs = crs
-
-        # Check that we are using a listlike of geometries
         level = _ensure_geometry(level, crs=crs)
+        level.crs = crs  # ensure_geometry only sets crs if crs None on level
+
         # update _geometry_column_name prior to assignment
         # to avoid default is None warning
         frame._geometry_column_name = geo_column_name

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1269,15 +1269,12 @@ class TestConstructor:
         check_geodataframe(gdf)
         gdf.columns == ["geometry", "a"]
 
-    @pytest.mark.xfail
     def test_preserve_series_name(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
         gs = GeoSeries(geoms)
         gdf = GeoDataFrame({"a": [1, 2, 3]}, geometry=gs)
 
-        check_geodataframe(gdf, geometry_column="geometry")
-
-        geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
+        # GH2770
         gs = GeoSeries(geoms, name="my_geom")
         gdf = GeoDataFrame({"a": [1, 2, 3]}, geometry=gs)
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1273,6 +1273,7 @@ class TestConstructor:
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
         gs = GeoSeries(geoms)
         gdf = GeoDataFrame({"a": [1, 2, 3]}, geometry=gs)
+        check_geodataframe(gdf, geometry_column="geometry")
 
         # GH2770
         gs = GeoSeries(geoms, name="my_geom")


### PR DESCRIPTION
Closes #2770. Edit: While this does deal with that particular issue, it doesn't deal with the associated inconsistency of `set_geometry` behaviour -see #1038 - I missed the coupling when I first looked at this. Probably not ideally to fix this in the constructor only and not in `set_geometry`