### PR TITLE
ENH: make pyproj a soft-dependency

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,7 @@ jobs:
           - ci/envs/310-latest-conda-forge.yaml
           - ci/envs/311-latest-conda-forge.yaml
           - ci/envs/312-latest-conda-forge.yaml
+          - ci/envs/312-latest-conda-forge_no_pyproj.yaml
         include:
           - env: ci/envs/39-latest-conda-forge_no_fiona.yaml
             os: macos-latest

--- a/ci/envs/312-latest-conda-forge_no_pyproj.yaml
+++ b/ci/envs/312-latest-conda-forge_no_pyproj.yaml
@@ -1,0 +1,31 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  # required
+  - pandas
+  - shapely
+  - fiona
+  # - pyproj
+  - packaging
+  # testing
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  - fsspec
+  # optional
+  # - pyogrio
+  - matplotlib
+  - mapclassify
+  - folium
+  - xyzservices
+  - scipy
+  - geopy
+  # - pointpats
+  - geodatasets
+  # - SQLalchemy>=2
+  # - psycopg2
+  # - libspatialite
+  # - geoalchemy2
+  - pyarrow

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -67,7 +67,6 @@ def import_optional_dependency(name: str, extra: str = ""):
 # -----------------------------------------------------------------------------
 # pyproj compat
 # -----------------------------------------------------------------------------
-
 try:
     import pyproj  # noqa: F401
 
@@ -75,3 +74,15 @@ try:
 
 except ImportError:
     HAS_PYPROJ = False
+
+
+def requires_pyproj(func):
+    def wrapper(*args, **kwargs):
+        if not HAS_PYPROJ:
+            raise ImportError(
+                f"The 'pyproj' package is required for {func.__name__} to work. "
+                "Install it and initialize the object with a CRS before using it."
+            )
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -67,3 +67,11 @@ def import_optional_dependency(name: str, extra: str = ""):
 # -----------------------------------------------------------------------------
 # pyproj compat
 # -----------------------------------------------------------------------------
+
+try:
+    import pyproj  # noqa: F401
+
+    HAS_PYPROJ = True
+
+except ImportError:
+    HAS_PYPROJ = False

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -72,8 +72,9 @@ try:
 
     HAS_PYPROJ = True
 
-except ImportError:
+except ImportError as err:
     HAS_PYPROJ = False
+    pyproj_import_error = str(err)
 
 
 def requires_pyproj(func):
@@ -82,6 +83,7 @@ def requires_pyproj(func):
             raise ImportError(
                 f"The 'pyproj' package is required for {func.__name__} to work. "
                 "Install it and initialize the object with a CRS before using it."
+                f"\nImporting pyproj resulted in: {pyproj_import_error}"
             )
         return func(*args, **kwargs)
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -20,7 +20,7 @@ from pandas.api.extensions import (
 from shapely.geometry.base import BaseGeometry
 
 from .sindex import SpatialIndex
-from ._compat import HAS_PYPROJ
+from ._compat import HAS_PYPROJ, requires_pyproj
 
 if HAS_PYPROJ:
     from pyproj import Transformer
@@ -388,7 +388,10 @@ class GeometryArray(ExtensionArray):
         else:
             if value is not None:
                 warnings.warn(
-                    "pyproj not available. Cannot set CRS, falling back to None.",
+                    "Cannot set the CRS, falling back to None. The CRS support requires"
+                    " the 'pyproj' package, but it is not installed or does not import"
+                    " correctly. The functions depending on CRS will raise an error or"
+                    " may produce unexpected results.",
                     UserWarning,
                     stacklevel=2,
                 )
@@ -881,6 +884,7 @@ class GeometryArray(ExtensionArray):
             crs=self.crs,
         )
 
+    @requires_pyproj
     def to_crs(self, crs=None, epsg=None):
         """Returns a ``GeometryArray`` with all geometries transformed to a new
         coordinate reference system.
@@ -950,12 +954,6 @@ class GeometryArray(ExtensionArray):
         - Prime Meridian: Greenwich
 
         """
-        if not HAS_PYPROJ:
-            raise ImportError(
-                "The pyproj package is required for this operation. "
-                "Install it before using the to_crs() method."
-            )
-
         from pyproj import CRS
 
         if self.crs is None:
@@ -979,6 +977,7 @@ class GeometryArray(ExtensionArray):
         new_data = transform(self._data, transformer.transform)
         return GeometryArray(new_data, crs=crs)
 
+    @requires_pyproj
     def estimate_utm_crs(self, datum_name="WGS 84"):
         """Returns the estimated UTM CRS based on the bounds of the dataset.
 
@@ -1017,12 +1016,6 @@ class GeometryArray(ExtensionArray):
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
         """
-        if not HAS_PYPROJ:
-            raise ImportError(
-                "The pyproj package is required for this operation. "
-                "Install it before using the to_crs() method."
-            )
-
         from pyproj import CRS
         from pyproj.aoi import AreaOfInterest
         from pyproj.database import query_utm_crs_info

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -10,14 +10,13 @@ from pandas.core.accessor import CachedAccessor
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 
-from pyproj import CRS
-
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely, to_wkb, to_wkt
 from geopandas.base import GeoPandasBase, is_geometry_type
 from geopandas.geoseries import GeoSeries
 import geopandas.io
 from geopandas.explore import _explore
 from ._decorator import doc
+from ._compat import HAS_PYPROJ
 
 
 def _geodataframe_constructor_with_fallback(*args, **kwargs):
@@ -486,7 +485,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 crs = state.pop("crs", None)
             else:
                 crs = state.pop("_crs", None)
-            crs = CRS.from_user_input(crs) if crs is not None else crs
+            if HAS_PYPROJ:
+                from pyproj import CRS
+
+                crs = CRS.from_user_input(crs) if crs is not None else crs
+            else:
+                crs = None
 
         super().__setstate__(state)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -485,12 +485,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 crs = state.pop("crs", None)
             else:
                 crs = state.pop("_crs", None)
-            if HAS_PYPROJ:
+            if crs is not None and not HAS_PYPROJ:
+                raise ImportError(
+                    "Unpickling a GeoDataFrame with CRS requires the 'pyproj' package, "
+                    "but it is not installed or does not import correctly. "
+                )
+            elif crs is None:
+                crs = None
+            else:
                 from pyproj import CRS
 
                 crs = CRS.from_user_input(crs) if crs is not None else crs
-            else:
-                crs = None
 
         super().__setstate__(state)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -490,12 +490,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                     "Unpickling a GeoDataFrame with CRS requires the 'pyproj' package, "
                     "but it is not installed or does not import correctly. "
                 )
-            elif crs is None:
-                crs = None
-            else:
+            elif crs is not None:
                 from pyproj import CRS
 
-                crs = CRS.from_user_input(crs) if crs is not None else crs
+                crs = CRS.from_user_input(crs)
 
         super().__setstate__(state)
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -10,7 +10,6 @@ import pandas as pd
 from pandas import Series
 from pandas.core.internals import SingleBlockManager
 
-from pyproj import CRS
 import shapely
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry import GeometryCollection
@@ -1042,6 +1041,14 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.to_crs : re-project to another CRS
 
         """
+        if not compat.HAS_PYPROJ:
+            raise ImportError(
+                "The pyproj library is required to set a CRS on a GeoSeries. "
+                "Please install pyproj and try again."
+            )
+
+        from pyproj import CRS
+
         if crs is not None:
             crs = CRS.from_user_input(crs)
         elif epsg is not None:
@@ -1145,7 +1152,7 @@ class GeoSeries(GeoPandasBase, Series):
             self.values.to_crs(crs=crs, epsg=epsg), index=self.index, name=self.name
         )
 
-    def estimate_utm_crs(self, datum_name: str = "WGS 84") -> CRS:
+    def estimate_utm_crs(self, datum_name: str = "WGS 84"):
         """Returns the estimated UTM CRS based on the bounds of the dataset.
 
         .. versionadded:: 0.9

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -963,7 +963,7 @@ class GeoSeries(GeoPandasBase, Series):
     #
     # Additional methods
     #
