### PR TITLE
DOC/RLS: start changelog for 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,18 @@ Bug fixes:
 - Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a
   `GeoDataFrame` when the `suffixes` argument is applied to the active
   geometry column (#2933).
-- Fix bug in `pandas.concat` CRS consistency checking where CRS differing by WKT
-  whitespace only were treated as incompatible (#3023).
 
 Deprecations and compatibility notes:
 
 - The deprecation of `geopandas.datasets` has been enforced and the module has been
   removed. New sample datasets are now available in the
   [geodatasets](https://geodatasets.readthedocs.io/en/latest/) package (#3084).
+
+## Version 0.14.3 (Jan ??, 2024)
+
+- Several fixes for compatibility with the latest pandas 2.2 release.
+- Fix bug in `pandas.concat` CRS consistency checking where CRS differing by WKT
+  whitespace only were treated as incompatible (#3023).
 
 ## Version 0.14.2 (Jan 4, 2024)
 


### PR DESCRIPTION
Starting a whatsnew entry for 0.14.3 (so this can be backported in https://github.com/geopandas/geopandas/pull/3161)