### PR TITLE
TST: properly skip set_geometry tests when pyproj is not available

### DIFF
--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -249,7 +249,6 @@ class TestDataFrame:
         with pytest.raises(ValueError, match=msg):
             self.df.rename_geometry("Shape_Area", inplace=True)
 
-    @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="Requires pyproj")
     def test_set_geometry(self):
         geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
         original_geom = self.df.geometry
@@ -267,6 +266,7 @@ class TestDataFrame:
         with pytest.raises(ValueError):
             self.df.set_geometry(self.df)
 
+    @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="Requires pyproj")
     def test_set_geometry_crs(self):
         geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
 


### PR DESCRIPTION
Fixing the issue caused by #3237. The set_geometry test was split to two, but the pyproj-related skip was added to the wrong part.