### PR TITLE
TST: remove nybb usage in set geometry api tests

### DIFF
--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1516,22 +1516,22 @@ def test_geodataframe_crs_colname():
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
 def test_set_geometry_supply_colname(dfs, geo_col_name):
-    df1, _ = dfs
+    df, _ = dfs
     if geo_col_name != "geometry":
-        df1 = df1.rename_geometry(geo_col_name)
-    df1["centroid"] = df1.geometry.centroid
-    res = df1.set_geometry("centroid")
+        df = df.rename_geometry(geo_col_name)
+    df["centroid"] = df.geometry.centroid
+    res = df.set_geometry("centroid")
     assert res.active_geometry_name == "centroid"
     assert geo_col_name in res.columns
 
     # Test that drop=False explicitly warns
     deprecated = "The `drop` keyword argument is deprecated"
     with pytest.warns(FutureWarning, match=deprecated):
-        res2 = df1.set_geometry("centroid", drop=False)
+        res2 = df.set_geometry("centroid", drop=False)
     assert_geodataframe_equal(res, res2)
 
     with pytest.warns(FutureWarning, match=deprecated):
-        res3 = df1.set_geometry("centroid", drop=True)
+        res3 = df.set_geometry("centroid", drop=True)
     # drop=True should preserve previous geometry col name (keep old behaviour)
     assert res3.active_geometry_name == geo_col_name
     assert "centroid" not in res3.columns
@@ -1539,7 +1539,7 @@ def test_set_geometry_supply_colname(dfs, geo_col_name):
     # Test that alternative suggested without using drop=True is equivalent
     assert_geodataframe_equal(
         res3,
-        df1.set_geometry("centroid")
+        df.set_geometry("centroid")
         .drop(columns=geo_col_name)
         .rename_geometry(geo_col_name),
     )
@@ -1547,11 +1547,11 @@ def test_set_geometry_supply_colname(dfs, geo_col_name):
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
 def test_set_geometry_supply_arraylike(dfs, geo_col_name):
-    df1, _ = dfs
+    df, _ = dfs
     if geo_col_name != "geometry":
-        df1 = df1.rename_geometry(geo_col_name)
-    centroids = df1.geometry.centroid
-    res = df1.set_geometry(centroids)
+        df = df.rename_geometry(geo_col_name)
+    centroids = df.geometry.centroid
+    res = df.set_geometry(centroids)
     assert res.active_geometry_name == geo_col_name
     # drop should do nothing if the column already exists
     match_str = (
@@ -1562,11 +1562,11 @@ def test_set_geometry_supply_arraylike(dfs, geo_col_name):
         FutureWarning,
         match=match_str,
     ):
-        res2 = df1.set_geometry(centroids, drop=True)
+        res2 = df.set_geometry(centroids, drop=True)
     assert res2.active_geometry_name == geo_col_name
 
     centroids = centroids.rename("centroids")
-    res3 = df1.set_geometry(centroids)
+    res3 = df.set_geometry(centroids)
     # Should preserve the geoseries name
     # (and old geometry column should be kept)
     assert res3.active_geometry_name == "centroids"
@@ -1577,6 +1577,6 @@ def test_set_geometry_supply_arraylike(dfs, geo_col_name):
         FutureWarning,
         match=match_str,
     ):
-        res4 = df1.set_geometry(centroids, drop=True)
+        res4 = df.set_geometry(centroids, drop=True)
     assert res4.active_geometry_name == "centroids"
     assert geo_col_name in res4.columns

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1514,20 +1514,9 @@ def test_geodataframe_crs_colname():
     assert getattr(gdf, "crs") is None
 
 
-@pytest.fixture
-def df1(nybb_filename):
-    yield GeoDataFrame(
-        {
-            "A": range(3),
-            "B": np.arange(3.0),
-            "geometry": [Point(x, x) for x in range(3)],
-        },
-        crs="EPSG:4326",
-    )
-
-
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
-def test_set_geometry_supply_colname(df1, geo_col_name):
+def test_set_geometry_supply_colname(dfs, geo_col_name):
+    df1, _ = dfs
     if geo_col_name != "geometry":
         df1 = df1.rename_geometry(geo_col_name)
     df1["centroid"] = df1.geometry.centroid