-
+    @compat.requires_pyproj
     def set_crs(
         self,
         crs: Optional[Any] = None,
@@ -1041,12 +1041,6 @@ class GeoSeries(GeoPandasBase, Series):
         GeoSeries.to_crs : re-project to another CRS
 
         """
-        if not compat.HAS_PYPROJ:
-            raise ImportError(
-                "The pyproj library is required to set a CRS on a GeoSeries. "
-                "Please install pyproj and try again."
-            )
-
         from pyproj import CRS
 
         if crs is not None:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -655,8 +655,8 @@ def _to_file(
 def _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs):
     if not HAS_PYPROJ and crs:
         raise ImportError(
-            "The 'pyproj' package is required to write a file with a CRS. "
-            "Install 'pyproj' to write a file with a CRS."
+            "The 'pyproj' package is required to write a file with a CRS, but it is not"
+            " installed or does not import correctly."
         )
 
     if schema is None:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_integer_dtype
 
-import pyproj
 import shapely
 from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry
@@ -20,7 +19,7 @@ from urllib.parse import urlparse as parse_url
 from urllib.parse import uses_netloc, uses_params, uses_relative
 import urllib.request
 
-from geopandas._compat import PANDAS_GE_20
+from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")
@@ -654,11 +653,19 @@ def _to_file(
 
 
 def _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs):
+    if not HAS_PYPROJ and crs:
+        raise ImportError(
+            "The 'pyproj' package is required to write a file with a CRS. "
+            "Install 'pyproj' to write a file with a CRS."
+        )
+
     if schema is None:
         schema = infer_schema(df)
 
     if crs:
-        crs = pyproj.CRS.from_user_input(crs)
+        from pyproj import CRS
+
+        crs = CRS.from_user_input(crs)
     else:
         crs = df.crs
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -31,6 +31,7 @@ from geopandas.io.arrow import (
 )
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import mock
+from geopandas._compat import HAS_PYPROJ
 
 
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
@@ -38,7 +39,6 @@ DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
 # Skip all tests in this module if pyarrow is not available
 pyarrow = pytest.importorskip("pyarrow")
-pyproj = pytest.importorskip("pyproj")
 
 
 @pytest.fixture(
@@ -68,9 +68,10 @@ def test_create_metadata(naturalearth_lowres):
     assert metadata["version"] == METADATA_VERSION
     assert metadata["primary_column"] == "geometry"
     assert "geometry" in metadata["columns"]
-    crs_expected = df.crs.to_json_dict()
-    _remove_id_from_member_of_ensembles(crs_expected)
-    assert metadata["columns"]["geometry"]["crs"] == crs_expected
+    if HAS_PYPROJ:
+        crs_expected = df.crs.to_json_dict()
+        _remove_id_from_member_of_ensembles(crs_expected)
+        assert metadata["columns"]["geometry"]["crs"] == crs_expected
     assert metadata["columns"]["geometry"]["encoding"] == "WKB"
     assert metadata["columns"]["geometry"]["geometry_types"] == [
         "MultiPolygon",
@@ -86,6 +87,7 @@ def test_create_metadata(naturalearth_lowres):
 
 
 def test_crs_metadata_datum_ensemble():
+    pyproj = pytest.importorskip("pyproj")
     # compatibility for older PROJ versions using PROJJSON with datum ensembles
     # https://github.com/geopandas/geopandas/pull/2453
     crs = pyproj.CRS("EPSG:4326")
@@ -677,6 +679,7 @@ def test_write_empty_bbox(tmpdir, geometry):
 
 @pytest.mark.parametrize("format", ["feather", "parquet"])
 def test_write_read_default_crs(tmpdir, format):
+    pyproj = pytest.importorskip("pyproj")
     if format == "feather":
         from pyarrow.feather import write_feather as write
     else:
@@ -752,13 +755,14 @@ def test_write_spec_version(tmpdir, format, schema_version):
     assert metadata["version"] == schema_version
 
     # verify that CRS is correctly handled between versions
-    if schema_version == "0.1.0":
-        assert metadata["columns"]["geometry"]["crs"] == gdf.crs.to_wkt()
+    if HAS_PYPROJ:
+        if schema_version == "0.1.0":
+            assert metadata["columns"]["geometry"]["crs"] == gdf.crs.to_wkt()
 
-    else:
-        crs_expected = gdf.crs.to_json_dict()
-        _remove_id_from_member_of_ensembles(crs_expected)
-        assert metadata["columns"]["geometry"]["crs"] == crs_expected
+        else:
+            crs_expected = gdf.crs.to_json_dict()
+            _remove_id_from_member_of_ensembles(crs_expected)
+            assert metadata["columns"]["geometry"]["crs"] == crs_expected
 
     # verify that geometry_type(s) is correctly handled between versions
     if Version(schema_version) <= Version("0.4.0"):

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -10,7 +10,6 @@ import pytest
 from pandas import DataFrame, read_parquet as pd_read_parquet
 from pandas.testing import assert_frame_equal
 import numpy as np
-import pyproj
 import shapely
 from shapely.geometry import box, Point, MultiPolygon
 
@@ -39,6 +38,7 @@ DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
 # Skip all tests in this module if pyarrow is not available
 pyarrow = pytest.importorskip("pyarrow")
+pyproj = pytest.importorskip("pyproj")
 
 
 @pytest.fixture(

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -16,7 +16,7 @@ from shapely.geometry import Point, Polygon, box, mapping
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
-from geopandas._compat import PANDAS_GE_20
+from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
 from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
@@ -440,6 +440,7 @@ def test_to_file_schema(tmpdir, df_nybb, engine):
         assert result_schema == schema
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_to_file_crs(tmpdir, engine, nybb_filename):
     """
     Ensure that the file is written according to the crs
@@ -574,7 +575,8 @@ NYBB_CRS = "epsg:2263"
 def test_read_file(engine, nybb_filename):
     df = read_file(nybb_filename, engine=engine)
     validate_boro_df(df)
-    assert df.crs == NYBB_CRS
+    if HAS_PYPROJ:
+        assert df.crs == NYBB_CRS
     expected_columns = ["BoroCode", "BoroName", "Shape_Leng", "Shape_Area"]
     assert (df.columns[:-1] == expected_columns).all()
 
@@ -865,6 +867,7 @@ def test_read_file__columns(naturalearth_lowres):
     assert gdf.columns.tolist() == ["name", "pop_est", "geometry"]
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 @pytest.mark.parametrize("file_like", [False, True])
 def test_read_file_bbox_gdf(df_nybb, engine, nybb_filename, file_like):
     full_df_shape = df_nybb.shape
@@ -888,6 +891,7 @@ def test_read_file_bbox_gdf(df_nybb, engine, nybb_filename, file_like):
     assert filtered_df_shape == (2, 5)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 @pytest.mark.parametrize("file_like", [False, True])
 def test_read_file_mask_gdf(df_nybb, engine, nybb_filename, file_like):
     skip_pyogrio_lt_07(engine)
@@ -941,6 +945,7 @@ def test_read_file_mask_geojson(df_nybb, nybb_filename, engine):
     assert filtered_df_shape == (2, 5)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_read_file_bbox_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
     skip_pyogrio_lt_07(engine)
     full_df_shape = df_nybb.shape
@@ -962,6 +967,7 @@ def test_read_file_bbox_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
     assert filtered_df_shape == (2, 5)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_read_file_mask_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
     skip_pyogrio_lt_07(engine)
     full_df_shape = df_nybb.shape

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -932,6 +932,7 @@ def test_missing_pyproj():
     with pytest.warns(UserWarning, match="Cannot set the CRS, falling back to None"):
         t = T.copy()
         t.crs = 4326
+    assert t.crs is None
 
 
 @pytest.mark.parametrize("NA", [None, np.nan])

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -897,6 +897,7 @@ def test_check_crs():
     assert _check_crs(t1, T, allow_none=True) is True
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_crs_mismatch_warn():
     t1 = T.copy()
     t2 = T.copy()
@@ -914,6 +915,13 @@ def test_crs_mismatch_warn():
     # right None
     with pytest.warns(UserWarning, match="CRS mismatch between the CRS"):
         _crs_mismatch_warn(t1, T)
+
+
+@pytest.mark.skipif(HAS_PYPROJ, reason="pyproj installed")
+def test_missing_pyproj():
+    with pytest.warns(UserWarning, match="Cannot set the CRS, falling back to None"):
+        t = T.copy()
+        t.crs = 4326
 
 
 @pytest.mark.parametrize("NA", [None, np.nan])
@@ -941,6 +949,24 @@ def test_unique_has_crs():
     t = T.copy()
     t.crs = 4326
     assert t.unique().crs == t.crs
+
+
+@pytest.mark.skipif(HAS_PYPROJ, reason="pyproj installed")
+def test_to_crs_pyproj_error():
+    t = T.copy()
+    t.crs = 4326
+    with pytest.raises(
+        ImportError, match="The 'pyproj' package is required for to_crs"
+    ):
+        t.to_crs(3857)
+
+
+@pytest.mark.skipif(HAS_PYPROJ, reason="pyproj installed")
+def test_estimate_utm_crs_pyproj_error():
+    with pytest.raises(
+        ImportError, match="The 'pyproj' package is required for estimate_utm_crs"
+    ):
+        T.estimate_utm_crs()
 
 
 class TestEstimateUtmCrs:

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -3,13 +3,14 @@ import warnings
 
 import numpy as np
 import pandas as pd
-import pyproj
 import pytest
 from shapely.geometry import Point, Polygon, LineString
 
 from geopandas import GeoSeries, GeoDataFrame, points_from_xy, read_file
 from geopandas.array import from_shapely, from_wkb, from_wkt, GeometryArray
 from geopandas.testing import assert_geodataframe_equal
+
+pyproj = pytest.importorskip("pyproj")
 
 
 def _create_df(x, y=None, crs=None):

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -9,7 +9,7 @@ from geopandas import GeoDataFrame, read_file
 from pandas.testing import assert_frame_equal
 import pytest
 
-from geopandas._compat import PANDAS_GE_15, PANDAS_GE_20, PANDAS_GE_30
+from geopandas._compat import PANDAS_GE_15, PANDAS_GE_20, PANDAS_GE_30, HAS_PYPROJ
 from geopandas.testing import assert_geodataframe_equal, geom_almost_equals
 
 
@@ -63,6 +63,7 @@ def test_geom_dissolve(nybb_polydf, first):
     assert geom_almost_equals(test, first)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_dissolve_retains_existing_crs(nybb_polydf):
     assert nybb_polydf.crs is not None
     test = nybb_polydf.dissolve("manhattan_bronx")

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -5,6 +5,8 @@ import pytest
 import shapely
 from packaging.version import Version
 
+from geopandas._compat import HAS_PYPROJ
+
 folium = pytest.importorskip("folium")
 branca = pytest.importorskip("branca")
 matplotlib = pytest.importorskip("matplotlib")
@@ -56,6 +58,7 @@ class TestExplore:
         """Make sure default choropleth pass"""
         self.world.explore(column="pop_est")
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_map_settings_default(self):
         """Check default map settings"""
         m = self.world.explore()
@@ -74,6 +77,7 @@ class TestExplore:
         assert m.global_switches.disable_3d is False
         assert "openstreetmap" in m.to_dict()["children"].keys()
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_map_settings_custom(self):
         """Check custom map settings"""
         m = self.nybb.explore(
@@ -693,6 +697,7 @@ class TestExplore:
             == "tickValues([140.0,'','','',559086084.0,'','','',1118172028.0,'','',''])"
         )
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_providers(self):
         xyzservices = pytest.importorskip("xyzservices")
 
@@ -709,6 +714,7 @@ class TestExplore:
         )
         assert '"maxNativeZoom":20,"maxZoom":20,"minZoom":0' in out_str
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_query_name(self):
         pytest.importorskip("xyzservices")
 
