### PR TITLE
COMPAT: avoid passing copy keyword to concat and astype for pandas 3.0

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -16,7 +16,7 @@ from geopandas.geoseries import GeoSeries
 import geopandas.io
 from geopandas.explore import _explore
 from ._decorator import doc
-from ._compat import HAS_PYPROJ
+from ._compat import HAS_PYPROJ, PANDAS_GE_30
 
 
 def _geodataframe_constructor_with_fallback(*args, **kwargs):
@@ -314,7 +314,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         if inplace:
             frame = self
         else:
-            frame = self.copy()
+            if PANDAS_GE_30:
+                frame = self.copy(deep=False)
+            else:
+                frame = self.copy()
 
         geo_column_name = self._geometry_column_name
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2007,7 +2007,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
 
     # overrides the pandas astype method to ensure the correct return type
     # should be removable when pandas 1.4 is dropped
-    def astype(self, dtype, copy=True, errors="raise", **kwargs):
+    def astype(self, dtype, copy=None, errors="raise", **kwargs):
         """
         Cast a pandas object to a specified dtype ``dtype``.
         Returns a GeoDataFrame when the geometry column is kept as geometries,
@@ -2017,7 +2017,12 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         -------
         GeoDataFrame or DataFrame
         """
-        df = super().astype(dtype, copy=copy, errors=errors, **kwargs)
+        if not PANDAS_GE_30 and copy is None:
+            copy = True
+        if copy is not None:
+            kwargs["copy"] = copy
+
+        df = super().astype(dtype, errors=errors, **kwargs)
 
         try:
             geoms = df[self._geometry_column_name]

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import _check_crs, _crs_mismatch_warn
+from geopandas._compat import PANDAS_GE_30
 
 
 def _ensure_geometry_column(df):
@@ -14,12 +15,19 @@ def _ensure_geometry_column(df):
     If another column with that name exists, it will be dropped.
     """
     if not df._geometry_column_name == "geometry":
-        if "geometry" in df.columns:
-            df.drop("geometry", axis=1, inplace=True)
-        df.rename(
-            columns={df._geometry_column_name: "geometry"}, copy=False, inplace=True
-        )
-        df.set_geometry("geometry", inplace=True)
+        if PANDAS_GE_30:
+            if "geometry" in df.columns:
+                df = df.drop("geometry", axis=1)
+            df = df.rename(columns={df._geometry_column_name: "geometry"})
+            df = df.set_geometry("geometry")
+        else:
+            if "geometry" in df.columns:
+                df.drop("geometry", axis=1, inplace=True)
+            df.rename(
+                columns={df._geometry_column_name: "geometry"}, copy=False, inplace=True
+            )
+            df.set_geometry("geometry", inplace=True)
+    return df
 
 
 def _overlay_intersection(df1, df2):
@@ -111,8 +119,8 @@ def _overlay_symmetric_diff(df1, df2):
     dfdiff1["__idx2"] = np.nan
     dfdiff2["__idx1"] = np.nan
     # ensure geometry name (otherwise merge goes wrong)
-    _ensure_geometry_column(dfdiff1)
-    _ensure_geometry_column(dfdiff2)
+    dfdiff1 = _ensure_geometry_column(dfdiff1)
+    dfdiff2 = _ensure_geometry_column(dfdiff2)
     # combine both 'difference' dataframes
     dfsym = dfdiff1.merge(
         dfdiff2, on=["__idx1", "__idx2"], how="outer", suffixes=("_1", "_2")

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -18,15 +18,11 @@ def _ensure_geometry_column(df):
         if PANDAS_GE_30:
             if "geometry" in df.columns:
                 df = df.drop("geometry", axis=1)
-            df = df.rename(columns={df._geometry_column_name: "geometry"})
-            df = df.set_geometry("geometry")
+            df = df.rename_geometry("geometry")
         else:
             if "geometry" in df.columns:
                 df.drop("geometry", axis=1, inplace=True)
-            df.rename(
-                columns={df._geometry_column_name: "geometry"}, copy=False, inplace=True
-            )
-            df.set_geometry("geometry", inplace=True)
+            df.rename_geometry("geometry", inplace=True)
     return df
 
 

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -422,7 +422,11 @@ def _frame_join(
     new_index = pd.RangeIndex(len(l_idx))
     left = left_df._reindex_with_indexers({0: (new_index, l_idx)})
     right = right_df._reindex_with_indexers({0: (new_index, r_idx)})
-    joined = pd.concat([left, right], axis=1, copy=False)
+    if PANDAS_GE_30:
+        kwargs = {}
+    else:
+        kwargs = dict(copy=False)
+    joined = pd.concat([left, right], axis=1, **kwargs)
 
     if how in ("inner", "left"):
         joined = _restore_index(joined, left_index, left_index_original)


### PR DESCRIPTION
This fixes some warnings in the dev build:

```
geopandas/tests/test_geodataframe.py: 54 warnings
geopandas/tests/test_pandas_methods.py: 8 warnings
geopandas/tools/tests/test_sjoin.py: 250 warnings
  /home/runner/work/geopandas/geopandas/geopandas/tools/sjoin.py:425: DeprecationWarning: The copy keyword is deprecated and will be removed in a future version. Copy-on-Write is active in pandas since 3.0 which utilizes a lazy copy mechanism that defers copies until necessary. Use .copy() to make an eager copy if necessary.
    joined = pd.concat([left, right], axis=1, copy=False)

geopandas/tests/test_overlay.py: 12 warnings
  /home/runner/work/geopandas/geopandas/geopandas/tools/overlay.py:19: DeprecationWarning: The copy keyword is deprecated and will be removed in a future version. Copy-on-Write is active in pandas since 3.0 which utilizes a lazy copy mechanism that defers copies until necessary. Use .copy() to make an eager copy if necessary.
    df.rename(
```