@@ -1557,7 +1546,8 @@ def test_set_geometry_supply_colname(df1, geo_col_name):
 
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
-def test_set_geometry_supply_arraylike(df1, geo_col_name):
+def test_set_geometry_supply_arraylike(dfs, geo_col_name):
+    df1, _ = dfs
     if geo_col_name != "geometry":
         df1 = df1.rename_geometry(geo_col_name)
     centroids = df1.geometry.centroid

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1515,27 +1515,34 @@ def test_geodataframe_crs_colname():
 
 
 @pytest.fixture
-def nybb2(nybb_filename):
-    yield read_file(nybb_filename).head(2)
+def df1(nybb_filename):
+    yield GeoDataFrame(
+        {
+            "A": range(3),
+            "B": np.arange(3.0),
+            "geometry": [Point(x, x) for x in range(3)],
+        },
+        crs="EPSG:4326",
+    )
 
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
-def test_set_geometry_supply_colname(nybb2, geo_col_name):
+def test_set_geometry_supply_colname(df1, geo_col_name):
     if geo_col_name != "geometry":
-        nybb2 = nybb2.rename_geometry(geo_col_name)
-    nybb2["centroid"] = nybb2.geometry.centroid
-    res = nybb2.set_geometry("centroid")
+        df1 = df1.rename_geometry(geo_col_name)
+    df1["centroid"] = df1.geometry.centroid
+    res = df1.set_geometry("centroid")
     assert res.active_geometry_name == "centroid"
     assert geo_col_name in res.columns
 
     # Test that drop=False explicitly warns
     deprecated = "The `drop` keyword argument is deprecated"
     with pytest.warns(FutureWarning, match=deprecated):
-        res2 = nybb2.set_geometry("centroid", drop=False)
+        res2 = df1.set_geometry("centroid", drop=False)
     assert_geodataframe_equal(res, res2)
 
     with pytest.warns(FutureWarning, match=deprecated):
-        res3 = nybb2.set_geometry("centroid", drop=True)
+        res3 = df1.set_geometry("centroid", drop=True)
     # drop=True should preserve previous geometry col name (keep old behaviour)
     assert res3.active_geometry_name == geo_col_name
     assert "centroid" not in res3.columns
@@ -1543,18 +1550,18 @@ def test_set_geometry_supply_colname(nybb2, geo_col_name):
     # Test that alternative suggested without using drop=True is equivalent
     assert_geodataframe_equal(
         res3,
-        nybb2.set_geometry("centroid")
+        df1.set_geometry("centroid")
         .drop(columns=geo_col_name)
         .rename_geometry(geo_col_name),
     )
 
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
-def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
+def test_set_geometry_supply_arraylike(df1, geo_col_name):
     if geo_col_name != "geometry":
-        nybb2 = nybb2.rename_geometry(geo_col_name)
-    centroids = nybb2.geometry.centroid
-    res = nybb2.set_geometry(centroids)
+        df1 = df1.rename_geometry(geo_col_name)
+    centroids = df1.geometry.centroid
+    res = df1.set_geometry(centroids)
     assert res.active_geometry_name == geo_col_name
     # drop should do nothing if the column already exists
     match_str = (
@@ -1565,11 +1572,11 @@ def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
         FutureWarning,
         match=match_str,
     ):
-        res2 = nybb2.set_geometry(centroids, drop=True)
+        res2 = df1.set_geometry(centroids, drop=True)
     assert res2.active_geometry_name == geo_col_name
 
     centroids = centroids.rename("centroids")
-    res3 = nybb2.set_geometry(centroids)
+    res3 = df1.set_geometry(centroids)
     # Should preserve the geoseries name
     # (and old geometry column should be kept)
     assert res3.active_geometry_name == "centroids"
@@ -1580,6 +1587,6 @@ def test_set_geometry_supply_arraylike(nybb2, geo_col_name):
         FutureWarning,
         match=match_str,
     ):
-        res4 = nybb2.set_geometry(centroids, drop=True)
+        res4 = df1.set_geometry(centroids, drop=True)
     assert res4.active_geometry_name == "centroids"
     assert geo_col_name in res4.columns


### PR DESCRIPTION
Follow up on #3237 to make these tests which don't rely on the nybb data structure use a toy dataset instead. Didn't managed to get to this in time for the original merge (https://github.com/geopandas/geopandas/pull/3237/files#r1546244011)