### PR TITLE
MAINT: Fiona 1.10 compat for zip files

### DIFF
--- a/ci/envs/310-pd20-conda-forge.yaml
+++ b/ci/envs/310-pd20-conda-forge.yaml
@@ -11,8 +11,7 @@ dependencies:
   - pyproj
   - packaging
   # testing
-  # TEMP pin, 8.1 breaks doctestplus, see https://github.com/scientific-python/pytest-doctestplus/issues/239
-  - pytest==8.0.*
+  - pytest
   - pytest-cov
   - pytest-xdist
   - fsspec

--- a/ci/envs/311-dev.yaml
+++ b/ci/envs/311-dev.yaml
@@ -24,8 +24,7 @@ dependencies:
     - mapclassify>=2.4.0
     # dev versions of packages
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
-    # TEMP pin, see https://github.com/geopandas/geopandas/issues/3207
-    - fiona==1.9.*
+    - fiona
     - pandas
     - matplotlib
     - pyarrow

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -188,27 +188,6 @@ else:
     from fiona.path import ParsedPath, UnparsedPath, parse_path
 
 
-def _fio_19_from_uri(uri):
-    # Note this logic will fail for bangs in urls, we need ot merge with to zip
-    # check if this yields something ending in zip, and if it doesn't, then we
-    # might have treated bangs
-    # incorrectly and should re-parse with fiona logic
-    parts = urlparse(uri)
-    path = parts.path
-    scheme = parts.scheme or None
-
-    if parts.query:
-        path += "?" + parts.query
-
-    if parts.scheme and parts.netloc:
-        path = parts.netloc + path
-
-    parts = path.split("!")
-    path = parts.pop() if parts else None
-    archive = parts.pop() if parts else None
-    return ParsedPath(path, archive, scheme)
-
-
 def _is_zip(uri):
     """Check if a given path is a zipfile"""
     # This logic is drawn from fiona <=1.9.4 ParsedPath.from_uri

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -6,6 +6,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from geopandas.io.util import vsi_path
 from pandas.api.types import is_integer_dtype
 
 import shapely
@@ -15,7 +16,7 @@ from shapely.geometry.base import BaseGeometry
 from geopandas import GeoDataFrame, GeoSeries
 
 # Adapted from pandas.io.common
-from urllib.parse import urlparse as parse_url, urlparse
+from urllib.parse import urlparse as parse_url
 from urllib.parse import uses_netloc, uses_params, uses_relative
 import urllib.request
 
@@ -31,7 +32,6 @@ fiona = None
 fiona_env = None
 fiona_import_error = None
 FIONA_GE_19 = False
-FIONA_GE_110 = False
 
 
 def _import_fiona():
@@ -39,7 +39,6 @@ def _import_fiona():
     global fiona_env
     global fiona_import_error
     global FIONA_GE_19
-    global FIONA_GE_110
 
     if fiona is None:
         try:
@@ -59,9 +58,7 @@ def _import_fiona():
             FIONA_GE_19 = Version(Version(fiona.__version__).base_version) >= Version(
                 "1.9.0"
             )
-            FIONA_GE_110 = Version(Version(fiona.__version__).base_version) >= Version(
-                "1.10a1"
-            )
+
         except ImportError as err:
             fiona = False
             fiona_import_error = str(err)
@@ -163,22 +160,6 @@ _EXTENSION_TO_DRIVER = {
 }
 
 
-def _fiona_path_internals():
-    # assume _check_fiona() has already happened
-    assert fiona is not None
-
-    # TODO: disconnect GeoPandas from Fiona's URI/path parsing internals.
-    if FIONA_GE_110:
-        # private imports avoid warnings bubbling to users
-        # but persist the underlying problem
-        from fiona._path import _ParsedPath as ParsedPath
-        from fiona._path import _UnparsedPath as UnparsedPath
-        from fiona._path import _parse_path as parse_path
-    else:
-        from fiona.path import ParsedPath, UnparsedPath, parse_path
-    return parse_path, ParsedPath, UnparsedPath
-
-
 def _expand_user(path):
     """Expand paths that use ~."""
     if isinstance(path, str):
@@ -194,23 +175,6 @@ def _is_url(url):
         return parse_url(url).scheme in _VALID_URLS
     except Exception:
         return False