@@ -725,6 +731,7 @@ class TestExplore:
         )
         assert '"maxNativeZoom":20,"maxZoom":20,"minZoom":0' in out_str
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_providers_min_zoom_override(self):
         xyzservices = pytest.importorskip("xyzservices")
 
@@ -735,6 +742,7 @@ class TestExplore:
 
         assert '"maxNativeZoom":20,"maxZoom":20,"minZoom":3' in out_str
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_providers_max_zoom_override(self):
         xyzservices = pytest.importorskip("xyzservices")
 
@@ -745,6 +753,7 @@ class TestExplore:
 
         assert '"maxNativeZoom":12,"maxZoom":12,"minZoom":0' in out_str
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_providers_both_zooms_override(self):
         xyzservices = pytest.importorskip("xyzservices")
 

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -11,6 +11,8 @@ from pandas.testing import assert_series_equal
 from geopandas.testing import assert_geodataframe_equal
 import pytest
 
+from geopandas._compat import HAS_PYPROJ
+
 geopy = pytest.importorskip("geopy")
 
 
@@ -71,7 +73,8 @@ def test_prepare_result():
 
     df = _prepare_geocode_result(d)
     assert type(df) is GeoDataFrame
-    assert df.crs == "EPSG:4326"
+    if HAS_PYPROJ:
+        assert df.crs == "EPSG:4326"
     assert len(df) == 2
     assert "address" in df
 
