### PR TITLE
COMPAT: Update import of parse_path from fiona

### DIFF
--- a/ci/envs/311-dev.yaml
+++ b/ci/envs/311-dev.yaml
@@ -24,8 +24,7 @@ dependencies:
     - mapclassify>=2.4.0
     # dev versions of packages
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
-    # TEMP pin, see https://github.com/geopandas/geopandas/issues/3207
-    - fiona==1.9.*
+    - fiona
     - pandas
     - matplotlib
     - pyarrow

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -326,6 +326,7 @@ def _read_file_fiona(
             # Meanwhile parse_path is imported here to avoid adding more conditional
             # statements at the top of the module.
             from fiona.path import parse_path
+
             parsed = parse_path(str(path_or_bytes))
             if isinstance(parsed, fiona.path.ParsedPath):
                 # If fiona is able to parse the path, we can safely look at the scheme

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -178,6 +178,8 @@ def _is_url(url):
 
 def _is_zip(path):
     """Check if a given path is a zipfile"""
+    import fiona.path
+
     parsed = fiona.path.ParsedPath.from_uri(path)
     return (
         parsed.archive.endswith(".zip")

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -322,7 +322,11 @@ def _read_file_fiona(
         # zipped file. In order to match that behavior, attempt to add a zip scheme
         # if missing.
         if _is_zip(str(path_or_bytes)):
-            parsed = fiona.parse_path(str(path_or_bytes))
+            # TODO: disconnect GeoPandas from Fiona's URI/path parsing internals.
+            # Meanwhile parse_path is imported here to avoid adding more conditional
+            # statements at the top of the module.
+            from fiona.path import parse_path
+            parsed = parse_path(str(path_or_bytes))
             if isinstance(parsed, fiona.path.ParsedPath):
                 # If fiona is able to parse the path, we can safely look at the scheme
                 # and update it to have a zip scheme if necessary.

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -687,11 +687,6 @@ def test_infer_zipped_file(engine, nybb_filename):
     gdf = read_file("file+file://" + path, engine=engine)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
-    # Check that it can add a zip scheme for a path that includes a subpath
-    # within the archive.
-    gdf = read_file(path + "!nybb.shp", engine=engine)
-    assert isinstance(gdf, geopandas.GeoDataFrame)
-
 
 def test_allow_legacy_gdal_path(engine, nybb_filename):
     # Construct a GDAL-style zip path.

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -687,6 +687,13 @@ def test_infer_zipped_file(engine, nybb_filename):
     gdf = read_file("file+file://" + path, engine=engine)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 
+    # Check that it can add a zip scheme for a path that includes a subpath
+    # within the archive.
+    # TODO: fix for fiona
+    if engine == "pyogrio":
+        gdf = read_file(path + "!nybb.shp", engine=engine)
+        assert isinstance(gdf, geopandas.GeoDataFrame)
+
 
 def test_allow_legacy_gdal_path(engine, nybb_filename):
     # Construct a GDAL-style zip path.


### PR DESCRIPTION
Replaces broken usage with deprecated usage. Disentangling GeoPandas from fiona's path module is left as a TODO.

Resolves #3207

@m-richards @jorisvandenbossche I think this should get the project back in green.