### PR TITLE
ENH: support limit keyword in GeoSeries.fillna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ New features and improvements:
   preservation of the original order of observations. (#3233)
 - Added `show_bbox`, `drop_id` and `to_wgs84` arguments to allow further customization of
   `GeoSeries.to_json` (#3226)
+- The `GeoSeries.fillna` method now supports the `limit` keyword (#3290).
 
 Backwards incompatible API changes:
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1209,7 +1209,7 @@ class GeometryArray(ExtensionArray):
         return GeometryArray(result, crs=self.crs)
 
     # compat for pandas < 3.0
-    def _pad_or_backfill(*args, **kwargs):
+    def _pad_or_backfill(self, *args, **kwargs):
         return super()._pad_or_backfill(*args, **kwargs)
 
     def fillna(self, value=None, method=None, limit=None, copy=True):

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1213,7 +1213,7 @@ class GeometryArray(ExtensionArray):
         self, method, limit=None, limit_area=None, copy=True, **kwargs
     ):
         return super()._pad_or_backfill(
-            method, limit=limit, limit_area=limit_area, copy=copy, **kwargs
+            method=method, limit=limit, limit_area=limit_area, copy=copy, **kwargs
         )
 
     def fillna(self, value=None, method=None, limit=None, copy=True):

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1208,6 +1208,9 @@ class GeometryArray(ExtensionArray):
             result[~shapely.is_valid_input(result)] = None
         return GeometryArray(result, crs=self.crs)
 
+    # compat for pandas < 3.0
+    _pad_or_backfill = ExtensionArray._pad_or_backfill
+
     def fillna(self, value=None, method=None, limit=None, copy=True):
         """
         Fill NA values with geometry (or geometries) or using the specified method.

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1225,12 +1225,7 @@ class GeometryArray(ExtensionArray):
             backfill / bfill: use NEXT valid observation to fill gap
 
         limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled.
+            The maximum number of entries where NA values will be filled.
 
         copy : bool, default True
             Whether to make a copy of the data before filling. If False, then
@@ -1251,6 +1246,11 @@ class GeometryArray(ExtensionArray):
 
         if not mask.any():
             return new_values
+
+        if limit is not None and limit < len(self):
+            modify = mask.cumsum() > limit
+            if modify.any():
+                mask[modify] = False
 
         if isna(value):
             value = [None]

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1209,7 +1209,8 @@ class GeometryArray(ExtensionArray):
         return GeometryArray(result, crs=self.crs)
 
     # compat for pandas < 3.0
-    _pad_or_backfill = ExtensionArray._pad_or_backfill
+    def _pad_or_backfill(*args, **kwargs):
+        return super()._pad_or_backfill(*args, **kwargs)
 
     def fillna(self, value=None, method=None, limit=None, copy=True):
         """

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1209,8 +1209,12 @@ class GeometryArray(ExtensionArray):
         return GeometryArray(result, crs=self.crs)
 
     # compat for pandas < 3.0
-    def _pad_or_backfill(self, *args, **kwargs):
-        return super()._pad_or_backfill(*args, **kwargs)
+    def _pad_or_backfill(
+        self, method, limit=None, limit_area=None, copy=True, **kwargs
+    ):
+        return super()._pad_or_backfill(
+            method, limit=limit, limit_area=limit_area, copy=copy, **kwargs
+        )
 
     def fillna(self, value=None, method=None, limit=None, copy=True):
         """

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -808,7 +808,7 @@ class GeoSeries(GeoPandasBase, Series):
         """Alias for `notna` method. See `notna` for more detail."""
         return self.notna()
 
-    def fillna(self, value=None, inplace: bool = False, **kwargs):
+    def fillna(self, value=None, inplace: bool = False, limit=None, **kwargs):
         """
         Fill NA values with geometry (or geometries).
 
@@ -821,6 +821,9 @@ class GeoSeries(GeoPandasBase, Series):
             are passed, missing values will be filled based on the corresponding index
             locations. If pd.NA or np.nan are passed, values will be filled with
             ``None`` (not GEOMETRYCOLLECTION EMPTY).
+        limit : int, default None
+            This is the maximum number of entries along the entire axis
+            where NaNs will be filled. Must be greater than 0 if not None.
 
         Returns
         -------
@@ -880,7 +883,7 @@ class GeoSeries(GeoPandasBase, Series):
         """
         if value is None:
             value = GeometryCollection()
-        return super().fillna(value=value, inplace=inplace, **kwargs)
+        return super().fillna(value=value, limit=limit, inplace=inplace, **kwargs)
 
     def __contains__(self, other) -> bool:
         """Allow tests of the form "geom in s"

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -453,28 +453,6 @@ class TestMissing(extension_tests.BaseMissingTests):
         # `geopandas\tests\test_pandas_methods.py::test_fillna_scalar`
         # and `geopandas\tests\test_pandas_methods.py::test_fillna_series`.
 
-    @pytest.mark.skip("fillna method not supported")
-    def test_fillna_limit_pad(self, data_missing):
-        pass
-
-    @pytest.mark.skip("fillna method not supported")
-    def test_fillna_limit_backfill(self, data_missing):
-        pass
-
-    @pytest.mark.skip("fillna method not supported")
-    def test_fillna_series_method(self, data_missing, method):
-        pass
-
-    @pytest.mark.skip("fillna method not supported")
-    def test_fillna_no_op_returns_copy(self, data):
-        pass
-
-    @pytest.mark.skip("fillna method not supported")
-    def test_ffill_limit_area(
-        self, data_missing, limit_area, input_ilocs, expected_ilocs
-    ):
-        pass
-
 
 if PANDAS_GE_22:
     from pandas.tests.extension.base import BaseReduceTests

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -26,7 +26,7 @@ import shapely.geometry
 from shapely.geometry import Point
 
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely
-from geopandas._compat import PANDAS_GE_15, PANDAS_GE_22
+from geopandas._compat import PANDAS_GE_15, PANDAS_GE_21, PANDAS_GE_22
 
 import pytest
 
@@ -452,6 +452,30 @@ class TestMissing(extension_tests.BaseMissingTests):
         # More `GeoSeries.fillna` testcases are in
         # `geopandas\tests\test_pandas_methods.py::test_fillna_scalar`
         # and `geopandas\tests\test_pandas_methods.py::test_fillna_series`.
+
+    @pytest.mark.skipif(
+        not PANDAS_GE_21, reason="fillna method not supported with older pandas"
+    )
+    def test_fillna_limit_pad(self, data_missing):
+        super().test_fillna_limit_pad(data_missing)
+
+    @pytest.mark.skipif(
+        not PANDAS_GE_21, reason="fillna method not supported with older pandas"
+    )
+    def test_fillna_limit_backfill(self, data_missing):
+        super().test_fillna_limit_backfill(data_missing)
+
+    @pytest.mark.skipif(
+        not PANDAS_GE_21, reason="fillna method not supported with older pandas"
+    )
+    def test_fillna_series_method(self, data_missing, fillna_method):
+        super().test_fillna_series_method(data_missing, fillna_method)
+
+    @pytest.mark.skipif(
+        not PANDAS_GE_21, reason="fillna method not supported with older pandas"
+    )
+    def test_fillna_no_op_returns_copy(self, data):
+        super().test_fillna_no_op_returns_copy(data)
 
 
 if PANDAS_GE_22:


### PR DESCRIPTION
Following the implementation of https://github.com/pandas-dev/pandas/pull/58249

This should fix the dev CI build, because pandas enabled this feature for EAs recently and added tests for it, and those tests were now failing.