@@ -93,7 +96,8 @@ def test_prepare_result_none():
 
     df = _prepare_geocode_result(d)
     assert type(df) is GeoDataFrame
-    assert df.crs == "EPSG:4326"
+    if HAS_PYPROJ:
+        assert df.crs == "EPSG:4326"
     assert len(df) == 2
     assert "address" in df
 

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -24,6 +24,7 @@ from geopandas import GeoDataFrame, GeoSeries
 from geopandas.base import GeoPandasBase
 from geopandas.testing import assert_geodataframe_equal
 from geopandas.tests.util import assert_geoseries_equal, geom_almost_equals, geom_equals
+from geopandas._compat import HAS_PYPROJ
 
 
 def assert_array_dtype_equal(a, b, *args, **kwargs):
@@ -415,6 +416,7 @@ class TestGeomMethods:
         expected = Series(np.array([0.5, np.nan]), index=self.na_none.index)
         self._test_unary_real("area", expected, self.na_none)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_area_crs_warn(self):
         with pytest.warns(UserWarning, match="Geometry is in a geographic CRS"):
             self.g4.area
@@ -506,6 +508,7 @@ class TestGeomMethods:
         expected = Series(np.array([2 + np.sqrt(2), np.nan]), index=self.na_none.index)
         self._test_unary_real("length", expected, self.na_none)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_length_crs_warn(self):
         with pytest.warns(UserWarning, match="Geometry is in a geographic CRS"):
             self.g4.length
