### PR TITLE
BUG/API: Set geometry api where `col` is named / with `drop=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ New features and improvements:
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now
   set to false for consistency with pandas (#3174)
+- The behaviour of `set_geometry` has been updated (#3237):
+   - When `col` is a str and `drop=True`, the new active geometry column name will be `col`,
+     rather than the previous active geometry column name
+   - When `col` is a (Geo)Series with `ser.name` not None, the new active geometry column name
+     will be `ser.name`, rather than the previous active geometry column name. This means that
+     `drop` now also functions when `col` is a (Geo)Series, and can be used to remove the 
+     previous active geometry column name when it differs from `ser.name`.
 
 Potentially breaking changes:
 
@@ -64,6 +71,8 @@ Bug fixes:
 - Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a
   `GeoDataFrame` when the `suffixes` argument is applied to the active
   geometry column (#2933).
+- Fix bug in `GeoDataFrame` constructor where if `geometry` is given a named 
+  `GeoSeries` the name was not used as the active geometry column name (#3160).
 
 Deprecations and compatibility notes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,13 +52,11 @@ New features and improvements:
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now
   set to false for consistency with pandas (#3174)
-- The behaviour of `set_geometry` has been updated (#3237):
-   - When `col` is an existing column name and `drop=True`, the new active geometry column name will be `col`,
-     rather than the previous active geometry column name
-   - When `col` is a (Geo)Series with `ser.name` not None, the new active geometry column name
-     will be `ser.name`, rather than the previous active geometry column name. This means that
-     `drop` now also functions when `col` is a (Geo)Series, and can be used to remove the 
-     previous active geometry column name when it differs from `ser.name`.
+- The behaviour of `set_geometry` has been updated when `col` is a (Geo)Series with `ser.name` 
+  not None. The new active geometry column name in this case will be `ser.name`, rather than
+  the previous active geometry column name. This means that if the new and old names are
+  different, then both columns will be preserved in the GeoDataFrame. To replicate the previous
+  behaviour, you can instead call `gdf.set_geometry(ser.rename(gdf.active_geometry_name))`.
 
 Potentially breaking changes:
 
@@ -96,8 +94,15 @@ Deprecations and compatibility notes:
   for the default pyogrio engine. Currently those are translated to the ``columns`` keyword
   for backwards compatibility, but you should directly use the ``columns`` keyword instead
   to select which columns to read (#3133).
-- The `drop` keyword in `set_geometry` has been deprecated, and in future the `drop=True` behaviour will be removed.
-  To preserve this behaviour in existing code
+- The `drop` keyword in `set_geometry` has been deprecated, and in future the `drop=True` 
+  behaviour will be removed. To prepare for this change, you should remove any explict 
+  `drop=False` calls in your code (the default behaviour already is the same as `drop=False`).
+  To replicate the previous `drop=True` behaviour you should replace 
+  `gdf.set_geometry(new_geo_col, drop=True)` with
+```python
+geo_col_name = gdf.active_geometry_name
+gdf.set_geometry(new_geo_col).drop(columns=geo_col_name).rename_geometry(geo_col_name)
+```
 
 ## Version 0.14.3 (Jan 31, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ Deprecations and compatibility notes:
   for the default pyogrio engine. Currently those are translated to the ``columns`` keyword
   for backwards compatibility, but you should directly use the ``columns`` keyword instead
   to select which columns to read (#3133).
+- The `drop` keyword in `set_geometry` has been deprecated, and in future the `drop=True` behaviour will be removed.
+  To preserve this behaviour in existing code
 
 ## Version 0.14.3 (Jan 31, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Deprecations and compatibility notes:
   for backwards compatibility, but you should directly use the ``columns`` keyword instead
   to select which columns to read (#3133).
 - The `drop` keyword in `set_geometry` has been deprecated, and in future the `drop=True` 
-  behaviour will be removed. To prepare for this change, you should remove any explict 
+  behaviour will be removed. To prepare for this change, you should remove any explicit 
   `drop=False` calls in your code (the default behaviour already is the same as `drop=False`).
   To replicate the previous `drop=True` behaviour you should replace 
   `gdf.set_geometry(new_geo_col, drop=True)` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ New features and improvements:
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now
   set to false for consistency with pandas (#3174).
-- The behaviour of `set_geometry` has been updated when `col` is a (Geo)Series with `ser.name` 
-  not None. The new active geometry column name in this case will be `ser.name`, rather than
+- The behaviour of `set_geometry` has been changed when passed a (Geo)Series `ser` with a name. 
+  The new active geometry column name in this case will be `ser.name`, if not None, rather than
   the previous active geometry column name. This means that if the new and old names are
   different, then both columns will be preserved in the GeoDataFrame. To replicate the previous
   behaviour, you can instead call `gdf.set_geometry(ser.rename(gdf.active_geometry_name))` (#3237).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,12 @@ New features and improvements:
 
 Backwards incompatible API changes:
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now
-  set to false for consistency with pandas (#3174)
+  set to false for consistency with pandas (#3174).
 - The behaviour of `set_geometry` has been updated when `col` is a (Geo)Series with `ser.name` 
   not None. The new active geometry column name in this case will be `ser.name`, rather than
   the previous active geometry column name. This means that if the new and old names are
   different, then both columns will be preserved in the GeoDataFrame. To replicate the previous
-  behaviour, you can instead call `gdf.set_geometry(ser.rename(gdf.active_geometry_name))`.
+  behaviour, you can instead call `gdf.set_geometry(ser.rename(gdf.active_geometry_name))` (#3237).
 
 Potentially breaking changes:
 
@@ -99,10 +99,11 @@ Deprecations and compatibility notes:
   `drop=False` calls in your code (the default behaviour already is the same as `drop=False`).
   To replicate the previous `drop=True` behaviour you should replace 
   `gdf.set_geometry(new_geo_col, drop=True)` with
-```python
-geo_col_name = gdf.active_geometry_name
-gdf.set_geometry(new_geo_col).drop(columns=geo_col_name).rename_geometry(geo_col_name)
-```
+  ```python
+  geo_col_name = gdf.active_geometry_name
+  gdf.set_geometry(new_geo_col).drop(columns=geo_col_name).rename_geometry(geo_col_name)
+  ```
+  (#3237).
 
 ## Version 0.14.3 (Jan 31, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Bug fixes:
   `GeoDataFrame` when the `suffixes` argument is applied to the active
   geometry column (#2933).
 - Fix bug in `GeoDataFrame` constructor where if `geometry` is given a named 
-  `GeoSeries` the name was not used as the active geometry column name (#3160).
+  `GeoSeries` the name was not used as the active geometry column name (#3237).
 
 Deprecations and compatibility notes:
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1288,7 +1288,13 @@ class GeometryArray(ExtensionArray):
                 return pd.array(string_values, dtype=pd_dtype)
             return string_values.astype(dtype, copy=False)
         else:
-            return np.array(self, dtype=dtype, copy=copy)
+            # numpy 2.0 makes copy=False case strict (errors if cannot avoid the copy)
+            # -> in that case use `np.asarray` as backwards compatible alternative
+            # for `copy=None` (when requiring numpy 2+, this can be cleaned up)
+            if not copy:
+                return np.asarray(self, dtype=dtype)
+            else:
+                return np.array(self, dtype=dtype, copy=copy)
 
     def isna(self):
         """
@@ -1615,7 +1621,7 @@ class GeometryArray(ExtensionArray):
             f"does not support reduction '{name}'"
         )
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """
         The numpy array interface.
 
@@ -1623,7 +1629,9 @@ class GeometryArray(ExtensionArray):
         -------
         values : numpy array
         """
-        return to_shapely(self)
+        if copy and (dtype is None or dtype == np.dtype("object")):
+            return self._data.copy()
+        return self._data
 
     def _binop(self, other, op):
         def convert_values(param):

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -307,9 +307,16 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         to_remove = None
         geo_column_name = self._geometry_column_name
+
         if geo_column_name is None:
             geo_column_name = "geometry"
         if isinstance(col, (Series, list, np.ndarray, GeometryArray)):
+            if isinstance(col, Series) and col.name is not None:
+                if drop:
+                    # drop old geo col name
+                    to_remove = geo_column_name
+                geo_column_name = col.name
+
             level = col
         elif hasattr(col, "ndim") and col.ndim > 1:
             raise ValueError("Must pass array with one dimension only.")
@@ -325,11 +332,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 )
 
             if drop:
-                to_remove = col
-            else:
-                geo_column_name = col
+                to_remove = geo_column_name
 
-        if to_remove:
+            geo_column_name = col
+        # if geo_col_name is None and drop=True, to_remove
+        # may not exist already
+        if to_remove and to_remove in frame.columns:
             del frame[to_remove]
 
         if not crs:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -252,9 +252,17 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Parameters
         ----------
-        col : column label or array
+        col : column label or array-like
+            An existing column name or values to set as the new geometry column.
+            If values (array-like, Series) are passed, then if they are named (Series)
+              the new geometry column will have the corresponding name, otherwise
+              the existing geometry column will be replaced. If there is no existing
+              geometry column, the new geometry column will use the default name
+              "geometry".
         drop : boolean, default False
-            Delete column to be used as the new geometry
+            When specifying a named Series or an existing column name for `col`,
+            controls if the previous geometry column should be dropped from the
+            result. The default of False keeps both the old and new geometry column.
         inplace : boolean, default False
             Modify the GeoDataFrame in place (do not create a new object)
         crs : pyproj.CRS, optional

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -319,8 +319,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             geo_column_name = "geometry"
         if isinstance(col, (Series, list, np.ndarray, GeometryArray)):
             if isinstance(col, Series) and col.name is not None:
-                if drop:
-                    # drop old geo col name
+                if drop:  # drop old geo col name
                     del frame[geo_column_name]
                 geo_column_name = col.name
 
@@ -339,8 +338,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 )
 
             if drop and geo_column_name in frame.columns:
-                # if _geometry_column_name is None, geo_column_name
-                # may not exist
+                # if _geometry_column_name is None, geo_column_name may not exist
                 del frame[geo_column_name]
 
             geo_column_name = col

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -254,15 +254,18 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         ----------
         col : column label or array-like
             An existing column name or values to set as the new geometry column.
-            If values (array-like, (Geo)Series) are passed, then if they are named (Series)
-              the new geometry column will have the corresponding name, otherwise
-              the existing geometry column will be replaced. If there is no existing
-              geometry column, the new geometry column will use the default name
-              "geometry".
+            If values (array-like, (Geo)Series) are passed, then if they are named
+              (Series) the new geometry column will have the corresponding name,
+              otherwise the existing geometry column will be replaced. If there is
+              no existing geometry column, the new geometry column will use the
+              default name "geometry".
         drop : boolean, default False
             When specifying a named Series or an existing column name for `col`,
             controls if the previous geometry column should be dropped from the
             result. The default of False keeps both the old and new geometry column.
+
+            .. deprecated:: 1.0.0
+
         inplace : boolean, default False
             Modify the GeoDataFrame in place (do not create a new object)
         crs : pyproj.CRS, optional

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -255,10 +255,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         col : column label or array-like
             An existing column name or values to set as the new geometry column.
             If values (array-like, (Geo)Series) are passed, then if they are named
-              (Series) the new geometry column will have the corresponding name,
-              otherwise the existing geometry column will be replaced. If there is
-              no existing geometry column, the new geometry column will use the
-              default name "geometry".
+            (Series) the new geometry column will have the corresponding name,
+            otherwise the existing geometry column will be replaced. If there is
+            no existing geometry column, the new geometry column will use the
+            default name "geometry".
         drop : boolean, default False
             When specifying a named Series or an existing column name for `col`,
             controls if the previous geometry column should be dropped from the

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1527,9 +1527,9 @@ def test_set_geometry_supply_colname(nybb2, geo_col_name):
     assert geo_col_name in res.columns
 
     res2 = nybb2.set_geometry("centroid", drop=True)
-    # current behaviour, drop=True will preserve the existing geometry colname
-    assert res2.active_geometry_name == geo_col_name
-    assert "centroid" not in res2.columns
+    # drop=True should preserve column name centroid
+    assert res2.active_geometry_name == "centroid"
+    assert geo_col_name not in res2.columns
 
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
@@ -1544,11 +1544,13 @@ def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
     assert res2.active_geometry_name == geo_col_name
 
     centroids = centroids.rename("centroids")
-    res2 = nybb2.set_geometry(centroids)
-    # Current behaviour is that geoseries name is ignored,
-    #   active geometry name is persisted
-    assert res2.active_geometry_name == geo_col_name
+    res3 = nybb2.set_geometry(centroids)
+    # Should preserve the geoseries name
+    # (and old geometry column should be kept)
+    assert res3.active_geometry_name == "centroids"
+    assert geo_col_name in res3.columns
 
-    # Drop does nothing because name is ignored
-    res2 = nybb2.set_geometry(centroids, drop=True)
-    assert res2.active_geometry_name == geo_col_name
+    # Drop should remove previous active geometry colname
+    res4 = nybb2.set_geometry(centroids, drop=True)
+    assert res4.active_geometry_name == "centroids"
+    assert geo_col_name not in res4.columns

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -267,6 +267,9 @@ class TestDataFrame:
         with pytest.raises(ValueError):
             self.df.set_geometry(self.df)
 
+    def test_set_geometry_crs(self):
+        geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
+
         # new crs - setting should default to GeoSeries' crs
         gs = GeoSeries(geom, crs="epsg:3857")
         new_df = self.df.set_geometry(gs)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -254,11 +254,9 @@ class TestDataFrame:
         geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
         original_geom = self.df.geometry
 
-        # passing values that replace existing geometry column
         df2 = self.df.set_geometry(geom)
         assert self.df is not df2
-        assert_geoseries_equal(df2.geometry, geom)  # , check_crs=False
-        assert_geoseries_equal(df2["geometry"], geom)  # , check_crs=False
+        assert_geoseries_equal(df2.geometry, geom, check_crs=False)
         assert_geoseries_equal(self.df.geometry, original_geom)
         assert_geoseries_equal(self.df["geometry"], self.df.geometry)
         # unknown column
@@ -268,9 +266,6 @@ class TestDataFrame:
         # ndim error
         with pytest.raises(ValueError):
             self.df.set_geometry(self.df)
-
-    def test_set_geometry_crs(self):
-        geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
 
         # new crs - setting should default to GeoSeries' crs
         gs = GeoSeries(geom, crs="epsg:3857")
@@ -295,16 +290,11 @@ class TestDataFrame:
 
         # Drop is false by default
         assert "simplified_geometry" in df2
-        assert "geometry" in df2
-        assert df2._geometry_column_name == "simplified_geometry"
         assert_geoseries_equal(df2.geometry, g_simplified)
 
         # If True, drops column and renames to geometry
         df3 = self.df.set_geometry("simplified_geometry", drop=True)
-        # TODO should this keep its name or not?
         assert "simplified_geometry" not in df3
-        assert "geometry" in df3
-        assert df3._geometry_column_name == "geometry"
         assert_geoseries_equal(df3.geometry, g_simplified)
 
     def test_set_geometry_inplace(self):
@@ -393,15 +383,6 @@ class TestDataFrame:
         assert multiple.active_geometry_name is None
         assert multiple.set_geometry("foo").active_geometry_name == "foo"
         assert multiple.set_geometry("bar").active_geometry_name == "bar"
-
-    def test_set_geometry_series_name(self):
-        # when Series is passed, use the Series name as 'geometry' column name
-        geom = [Point(x, y) for x, y in zip(range(5), range(5))]
-        g = GeoSeries(geom, name="my_geom")
-        df = self.df.set_geometry(g)
-        assert df._geometry_column_name == "my_geom"
-        assert df.geometry.name == "my_geom"
-        assert "geometry" not in df.columns
 
     def test_align(self):
         df = self.df2
@@ -1303,6 +1284,7 @@ class TestConstructor:
         check_geodataframe(gdf)
         gdf.columns == ["geometry", "a"]
 
+    @pytest.mark.xfail
     def test_preserve_series_name(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
         gs = GeoSeries(geoms)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -294,7 +294,7 @@ class TestDataFrame:
 
         # If True, drops column and renames to geometry
         df3 = self.df.set_geometry("simplified_geometry", drop=True)
-        assert "simplified_geometry" not in df3
+        assert g.name not in df3
         assert_geoseries_equal(df3.geometry, g_simplified)
 
     def test_set_geometry_inplace(self):
@@ -808,9 +808,9 @@ class TestDataFrame:
         gf2 = df.set_geometry("location", crs=self.df.crs, drop=True)
         assert isinstance(df, pd.DataFrame)
         assert isinstance(gf2, GeoDataFrame)
-        assert gf2.geometry.name == "geometry"
-        assert "geometry" in gf2
-        assert "location" not in gf2
+        assert gf2.geometry.name == "location"
+        assert "geometry" not in gf2
+        assert "location" in gf2
         assert "location" in df
 
         # should be a copy
@@ -1284,7 +1284,6 @@ class TestConstructor:
         check_geodataframe(gdf)
         gdf.columns == ["geometry", "a"]
 
-    @pytest.mark.xfail
     def test_preserve_series_name(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]
         gs = GeoSeries(geoms)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1529,11 +1529,12 @@ def test_set_geometry_supply_colname(nybb2, geo_col_name):
     assert geo_col_name in res.columns
 
     # Test that drop=False explicitly warns
-    with pytest.warns(FutureWarning, match="The drop keyword argument is deprecated"):
+    deprecated = "The `drop` keyword argument is deprecated"
+    with pytest.warns(FutureWarning, match=deprecated):
         res2 = nybb2.set_geometry("centroid", drop=False)
     assert_geodataframe_equal(res, res2)
 
-    with pytest.warns(FutureWarning, match="The drop keyword argument is deprecated"):
+    with pytest.warns(FutureWarning, match=deprecated):
         res3 = nybb2.set_geometry("centroid", drop=True)
     # drop=True should preserve previous geometry col name (keep old behaviour)
     assert res3.active_geometry_name == geo_col_name
@@ -1541,7 +1542,7 @@ def test_set_geometry_supply_colname(nybb2, geo_col_name):
 
     # Test that alternative suggested without using drop=True is equivalent
     assert_geodataframe_equal(
-        res2,
+        res3,
         nybb2.set_geometry("centroid")
         .drop(columns=geo_col_name)
         .rename_geometry(geo_col_name),
@@ -1558,7 +1559,7 @@ def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
     # drop should do nothing if the column already exists
     match_str = (
         "The `drop` keyword argument is deprecated and has no effect when "
-        "`col` is an array-like is passed"
+        "`col` is an array-like value"
     )
     with pytest.warns(
         FutureWarning,

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1517,32 +1517,38 @@ def nybb2(nybb_filename):
     yield read_file(nybb_filename).head(2)
 
 
-def test_set_geometry_supply_colname(nybb2):
+@pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
+def test_set_geometry_supply_colname(nybb2, geo_col_name):
+    if geo_col_name != "geometry":
+        nybb2 = nybb2.rename_geometry(geo_col_name)
     nybb2["centroid"] = nybb2.geometry.centroid
     res = nybb2.set_geometry("centroid")
     assert res.active_geometry_name == "centroid"
-    assert "geometry" in res.columns
+    assert geo_col_name in res.columns
 
     res2 = nybb2.set_geometry("centroid", drop=True)
     # current behaviour, drop=True will preserve the existing geometry colname
-    assert res2.active_geometry_name == "geometry"
+    assert res2.active_geometry_name == geo_col_name
     assert "centroid" not in res2.columns
 
 
-def test_set_geometry_supply_arraylike(nybb2):
+@pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
+def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
+    if geo_col_name != "geometry":
+        nybb2 = nybb2.rename_geometry(geo_col_name)
     centroids = nybb2.geometry.centroid
     res = nybb2.set_geometry(centroids)
-    assert res.active_geometry_name == "geometry"
+    assert res.active_geometry_name == geo_col_name
     # drop should do nothing if the column already exists
     res2 = nybb2.set_geometry(centroids, drop=True)
-    assert res2.active_geometry_name == "geometry"
+    assert res2.active_geometry_name == geo_col_name
 
     centroids = centroids.rename("centroids")
     res2 = nybb2.set_geometry(centroids)
     # Current behaviour is that geoseries name is ignored,
     #   active geometry name is persisted
-    assert res2.active_geometry_name == "geometry"
+    assert res2.active_geometry_name == geo_col_name
 
     # Drop does nothing because name is ignored
     res2 = nybb2.set_geometry(centroids, drop=True)
-    assert res2.active_geometry_name == "geometry"
+    assert res2.active_geometry_name == geo_col_name


### PR DESCRIPTION
Closes #2770
Closes #1038, #3160 (superceded PRs) 

This originally started with trying to rebase #1038, but that solution was breaking some tests due to column sort order, and also doesn't seem to implement what is discussed in the thread. I think this is a faithful implementation of what is discussed in #1038 minus the `geometry_name` discussion except for 

>But if the values have a name, it can also be an option to keep the original geometry column intact (not necessarily the default, but people could do drop=False to keep the original one)

as the default is drop=False as it would be quite odd to have drop=False the default for string like arguments and drop=True the default for Series like arguments.

(maybe I've misinterpreted that though. If this does become not straightforward to resolve I certainly don't think it's a blocker for 1.0, just something that would be nice to tie off if possible.)

----------------------------------

This is a breaking change, and I think is best done as a breaking change, there's no clean way to deprecate this. 

The best options with deprecation warnings I could see  (besides the already mentioned extra geometry col argument) would be to either, do what pandas is doing now for some behaviour (which I think is arguably quite annoying) and warn the behaviour will change in future every time the method is called (or called with arguments that the behaviour change would affect), or to provide some kind of toplevel `geopandas.options.set_geometry_new_behaviour = False/True/None` defaulting to None, so there is at least some way to migrate / silence warnings.

To try and make the changes as clear as possible, I opted to add new tests, replicating the exploratory notebook Joris set up on the original thread.