-
-
-def _is_zip(uri):
-    """Check if a given path is a zipfile"""
-    # This logic is drawn from fiona <=1.9.4 ParsedPath.from_uri
-    parts = urlparse(uri)
-    path = parts.path
-    if parts.query:
-        path += "?" + parts.query
-
-    if parts.scheme and parts.netloc:
-        path = parts.netloc + path
-
-    first, *rest = path.rsplit("!", maxsplit=1)
-    # Either 1 or 2 components, first element is either the whole path,
-    # or the part before the (potential) archive path
-    return first.endswith(".zip")
 
 
 def _read_file(filename, bbox=None, mask=None, rows=None, engine=None, **kwargs):
@@ -348,27 +312,7 @@ def _read_file_fiona(
         # Opening a file via URL or file-like-object above automatically detects a
         # zipped file. In order to match that behavior, attempt to add a zip scheme
         # if missing.
-        parse_path, ParsedPath, UnparsedPath = _fiona_path_internals()
-        if _is_zip(str(path_or_bytes)):
-            # TODO: disconnect GeoPandas from Fiona's URI/path parsing internals.
-            parsed = parse_path(str(path_or_bytes))
-            if isinstance(parsed, ParsedPath):
-                # If fiona is able to parse the path, we can safely look at the scheme
-                # and update it to have a zip scheme if necessary.
-                schemes = (parsed.scheme or "").split("+")
-                if "zip" not in schemes:
-                    # In fiona 1.10, Windows drive schema paths become
-                    # ParsedPaths instead of UnparsedPaths,
-                    # but with no scheme set, so need to rstrip "+" in this case.
-                    parsed.scheme = "+".join(["zip"] + schemes).rstrip("+")
-                path_or_bytes = parsed.name
-            elif isinstance(parsed, UnparsedPath) and not str(path_or_bytes).startswith(
-                "/vsi"
-            ):
-                # If fiona is unable to parse the path, it might have a Windows drive
-                # scheme. Try adding zip:// to the front. If the path starts with "/vsi"
-                # it is a legacy GDAL path type, so let it pass unmodified.
-                path_or_bytes = "zip://" + parsed.name
+        path_or_bytes = vsi_path(str(path_or_bytes))
 
     if from_bytes:
         reader = fiona.BytesCollection

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -337,6 +337,9 @@ def _read_file_fiona(
         raise NotImplementedError("where requires fiona 1.9+")
 
     if not from_bytes:
+        # Opening a file via URL or file-like-object above automatically detects a
+        # zipped file. In order to match that behavior, attempt to add a zip scheme
+        # if missing.
         if _is_zip(str(path_or_bytes)):
             parsed = parse_path(str(path_or_bytes))
             if isinstance(parsed, ParsedPath):

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -691,10 +691,8 @@ def test_infer_zipped_file(engine, nybb_filename):
 
     # Check that it can add a zip scheme for a path that includes a subpath
     # within the archive.
-    # TODO: fix for fiona
-    if engine == "pyogrio":
-        gdf = read_file(path + "!nybb.shp", engine=engine)
-        assert isinstance(gdf, geopandas.GeoDataFrame)
+    gdf = read_file(path + "!nybb.shp", engine=engine)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
 def test_allow_legacy_gdal_path(engine, nybb_filename):

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -17,7 +17,7 @@ from shapely.geometry import Point, Polygon, box, mapping
 import geopandas
 from geopandas import GeoDataFrame, read_file
 from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
-from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER
+from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER, _is_zip
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
 
@@ -586,15 +586,15 @@ def test_read_file(engine, nybb_filename):
     "url",
     [
         # geojson url
-        "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "main/geopandas/tests/data/null_geom.geojson",
+        # "https://raw.githubusercontent.com/geopandas/geopandas/"
+        # "main/geopandas/tests/data/null_geom.geojson",
         # url to zip file
         "https://raw.githubusercontent.com/geopandas/geopandas/"
         "main/geopandas/tests/data/nybb_16a.zip",
         # url to zipfile without extension
-        "https://geonode.goosocean.org/download/480",
+        # "https://geonode.goosocean.org/download/480",
         # url to web service
-        "https://demo.pygeoapi.io/stable/collections/obs/items",
+        # "https://demo.pygeoapi.io/stable/collections/obs/items",
     ],
 )
 def test_read_file_url(engine, url):
@@ -677,17 +677,25 @@ def test_read_text_file_fsspec(file_path, engine):
         assert isinstance(gdf, geopandas.GeoDataFrame)
 
 
+def test_is_zip():
+    url = "https://xxx:yyy!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d-440eb61d891a/baum.tif"
+    assert not _is_zip(url)
+
+    url = ("https://xxx:yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
+           "-440eb61d891a/baum.tif")
+    assert _is_zip(url)
+
 def test_infer_zipped_file(engine, nybb_filename):
     # Remove the zip scheme so that the test for a zipped file can
     # check it and add it back.
     path = nybb_filename[6:]
-    gdf = read_file(path, engine=engine)
-    assert isinstance(gdf, geopandas.GeoDataFrame)
-
-    # Check that it can successfully add a zip scheme to a path that already has a
-    # scheme
-    gdf = read_file("file+file://" + path, engine=engine)
-    assert isinstance(gdf, geopandas.GeoDataFrame)
+    # gdf = read_file(path, engine=engine)
+    # assert isinstance(gdf, geopandas.GeoDataFrame)
+    #
+    # # Check that it can successfully add a zip scheme to a path that already has a
+    # # scheme
+    # gdf = read_file("file+file://" + path, engine=engine)
+    # assert isinstance(gdf, geopandas.GeoDataFrame)
 
     # Check that it can add a zip scheme for a path that includes a subpath
     # within the archive.
@@ -819,6 +827,7 @@ def test_read_file_missing_geometry(tmpdir, engine):
 
 
 def test_read_file_None_attribute(tmp_path, engine):
+    # this was failing
     # Test added in context of https://github.com/geopandas/geopandas/issues/2901
     test_path = tmp_path / "test.gpkg"
     gdf = GeoDataFrame(

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -17,7 +17,7 @@ from shapely.geometry import Point, Polygon, box, mapping
 import geopandas
 from geopandas import GeoDataFrame, read_file
 from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
-from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER, _is_zip
+from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
 
@@ -675,51 +675,6 @@ def test_read_text_file_fsspec(file_path, engine):
     with fsspec.open(file_path, "r") as f:
         gdf = read_file(f, engine=engine)
         assert isinstance(gdf, geopandas.GeoDataFrame)
-
-
-def test_is_zip():
-    # from https://github.com/rasterio/rasterio/commit/dce1c75880d09d7da83b8d7d966c7da2f4faa448
-    url = "https://xxx:yyy!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d-440eb61d891a/baum.tif"
-    assert not _is_zip(url)
-
-    url = (
-        "https://xxx:yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
-        "-440eb61d891a/baum.tif"
-    )
-    assert _is_zip(url)
-    # Degenerate cases which may not actually come up
-    url = (
-        "https://xxx:yyy.zip!foo!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
-        "-440eb61d891a/baum.tif"
-    )
-    assert not _is_zip(url)
-    url = (
-        "https://xxx!yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
-        "-440eb61d891a/baum.tif"
-    )
-    assert _is_zip(url)
-
-    assert _is_zip("nybb.zip")
-    assert _is_zip("./nybb.zip")
-    assert _is_zip("~/nybb.zip")
-    assert _is_zip("c:/users/jane.doe/nybb.zip")
-    assert _is_zip(r"c:\users\jane.doe\nybb.zip")
-    assert _is_zip(r"c:\users\jane.doe\nybb.zip!nybb.shp")
-    assert _is_zip(r"zip://c:\users\jane.doe\nybb.zip!nybb.shp")
-    assert _is_zip("/home/jane.doe/nybb.zip")
-    assert _is_zip("/mnt/data/nybb.zip")
-    assert _is_zip("/mnt/data/nybb.zip!nybb.shp")
-    assert _is_zip(
-        "https://raw.githubusercontent.com/geopandas/geopandas/"
-        "main/geopandas/tests/data/nybb_16a.zip"
-    )
-    assert not _is_zip("nybb.txt")
-    assert not _is_zip("./nybb.txt")
-    assert not _is_zip("~/nybb.txt")
-    assert not _is_zip("c:/users/jane.doe/nybb.txt")
-    assert not _is_zip(r"c:\users\jane.doe\nybb.txt")
-    assert not _is_zip("/home/jane.doe/nybb.txt")
-    assert not _is_zip("/mnt/data/nybb.txt")
 
 
 def test_infer_zipped_file(engine, nybb_filename):

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -699,6 +699,28 @@ def test_is_zip():
     )
     assert _is_zip(url)
 
+    assert _is_zip("nybb.zip")
+    assert _is_zip("./nybb.zip")
+    assert _is_zip("~/nybb.zip")
+    assert _is_zip("c:/users/jane.doe/nybb.zip")
+    assert _is_zip(r"c:\users\jane.doe\nybb.zip")
+    assert _is_zip(r"c:\users\jane.doe\nybb.zip!nybb.shp")
+    assert _is_zip(r"zip://c:\users\jane.doe\nybb.zip!nybb.shp")
+    assert _is_zip("/home/jane.doe/nybb.zip")
+    assert _is_zip("/mnt/data/nybb.zip")
+    assert _is_zip("/mnt/data/nybb.zip!nybb.shp")
+    assert _is_zip(
+        "https://raw.githubusercontent.com/geopandas/geopandas/"
+        "main/geopandas/tests/data/nybb_16a.zip"
+    )
+    assert not _is_zip("nybb.txt")
+    assert not _is_zip("./nybb.txt")
+    assert not _is_zip("~/nybb.txt")
+    assert not _is_zip("c:/users/jane.doe/nybb.txt")
+    assert not _is_zip(r"c:\users\jane.doe\nybb.txt")
+    assert not _is_zip("/home/jane.doe/nybb.txt")
+    assert not _is_zip("/mnt/data/nybb.txt")
+
 
 def test_infer_zipped_file(engine, nybb_filename):
     # Remove the zip scheme so that the test for a zipped file can

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -678,12 +678,27 @@ def test_read_text_file_fsspec(file_path, engine):
 
 
 def test_is_zip():
+    # from https://github.com/rasterio/rasterio/commit/dce1c75880d09d7da83b8d7d966c7da2f4faa448
     url = "https://xxx:yyy!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d-440eb61d891a/baum.tif"
     assert not _is_zip(url)
 
-    url = ("https://xxx:yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
-           "-440eb61d891a/baum.tif")
+    url = (
+        "https://xxx:yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
+        "-440eb61d891a/baum.tif"
+    )
     assert _is_zip(url)
+    # Degenerate cases which may not actually come up
+    url = (
+        "https://xxx:yyy.zip!foo!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
+        "-440eb61d891a/baum.tif"
+    )
+    assert not _is_zip(url)
+    url = (
+        "https://xxx!yyy.zip!@actinia.mundialis.de/api/v3/resources/demouser/resource_id-1e904ec8-ad55-4eda-8f0d"
+        "-440eb61d891a/baum.tif"
+    )
+    assert _is_zip(url)
+
 
 def test_infer_zipped_file(engine, nybb_filename):
     # Remove the zip scheme so that the test for a zipped file can

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -586,15 +586,15 @@ def test_read_file(engine, nybb_filename):
     "url",
     [
         # geojson url
-        # "https://raw.githubusercontent.com/geopandas/geopandas/"
-        # "main/geopandas/tests/data/null_geom.geojson",
+        "https://raw.githubusercontent.com/geopandas/geopandas/"
+        "main/geopandas/tests/data/null_geom.geojson",
         # url to zip file
         "https://raw.githubusercontent.com/geopandas/geopandas/"
         "main/geopandas/tests/data/nybb_16a.zip",
         # url to zipfile without extension
-        # "https://geonode.goosocean.org/download/480",
+        "https://geonode.goosocean.org/download/480",
         # url to web service
-        # "https://demo.pygeoapi.io/stable/collections/obs/items",
+        "https://demo.pygeoapi.io/stable/collections/obs/items",
     ],
 )
 def test_read_file_url(engine, url):
