### PR TITLE
Add area averaged mean aggfunc to dissolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ New features and improvements:
 - Added `geom_equals_identical` method exposing `equals_identical` from shapely to GeoSeries/GeoDataFrame (#3560).
 - GeoPandas now attempts to use a range request when reading from an URL even if the header
  does not directly indicate its support (#3572).
+- Added `area_weighted_mean` aggfunc option to `GeoDataFrame.dissolve()` (#3229)
 
 Bug fixes:
 


### PR DESCRIPTION
Resolves #3028.

A proposed approach to do an area averaged mean (specific aggfunc argument TBD).

This approach allows us to use the existing pandas aggfunc so the kwargs still take effect.

Have refactored to process geometries first, allowing processing of spatial_average_mean in one `if` statement, instead of having one at the start during non-geometry processing, and one after geometry processing (ref first commit before refactoring).

Haven't fully tested the kwargs, nor written unit testing yet, nor documentation. Seeking prelim feedback before progressing further.