### PR TITLE
Fix error message when specifying IO engine that is not available

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -82,7 +82,7 @@ def _import_pyogrio():
 
 
 def _check_fiona(func):
-    if fiona is None:
+    if not fiona:
         raise ImportError(
             f"the {func} requires the 'fiona' package, but it is not installed or does "
             f"not import correctly.\nImporting fiona resulted in: {fiona_import_error}"
@@ -90,7 +90,7 @@ def _check_fiona(func):
 
 
 def _check_pyogrio(func):
-    if pyogrio is None:
+    if not pyogrio:
         raise ImportError(
             f"the {func} requires the 'pyogrio' package, but it is not installed "
             "or does not import correctly."

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -874,7 +874,7 @@ def test_read_file__columns_empty(engine, naturalearth_lowres):
     assert gdf.columns.tolist() == ["geometry"]
 
 
-@pytest.mark.skipif(FIONA_GE_19, reason="test for fiona < 1.9")
+@pytest.mark.skipif(FIONA_GE_19 or not fiona, reason="test for fiona < 1.9")
 def test_read_file__columns_old_fiona(naturalearth_lowres):
     with pytest.raises(NotImplementedError):
         geopandas.read_file(

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1306,6 +1306,26 @@ def test_option_io_engine(nybb_filename):
         geopandas.options.io_engine = None
 
 
+@pytest.mark.skipif(pyogrio, reason="test for pyogrio not installed")
+def test_error_engine_unavailable_pyogrio(tmp_path, df_points, file_path):
+
+    with pytest.raises(ImportError, match="the 'read_file' function requires"):
+        geopandas.read_file(file_path, engine="pyogrio")
+
+    with pytest.raises(ImportError, match="the 'to_file' method requires"):
+        df_points.to_file(tmp_path / "test.gpkg", engine="pyogrio")
+
+
+@pytest.mark.skipif(fiona, reason="test for fiona not installed")
+def test_error_engine_unavailable_fiona(tmp_path, df_points, file_path):
+
+    with pytest.raises(ImportError, match="the 'read_file' function requires"):
+        geopandas.read_file(file_path, engine="fiona")
+
+    with pytest.raises(ImportError, match="the 'to_file' method requires"):
+        df_points.to_file(tmp_path / "test.gpkg", engine="fiona")
+
+
 @PYOGRIO_MARK
 def test_list_layers(df_points, tmpdir):
     tempfilename = os.path.join(str(tmpdir), "dataset.gpkg")


### PR DESCRIPTION
While testing https://github.com/geopandas/geopandas/issues/3260#issuecomment-2078302687 I noticed I got a confusing error because I actually had no fiona installed, not because fiona was failing to write to bytes:

```
In [3]: data.to_file(outpath, layer="geometry", driver="GPKG", engine="fiona")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 3
      1 if outpath.exists():
      2     outpath.unlink()
----> 3 data.to_file(outpath, layer="geometry", driver="GPKG", engine="fiona")

File ~/scipy/repos/geopandas/geopandas/geodataframe.py:1349, in GeoDataFrame.to_file(self, filename, driver, schema, index, **kwargs)
   1257 """Write the ``GeoDataFrame`` to a file.
   1258 
   1259 By default, an ESRI shapefile is written, but any OGR data source
   (...)
   1345 
   1346 """
   1347 from geopandas.io.file import _to_file
-> 1349 _to_file(self, filename, driver, schema, index, **kwargs)

File ~/scipy/repos/geopandas/geopandas/io/file.py:668, in _to_file(df, filename, driver, schema, index, mode, crs, engine, **kwargs)
    666     _to_file_pyogrio(df, filename, driver, schema, crs, mode, **kwargs)
    667 elif engine == "fiona":
--> 668     _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs)
    669 else:
    670     raise ValueError(f"unknown engine '{engine}'")

File ~/scipy/repos/geopandas/geopandas/io/file.py:690, in _to_file_fiona(df, filename, driver, schema, crs, mode, **kwargs)
    687 else:
    688     crs = df.crs
--> 690 with fiona_env():
    691     crs_wkt = None
    692     try:

TypeError: 'NoneType' object is not callable
```