@@ -608,6 +611,7 @@ class TestGeomMethods:
         expected = Series(np.array([0, 0, 0, 0, val, np.nan, np.nan]), self.g0.index)
         assert_array_dtype_equal(expected, self.g0.distance(self.g9, align=False))
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_distance_crs_warning(self):
         with pytest.warns(UserWarning, match="Geometry is in a geographic CRS"):
             self.g4.distance(self.p0)
@@ -847,6 +851,7 @@ class TestGeomMethods:
         points = GeoSeries([point for i in range(3)])
         assert_geoseries_equal(polygons.centroid, points)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_centroid_crs_warn(self):
         with pytest.warns(UserWarning, match="Geometry is in a geographic CRS"):
             self.g4.centroid
@@ -1067,6 +1072,7 @@ class TestGeomMethods:
         with pytest.raises(ValueError):
             self.g5.interpolate(distances)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_interpolate_crs_warning(self):
         g5_crs = self.g5.copy()
         g5_crs.crs = 4326
@@ -1199,6 +1205,7 @@ class TestGeomMethods:
         result = s.buffer(np.array([0, 0, 0]))
         assert_geoseries_equal(result, s)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_buffer_crs_warn(self):
         with pytest.warns(UserWarning, match="Geometry is in a geographic CRS"):
             self.g4.buffer(1)

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -423,6 +423,13 @@ class TestSeries:
         expected = GeoSeries([Point(0, 2, -1), Point(3, 5, 4)])
         assert_geoseries_equal(expected, GeoSeries.from_xy(x, y, z))
 
+    @pytest.mark.skipif(HAS_PYPROJ, reason="pyproj installed")
+    def test_set_crs_pyproj_error(self):
+        with pytest.raises(
+            ImportError, match="The 'pyproj' package is required for set_crs"
+        ):
+            self.g1.set_crs(3857)
+
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_missing_values():

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -179,7 +179,6 @@ class TestMerging:
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res)
 
