### PR TITLE
MAINT: Add optional-dependencies to pyproject.toml

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -103,7 +103,7 @@ as well::
 
 Optional runtime dependencies can also be installed all at once::
 
-    pip install geopandas[all]
+    pip install 'geopandas[all]'
 
 Installing from source
 ----------------------
@@ -118,7 +118,7 @@ You may install the latest development version by cloning the
 Development dependencies can be installed using the dev optional
 dependency group::
 
-    pip install .[dev]
+    pip install '.[dev]'
 
 It is also possible to install the latest development version
 directly from the GitHub repository with::

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -85,6 +85,10 @@ as well::
 
     pip install geopandas
 
+Optional runtime dependencies can also be installed at once::
+
+    pip install geopandas[all]
+
 .. _install-deps:
 
 .. warning::
@@ -110,6 +114,11 @@ You may install the latest development version by cloning the
     git clone https://github.com/geopandas/geopandas.git
     cd geopandas
     pip install .
+
+Development dependencies can be installed using the dev optional
+dependency group::
+
+    pip install .[dev]
 
 It is also possible to install the latest development version
 directly from the GitHub repository with::

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -85,10 +85,6 @@ as well::
 
     pip install geopandas
 
-Optional runtime dependencies can also be installed at once::
-
-    pip install geopandas[all]
-
 .. _install-deps:
 
 .. warning::
@@ -104,6 +100,10 @@ Optional runtime dependencies can also be installed at once::
     dependencies manually. We refer to the individual packages for more details on
     installing those. Using conda (see above) avoids the need to compile the
     dependencies yourself.
+
+Optional runtime dependencies can also be installed all at once::
+
+    pip install geopandas[all]
 
 Installing from source
 ----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,26 +29,26 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-geodatabase = [
+all = [
     "psycopg2-binary>=2.8.0",
     "SQLAlchemy>=1.3",
-]
-geocoding = [
     "geopy",
-]
-plotting = [
     "matplotlib>=3.5.0",
     "mapclassify",
-    "cartopy",
-    "geoplot",
+    "xyzservices",
     "folium",
-]
-postgis = [
     "GeoAlchemy2",
-]
-parquet = [
     "pyarrow>=8.0.0",
 ]
+dev = [
+    "pytest>=3.1.0",
+    "pytest-cov",
+    "pytest-xdist",
+    "codecov",
+    "black",
+    "pre-commit",
+]
+
 
 [project.readme]
 text = """\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,28 @@ dependencies = [
     "shapely >= 2.0.0",
 ]
 
+[project.optional-dependencies]
+geodatabase = [
+    "psycopg2-binary>=2.8.0",
+    "SQLAlchemy>=1.3",
+]
+geocoding = [
+    "geopy",
+]
+plotting = [
+    "matplotlib>=3.5.0",
+    "mapclassify",
+    "cartopy",
+    "geoplot",
+    "folium",
+]
+postgis = [
+    "GeoAlchemy2",
+]
+parquet = [
+    "pyarrow>=8.0.0",
+]
+
 [project.readme]
 text = """\
 GeoPandas is a project to add support for geographic data to

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,20 +5,20 @@ pyproj>=3.3.0
 shapely>=2.0.0
 packaging
 
-# postgis
+# geodatabase access
 psycopg2-binary>=2.8.0
 SQLAlchemy>=1.3
 
 # geocoding
 geopy
 
-# plot
+# plotting
 matplotlib>=3.5.0
 mapclassify
 xyzservices
 folium
 
-# test
+# testing
 pytest>=3.1.0
 pytest-cov
 pytest-xdist
@@ -28,7 +28,7 @@ codecov
 black
 pre-commit
 
-# postgis-write
+# PostGIS writing
 GeoAlchemy2
 
 # parquet

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,25 +5,31 @@ pyproj>=3.3.0
 shapely>=2.0.0
 packaging
 
-# geodatabase access
-psycopg2>=2.8.0
+# postgis
+psycopg2-binary>=2.8.0
 SQLAlchemy>=1.3
 
 # geocoding
 geopy
 
-# plotting
+# plot
 matplotlib>=3.5.0
 mapclassify
+xyzservices
+folium
 
-# testing
+# test
 pytest>=3.1.0
 pytest-cov
+pytest-xdist
 codecov
 
 # styling
 black
 pre-commit
 
-# PostGIS writing
+# postgis-write
 GeoAlchemy2
+
+# parquet
+pyarrow>=8.0.0


### PR DESCRIPTION
## What

The specification for `optional-dependencies` is part of PEP 621
<https://peps.python.org/pep-0621/>. See
<https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-toml-spec>
for latest specification.

I added the dependencies to `optional-dependencies` based on
`./requirements-dev.txt`, `./environment.yml` and #2990.

## Why?

This would be useful for defining the optional dependencies when packaging
`geopandas` for e.g. `nixpkgs`
(<https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/geopandas/default.nix>)
as it is better for them to be defined here in the main repository than
downstream. As there is already code in `./geopandas/` that use these optional
dependencies, I believe they should be documented somewhere.

## Misc

I did not update `requirements-dev.txt` as I do not know if it is currently
up-to-date (<https://github.com/geopandas/geopandas/pull/2438#issuecomment-1205268708>)
or being maintained.

Marked as draft as no feedback yet given from maintainers. Hopefully this sounds good!