@@ -704,13 +704,13 @@ def test_infer_zipped_file(engine, nybb_filename):
     # Remove the zip scheme so that the test for a zipped file can
     # check it and add it back.
     path = nybb_filename[6:]
-    # gdf = read_file(path, engine=engine)
-    # assert isinstance(gdf, geopandas.GeoDataFrame)
-    #
-    # # Check that it can successfully add a zip scheme to a path that already has a
-    # # scheme
-    # gdf = read_file("file+file://" + path, engine=engine)
-    # assert isinstance(gdf, geopandas.GeoDataFrame)
+    gdf = read_file(path, engine=engine)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
+    # Check that it can successfully add a zip scheme to a path that already has a
+    # scheme
+    gdf = read_file("file+file://" + path, engine=engine)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
 
     # Check that it can add a zip scheme for a path that includes a subpath
     # within the archive.
@@ -842,7 +842,6 @@ def test_read_file_missing_geometry(tmpdir, engine):
 
 
 def test_read_file_None_attribute(tmp_path, engine):
-    # this was failing
     # Test added in context of https://github.com/geopandas/geopandas/issues/2901
     test_path = tmp_path / "test.gpkg"
     gdf = GeoDataFrame(

--- a/geopandas/io/util.py
+++ b/geopandas/io/util.py
@@ -1,0 +1,118 @@
+"""Vendored, cut down version of pyogrio/util.py for use with fiona"""
+
+import re
+import sys
+from urllib.parse import urlparse
+
+
+def vsi_path(path: str) -> str:
+    """
+    Ensure path is a local path or a GDAL-compatible vsi path.
+
+    """
+
+    # path is already in GDAL format
+    if path.startswith("/vsi"):
+        return path
+
+    # Windows drive letters (e.g. "C:\") confuse `urlparse` as they look like
+    # URL schemes
+    if sys.platform == "win32" and re.match("^[a-zA-Z]\\:", path):
+        if not path.split("!")[0].endswith(".zip"):
+            return path
+
+        # prefix then allow to proceed with remaining parsing
+        path = f"zip://{path}"
+
+    path, archive, scheme = _parse_uri(path)
+
+    if scheme or archive or path.endswith(".zip"):
+        return _construct_vsi_path(path, archive, scheme)
+
+    return path
+
+
+# Supported URI schemes and their mapping to GDAL's VSI suffix.
+SCHEMES = {
+    "file": "file",
+    "zip": "zip",
+    "tar": "tar",
+    "gzip": "gzip",
+    "http": "curl",
+    "https": "curl",
+    "ftp": "curl",
+    "s3": "s3",
+    "gs": "gs",
+    "az": "az",
+    "adls": "adls",
+    "adl": "adls",  # fsspec uses this
+    "hdfs": "hdfs",
+    "webhdfs": "webhdfs",
+    # GDAL additionally supports oss and swift for remote filesystems, but
+    # those are for now not added as supported URI
+}
+
+CURLSCHEMES = {k for k, v in SCHEMES.items() if v == "curl"}
+
+
+def _parse_uri(path: str):
+    """
+    Parse a URI
+
+    Returns a tuples of (path, archive, scheme)
+
+    path : str
+        Parsed path. Includes the hostname and query string in the case
+        of a URI.
+    archive : str
+        Parsed archive path.
+    scheme : str
+        URI scheme such as "https" or "zip+s3".
+    """
+    parts = urlparse(path)
+
+    # if the scheme is not one of GDAL's supported schemes, return raw path
+    if parts.scheme and not all(p in SCHEMES for p in parts.scheme.split("+")):
+        return path, "", ""
+
+    # we have a URI
+    path = parts.path
+    scheme = parts.scheme or ""
+
+    if parts.query:
+        path += "?" + parts.query
+
+    if parts.scheme and parts.netloc:
+        path = parts.netloc + path
+
+    parts = path.split("!")
+    path = parts.pop() if parts else ""
+    archive = parts.pop() if parts else ""
+    return (path, archive, scheme)
+
+
+def _construct_vsi_path(path, archive, scheme) -> str:
+    """Convert a parsed path to a GDAL VSI path"""
+
+    prefix = ""
+    suffix = ""
+    schemes = scheme.split("+")
+
+    if "zip" not in schemes and (archive.endswith(".zip") or path.endswith(".zip")):
+        schemes.insert(0, "zip")
+
+    if schemes:
+        prefix = "/".join(
+            "vsi{0}".format(SCHEMES[p]) for p in schemes if p and p != "file"
+        )
+
+        if schemes[-1] in CURLSCHEMES:
+            suffix = f"{schemes[-1]}://"
+
+    if prefix:
+        if archive:
+            return "/{}/{}{}/{}".format(prefix, suffix, archive, path.lstrip("/"))
+        else:
+            return "/{}/{}{}".format(prefix, suffix, path)
+
+    return path


### PR DESCRIPTION
Closes #3207. It's worth looking at the diff before 12393dc773bc5213538ee3751fa53a72ec353180. I was originally intending to just fix the zipfile case and still depend on the internal details to push down the road until fiona 1.11/  fiona 2 for a future break. But I was looking into how we could replace this, and it actually seemed simpler to pinch the pyogrio logic for this, than to work out how to come up with a minimal equivalent of the fiona path classes - which we only want specifically for this purpose.

Not sure how we feel about introducing the new code / duplication.