-    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_concat_axis1_multiple_geodataframes(self):
         # https://github.com/geopandas/geopandas/issues/1230
         # Expect that concat should fail gracefully if duplicate column names belonging
@@ -208,10 +207,11 @@ class TestMerging:
         with pytest.raises(ValueError, match=expected_err2):
             pd.concat([df2, df2], axis=1)
 
-        # Check that two geometry columns is fine, if they have different names
-        res3 = pd.concat([df2.set_crs("epsg:4326"), self.gdf], axis=1)
-        # check metadata comes from first df
-        self._check_metadata(res3, geometry_column_name="geom", crs="epsg:4326")
+        if HAS_PYPROJ:
+            # Check that two geometry columns is fine, if they have different names
+            res3 = pd.concat([df2.set_crs("epsg:4326"), self.gdf], axis=1)
+            # check metadata comes from first df
+            self._check_metadata(res3, geometry_column_name="geom", crs="epsg:4326")
 
     @pytest.mark.filterwarnings("ignore:Accessing CRS")
     def test_concat_axis1_geoseries(self):

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -1,10 +1,9 @@
 import warnings
 
 import pandas as pd
-import pyproj
 import pytest
 
-from geopandas._compat import PANDAS_GE_21
+from geopandas._compat import PANDAS_GE_21, HAS_PYPROJ
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_index_equal
 
@@ -62,6 +61,7 @@ class TestMerging:
         assert isinstance(res, GeoSeries)
         assert isinstance(res.geometry, GeoSeries)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_concat_axis0_crs(self):
         # CRS not set for both GeoDataFrame
         res = pd.concat([self.gdf, self.gdf])
