### PR TITLE
CLN: pass drop=None to DataFrame.set_geometry

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2459,7 +2459,7 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
         )
 
 
-def _dataframe_set_geometry(self, col, drop=False, inplace=False, crs=None):
+def _dataframe_set_geometry(self, col, drop=None, inplace=False, crs=None):
     if inplace:
         raise ValueError(
             "Can't do inplace setting when converting from DataFrame to GeoDataFrame"


### PR DESCRIPTION
A small follow-up on https://github.com/geopandas/geopandas/pull/3237 to be consistent with our own new default and don't warn when user does `DataFrame.set_geometry(geoms)`.

This also gets emitted in `explode` with no way of silencing.

```py
import geopandas as gpd
from geodatasets import get_path

df = gpd.read_file(get_path('nybb'))
df.explode()
/Users/martin/Git/geopandas/geopandas/geodataframe.py:2469: FutureWarning: The `drop` keyword argument is deprecated and in future the only supported behaviour will match drop=False. To silence this warning and adopt the future behaviour, stop providing `drop` as a keyword to `set_geometry`. To replicate the `drop=True` behaviour you should update your code to
`geo_col_name = gdf.active_geometry_name; gdf.set_geometry(new_geo_col).drop(columns=geo_col_name).rename_geometry(geo_col_name)`.
  return gf.set_geometry(col, drop=drop, inplace=False, crs=crs)
```