### PR TITLE
REGR: fix order of left sjoin with within predicate

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -196,6 +196,9 @@ def _geom_predicate_query(left_df, right_df, predicate, distance):
         # within is implemented as the inverse of contains
         # flip back the results
         r_idx, l_idx = l_idx, r_idx
+        indexer = np.lexsort((r_idx, l_idx))
+        l_idx = l_idx[indexer]
+        r_idx = r_idx[indexer]
 
     return l_idx, r_idx
 
@@ -319,14 +322,14 @@ def _adjust_indexers(indices, distances, original_length, how, predicate):
     """
     # the indices represent an inner join, no adjustment needed
     if how == "inner":
-        if predicate == "within":
-            # except for the within predicate, where we switched to contains
-            # with swapped left/right -> need to re-sort to have consistent result
-            l_idx, r_idx = indices
-            indexer = np.lexsort((r_idx, l_idx))
-            indices = l_idx[indexer], r_idx[indexer]
-            if distances is not None:
-                distances = distances[indexer]
+        # if predicate == "within":
+        #     # except for the within predicate, where we switched to contains
+        #     # with swapped left/right -> need to re-sort to have consistent result
+        #     l_idx, r_idx = indices
+        #     indexer = np.lexsort((r_idx, l_idx))
+        #     indices = l_idx[indexer], r_idx[indexer]
+        #     if distances is not None:
+        #         distances = distances[indexer]
         return indices, distances
 
     l_idx, r_idx = indices

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -322,7 +322,6 @@ def _adjust_indexers(indices, distances, original_length, how, predicate):
     """
     # the indices represent an inner join, no adjustment needed
     if how == "inner":
-
         return indices, distances
 
     l_idx, r_idx = indices

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -322,14 +322,7 @@ def _adjust_indexers(indices, distances, original_length, how, predicate):
     """
     # the indices represent an inner join, no adjustment needed
     if how == "inner":
-        # if predicate == "within":
-        #     # except for the within predicate, where we switched to contains
-        #     # with swapped left/right -> need to re-sort to have consistent result
-        #     l_idx, r_idx = indices
-        #     indexer = np.lexsort((r_idx, l_idx))
-        #     indices = l_idx[indexer], r_idx[indexer]
-        #     if distances is not None:
-        #         distances = distances[indexer]
+
         return indices, distances
 
     l_idx, r_idx = indices

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -406,6 +406,8 @@ class TestSpatialJoin:
         ],
     )
     def test_sjoin_left_order(self, predicate):
+        # a set of points in random order -> that order should be preserved
+        # with a left join
         pts = GeoDataFrame(
             geometry=points_from_xy([0.1, 0.4, 0.3, 0.7], [0.8, 0.6, 0.9, 0.1])
         )

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -392,8 +392,23 @@ class TestSpatialJoin:
         assert_frame_equal(expected_gdf.sort_index(), joined.sort_index())
 
     # GH3239
-    def test_sjoin_left_within_order(self):
-        pts = GeoDataFrame(geometry=points_from_xy(*np.random.rand(2, 10)))
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            "contains",
+            "contains_properly",
+            "covered_by",
+            "covers",
+            "crosses",
+            "intersects",
+            "touches",
+            "within",
+        ],
+    )
+    def test_sjoin_left_order(self, predicate):
+        pts = GeoDataFrame(
+            geometry=points_from_xy(np.linspace(0, 1, 10), np.linspace(0, 1, 10))
+        )
         polys = GeoDataFrame(
             {"id": [1, 2, 3, 4]},
             geometry=[
@@ -404,7 +419,7 @@ class TestSpatialJoin:
             ],
         )
 
-        joined = sjoin(pts, polys, predicate="within", how="left")
+        joined = sjoin(pts, polys, predicate=predicate, how="left")
         assert_index_equal(joined.index, pts.index)
 
 

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -407,7 +407,7 @@ class TestSpatialJoin:
     )
     def test_sjoin_left_order(self, predicate):
         pts = GeoDataFrame(
-            geometry=points_from_xy(np.linspace(0, 1, 10), np.linspace(0, 1, 10))
+            geometry=points_from_xy([0.1, 0.4, 0.3, 0.7], [0.8, 0.6, 0.9, 0.1])
         )
         polys = GeoDataFrame(
             {"id": [1, 2, 3, 4]},


### PR DESCRIPTION
Closes #3239 

Moving the sorting to the query so we don't have to deal with it later. I _think_ it does not brake anything else.