@@ -103,6 +103,7 @@ class TestMerging:
                 [self.gdf, self.gdf.set_crs("epsg:4326"), self.gdf.set_crs("epsg:4327")]
             )
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_concat_axis0_unaligned_cols(self):
         # https://github.com/geopandas/geopandas/issues/2679
         gdf = self.gdf.set_crs("epsg:4326").assign(
@@ -137,6 +138,8 @@ class TestMerging:
             pd.concat([single_geom_col, partial_none_case])
 
     def test_concat_axis0_crs_wkt_mismatch(self):
+        pyproj = pytest.importorskip("pyproj")
+
         # https://github.com/geopandas/geopandas/issues/326#issuecomment-1727958475
         wkt_template = """GEOGCRS["WGS 84",
         ENSEMBLE["World Geodetic System 1984 ensemble",
@@ -176,6 +179,7 @@ class TestMerging:
         assert isinstance(res.geometry, GeoSeries)
         self._check_metadata(res)
 
+    @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
     def test_concat_axis1_multiple_geodataframes(self):
         # https://github.com/geopandas/geopandas/issues/1230
         # Expect that concat should fail gracefully if duplicate column names belonging

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pyproj
 import pytest
 
 from shapely.geometry import Point
@@ -8,6 +7,8 @@ import numpy as np
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.testing import assert_geodataframe_equal
 import geopandas
+
+pyproj = pytest.importorskip("pyproj")
 
 crs_osgb = pyproj.CRS(27700)
 crs_wgs = pyproj.CRS(4326)

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -8,7 +8,7 @@ from shapely.geometry import Point, Polygon, LineString, GeometryCollection, box
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, overlay, read_file
-from geopandas._compat import PANDAS_GE_20
+from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
@@ -345,6 +345,7 @@ def test_geoseries_warning(dfs):
         overlay(df1, df2.geometry, how="union")
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
 def test_preserve_crs(dfs, how):
     df1, df2 = dfs
     result = overlay(df1, df2, how=how)
@@ -356,6 +357,7 @@ def test_preserve_crs(dfs, how):
     assert result.crs == crs
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
 def test_crs_mismatch(dfs, how):
     df1, df2 = dfs
     df1.crs = 4326

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -287,6 +287,7 @@ def test_astype_invalid_geodataframe():
     assert res["a"].dtype == object
 
 
+@pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")
 def test_convert_dtypes(df):
     # https://github.com/geopandas/geopandas/issues/1870
 
@@ -657,6 +658,7 @@ def test_groupby_groups(df):
     assert_frame_equal(res, exp)
 
 
+@pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")
 @pytest.mark.parametrize("crs", [None, "EPSG:4326"])
 @pytest.mark.parametrize("geometry_name", ["geometry", "geom"])
 def test_groupby_metadata(crs, geometry_name):
@@ -768,6 +770,7 @@ def test_apply_convert_dtypes_keyword(s):
         assert len(record) == 0
 
 
+@pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")
 @pytest.mark.parametrize("crs", [None, "EPSG:4326"])
 def test_apply_no_geometry_result(df, crs):
     if crs:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1079,6 +1079,7 @@ def _setup_class_geographic_aspect(naturalearth_lowres, request):
 
 
 @pytest.mark.usefixtures("_setup_class_geographic_aspect")
+@pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")
 class TestGeographicAspect:
     def test_auto(self):
         ax = self.north.geometry.plot()

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -10,6 +10,7 @@ from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import from_shapely
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from geopandas._compat import HAS_PYPROJ
 import pytest
 
 s1 = GeoSeries(
@@ -102,9 +103,10 @@ def test_geodataframe():
         assert_geodataframe_equal(df1, df3)
 
     assert_geodataframe_equal(df5, df4, check_like=True)
-    df5.geom2.crs = 3857
-    with pytest.raises(AssertionError):
-        assert_geodataframe_equal(df5, df4, check_like=True)
+    if HAS_PYPROJ:
+        df5.geom2.crs = 3857
+        with pytest.raises(AssertionError):
+            assert_geodataframe_equal(df5, df4, check_like=True)
 
 
 def test_equal_nans():
@@ -119,6 +121,7 @@ def test_no_crs():
     assert_geodataframe_equal(df1, df2)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
 def test_ignore_crs_mismatch():
     df1 = GeoDataFrame({"col1": [1, 2], "geometry": s1.copy()}, crs="EPSG:4326")
     df2 = GeoDataFrame({"col1": [1, 2], "geometry": s1}, crs="EPSG:31370")

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -16,6 +16,7 @@ from shapely.geometry import (
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, clip
+from geopandas._compat import HAS_PYPROJ
 
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
@@ -397,6 +398,7 @@ def test_clip_multipoly_keep_slivers(multi_poly_gdf, single_rectangle_gdf):
     assert "GeometryCollection" in clipped.geom_type[0]
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not available")
 def test_warning_crs_mismatch(point_gdf, single_rectangle_gdf):
     with pytest.warns(UserWarning, match="CRS mismatch between the CRS"):
         clip(point_gdf, single_rectangle_gdf.to_crs(4326))

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -107,6 +107,7 @@ class TestSpatialJoin:
         joined = sjoin(left, right, how=how, lsuffix=lsuffix, rsuffix=rsuffix)
         assert set(joined.columns) == expected_cols | {"geometry"}
 
+    @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")
     @pytest.mark.parametrize("dfs", ["default-index", "string-index"], indirect=True)
     def test_crs_mismatch(self, dfs):
         index, df1, df2, expected = dfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ filterwarnings = [
     "ignore:The --rsyncdir command line argument:DeprecationWarning",
     # dateutil incompatibility with python 3.12 (https://github.com/dateutil/dateutil/issues/1284)
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil",
+    "ignore:pyproj not available:UserWarning:geopandas",
 ]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ filterwarnings = [
     "ignore:The --rsyncdir command line argument:DeprecationWarning",
     # dateutil incompatibility with python 3.12 (https://github.com/dateutil/dateutil/issues/1284)
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil",
-    "ignore:pyproj not available:UserWarning:geopandas",
+    "ignore:Cannot set the CRS, falling back to None:UserWarning:geopandas",
 ]
 
 [tool.black]


### PR DESCRIPTION
Closes #2077

When pyproj is not available and a user tries to set a CRS, it currently falls back to `None` and warns about the situation. It may be cleaner to raise an error to avoid potential issues with that though but you wouldn't be able to read a file in such a case. Now you can read it but you won't get CRS support.

Also, raising would require a ton of skips in our tests. Warnings can just be silenced.