### PR TITLE
DOC: link to pyarrow.parquet.read_table

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -559,7 +559,7 @@ def _read_parquet(path, columns=None, storage_options=None, **kwargs):
         filesystem is preferred. Provide the instantiated fsspec filesystem using
         the ``filesystem`` keyword if you wish to use its implementation.
     **kwargs
-        Any additional kwargs passed to pyarrow.parquet.read_table().
+        Any additional kwargs passed to :func:`pyarrow.parquet.read_table`.
 
     Returns
     -------


### PR DESCRIPTION
This should use intersphinx mapping and render as a link to https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html
see also https://github.com/geopandas/geopandas/pull/2016

