### PR TITLE
COMPAT: fix _get_index_for_parts (explode, etc) for future pandas

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -5050,7 +5050,7 @@ def _get_index_for_parts(orig_idx, outer_idx, ignore_index, index_parts):
             index_arrays.append(inner_index)
 
             index = pd.MultiIndex.from_arrays(
-                index_arrays, names=orig_idx.names + [None]
+                index_arrays, names=list(orig_idx.names) + [None]
             )
 
         else:


### PR DESCRIPTION
We currently have a whole bunch of failures in the dev build with pandas main because of a change in the `.names` attribute of an Index no longer returning a list-like (FrozenList) but a tuple. This small fix will ensure it works in either case.
(https://github.com/pandas-dev/pandas/pull/57042#issuecomment-1935700777)
