### PR TITLE
ENH: show_bbox and drop_id added to geoseries.to_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,8 @@ New features and improvements:
   the specified columns (#3101).
 - Added support to ``read_file`` for the ``mask`` keyword for the pyogrio engine (#3062).
 - Added support to ``read_file`` for the ``columns`` keyword for the fiona engine (#3133).
-- Added `show_bbox`, `drop_id` and `to_wgs84` arguments to allow further customization of 
+- Added `show_bbox`, `drop_id` and `to_wgs84` arguments to allow further customization of
   `GeoSeries.to_json` (#3226)
-
-API changes:
-- Added support for ``mask`` keyword for pyogrio engine for pyogrio >= 0.7.0 (#3062).
 
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ New features and improvements:
   the specified columns (#3101).
 - Added support to ``read_file`` for the ``mask`` keyword for the pyogrio engine (#3062).
 - Added support to ``read_file`` for the ``columns`` keyword for the fiona engine (#3133).
+- Added `show_bbox` and `drop_id` arguments to allow removal of unwanted parameters from 
+  `GeoSeries.to_json` (#3226)
+
+API changes:
+- Added support for ``mask`` keyword for pyogrio engine for pyogrio >= 0.7.0 (#3062).
 
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ New features and improvements:
   the specified columns (#3101).
 - Added support to ``read_file`` for the ``mask`` keyword for the pyogrio engine (#3062).
 - Added support to ``read_file`` for the ``columns`` keyword for the fiona engine (#3133).
-- Added `show_bbox` and `drop_id` arguments to allow removal of unwanted parameters from 
+- Added `show_bbox`, `drop_id` and `to_wgs84` arguments to allow further customization of 
   `GeoSeries.to_json` (#3226)
 
 API changes:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1189,7 +1189,7 @@ class GeoSeries(GeoPandasBase, Series):
         """
         return self.values.estimate_utm_crs(datum_name)
 
-    def to_json(self, show_bbox=True, drop_id=False, to_wgs84=False, **kwargs) -> str:
+    def to_json(self, show_bbox:bool=True, drop_id:bool=False, to_wgs84:bool=False, **kwargs) -> str:
         """
         Returns a GeoJSON string representation of the GeoSeries.
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1201,6 +1201,13 @@ class GeoSeries(GeoPandasBase, Series):
             Whether to retain the index of the GeoSeries as the id property
             in the generated GeoJSON. Default is False, but may want True
             if the index is just arbitrary row numbers.
+        to_wgs84: bool, optional, default: False
+            If the CRS is set on the active geometry column it is exported as
+            WGS84 (EPSG:4326) to meet the `2016 GeoJSON specification
+            <https://tools.ietf.org/html/rfc7946>`_.
+            Set to True to force re-projection and set to False to ignore CRS. False by
+            default.
+
         *kwargs* that will be passed to json.dumps().
 
         Returns

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1190,12 +1190,18 @@ class GeoSeries(GeoPandasBase, Series):
         """
         return self.values.estimate_utm_crs(datum_name)
 
-    def to_json(self, **kwargs) -> str:
+    def to_json(self, show_bbox=True, drop_id=False, **kwargs) -> str:
         """
         Returns a GeoJSON string representation of the GeoSeries.
 
         Parameters
         ----------
+        show_bbox : bool, optional, default: True
+            Include bbox (bounds) in the geojson
+        drop_id : bool, default: False
+            Whether to retain the index of the GeoSeries as the id property
+            in the generated GeoJSON. Default is False, but may want True
+            if the index is just arbitrary row numbers.
         *kwargs* that will be passed to json.dumps().
 
         Returns
@@ -1224,7 +1230,13 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         --------
         GeoSeries.to_file : write GeoSeries to file
         """
-        return json.dumps(self.__geo_interface__, **kwargs)
+        from geopandas import GeoDataFrame
+
+        return json.dumps(
+            GeoDataFrame({"geometry": self}).to_geo_dict(
+                show_bbox=show_bbox, drop_id=drop_id
+            )
+        )
 
     def to_wkb(self, hex: bool = False, **kwargs) -> Series:
         """

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import typing
 from typing import Optional, Any, Callable, Dict
 import warnings
@@ -1190,7 +1189,7 @@ class GeoSeries(GeoPandasBase, Series):
         """
         return self.values.estimate_utm_crs(datum_name)
 
-    def to_json(self, show_bbox=True, drop_id=False, **kwargs) -> str:
+    def to_json(self, show_bbox=True, drop_id=False, to_wgs84=False, **kwargs) -> str:
         """
         Returns a GeoJSON string representation of the GeoSeries.
 
@@ -1232,10 +1231,8 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         """
         from geopandas import GeoDataFrame
 
-        return json.dumps(
-            GeoDataFrame({"geometry": self}).to_geo_dict(
-                show_bbox=show_bbox, drop_id=drop_id
-            )
+        return GeoDataFrame({"geometry": self}).to_json(
+            na="null", show_bbox=show_bbox, drop_id=drop_id, to_wgs84=to_wgs84, **kwargs
         )
 
     def to_wkb(self, hex: bool = False, **kwargs) -> Series:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1236,9 +1236,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         --------
         GeoSeries.to_file : write GeoSeries to file
         """
-        from geopandas import GeoDataFrame
-
-        return GeoDataFrame({"geometry": self}).to_json(
+        return self.to_frame("geometry").to_json(
             na="null", show_bbox=show_bbox, drop_id=drop_id, to_wgs84=to_wgs84, **kwargs
         )
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1189,7 +1189,13 @@ class GeoSeries(GeoPandasBase, Series):
         """
         return self.values.estimate_utm_crs(datum_name)
 
-    def to_json(self, show_bbox:bool=True, drop_id:bool=False, to_wgs84:bool=False, **kwargs) -> str:
+    def to_json(
+        self,
+        show_bbox: bool = True,
+        drop_id: bool = False,
+        to_wgs84: bool = False,
+        **kwargs,
+    ) -> str:
         """
         Returns a GeoJSON string representation of the GeoSeries.
 

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -201,8 +201,36 @@ class TestSeries:
         Test whether GeoSeries.to_json works and returns an actual json file.
         """
         json_str = self.g3.to_json()
-        json.loads(json_str)
+        data = json.loads(json_str)
+        assert "id" in data["features"][0].keys()
+        assert "bbox" in data["features"][0].keys()
         # TODO : verify the output is a valid GeoJSON.
+
+    def test_to_json_drop_id(self):
+        """
+        Test whether GeoSeries.to_json works when drop_id is True.
+        """
+        json_str = self.g3.to_json(drop_id=True)
+        data = json.loads(json_str)
+        assert "id" not in data["features"][0].keys()
+
+    def test_to_json_no_bbox(self):
+        """
+        Test whether GeoSeries.to_json works when show_bbox is False.
+        """
+        json_str = self.g3.to_json(show_bbox=False)
+        data = json.loads(json_str)
+        assert "bbox" not in data["features"][0].keys()
+
+    def test_to_json_no_bbox_drop_id(self):
+        """
+        Test whether GeoSeries.to_json works when show_bbox is False
+        and drop_id is True.
+        """
+        json_str = self.g3.to_json(show_bbox=False, drop_id=True)
+        data = json.loads(json_str)
+        assert "id" not in data["features"][0].keys()
+        assert "bbox" not in data["features"][0].keys()
 
     def test_representative_point(self):
         assert np.all(self.g1.contains(self.g1.representative_point()))

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -55,6 +55,9 @@ class TestSeries:
         self.l1 = LineString([(0, 0), (0, 1), (1, 1)])
         self.l2 = LineString([(0, 0), (1, 0), (1, 1), (0, 1)])
         self.g5 = GeoSeries([self.l1, self.l2])
+        self.esb3857 = Point(-8235939.130493107, 4975301.253789809)
+        self.sol3857 = Point(-8242607.167991625, 4966620.938285081)
+        self.landmarks3857 = GeoSeries([self.esb3857, self.sol3857], crs="epsg:3857")
 
     def teardown_method(self):
         shutil.rmtree(self.tempdir)
@@ -231,6 +234,30 @@ class TestSeries:
         data = json.loads(json_str)
         assert "id" not in data["features"][0].keys()
         assert "bbox" not in data["features"][0].keys()
+
+    def test_to_json_wgs84(self):
+        """
+        Test whether the wgs84 conversion works as intended.
+        """
+        text = self.landmarks3857.to_json(to_wgs84=True)
+        data = json.loads(text)
+        assert data["type"] == "FeatureCollection"
+        assert "id" in data["features"][0].keys()
+        coord1 = data["features"][0]["geometry"]["coordinates"]
+        coord2 = data["features"][1]["geometry"]["coordinates"]
+        np.testing.assert_allclose(coord1, self.esb.coords[0])
+        np.testing.assert_allclose(coord2, self.sol.coords[0])
+
+    def test_to_json_wgs84_false(self):
+        """
+        Ensure no conversion to wgs84
+        """
+        text = self.landmarks3857.to_json()
+        data = json.loads(text)
+        coord1 = data["features"][0]["geometry"]["coordinates"]
+        coord2 = data["features"][1]["geometry"]["coordinates"]
+        np.testing.assert_allclose(coord1, [-8235939.130493107, 4975301.253789809])
+        np.testing.assert_allclose(coord2, [-8242607.167991625, 4966620.938285081])
 
     def test_representative_point(self):
         assert np.all(self.g1.contains(self.g1.representative_point()))

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -235,6 +235,7 @@ class TestSeries:
         assert "id" not in data["features"][0].keys()
         assert "bbox" not in data["features"][0].keys()
 
+    @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="Requires pyproj")
     def test_to_json_wgs84(self):
         """
         Test whether the wgs84 conversion works as intended.
@@ -256,8 +257,8 @@ class TestSeries:
         data = json.loads(text)
         coord1 = data["features"][0]["geometry"]["coordinates"]
         coord2 = data["features"][1]["geometry"]["coordinates"]
-        np.testing.assert_allclose(coord1, [-8235939.130493107, 4975301.253789809])
-        np.testing.assert_allclose(coord2, [-8242607.167991625, 4966620.938285081])
+        assert coord1 == [-8235939.130493107, 4975301.253789809]
+        assert coord2 == [-8242607.167991625, 4966620.938285081]
 
     def test_representative_point(self):
         assert np.all(self.g1.contains(self.g1.representative_point()))


### PR DESCRIPTION
Closes #3199 using existing functions in GeoDataFrame.

Have not included `na` as an attribute as Properties aren't used in GeoSeries as far as I understand.

I noted default of `GeoDataFrame.to_json` show_bbox is False, but the existing code defaults to True, hence have explicitly left default as True.