### PR TITLE
MAINT: Update ruff version and clean up settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
           - id: black
             language_version: python3
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: "v0.1.13"
+      rev: "v0.4.4"
       hooks:
         - id: ruff

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2096,7 +2096,7 @@ GeometryCollection
 
         An object is said to contain `other` if at least one point of `other` lies in
         the interior and no points of `other` lie in the exterior of the object.
-        (Therefore, any given polygon does not contain its own boundary – there is not
+        (Therefore, any given polygon does not contain its own boundary - there is not
         any point that lies in the interior.)
         If either object is empty, this operation returns ``False``.
 
@@ -4540,7 +4540,7 @@ GeometryCollection
         return _binary_geo("shortest_line", self, other, align)
 
     def snap(self, other, tolerance, align=None):
-        """Snaps an input geometry to reference geometry’s vertices.
+        """Snaps an input geometry to reference geometry's vertices.
 
         Vertices of the first geometry are snapped to vertices of the second. geometry,
         returning a new geometry; the input geometries are not modified. The result
@@ -4872,7 +4872,7 @@ GeometryCollection
         each geometry.
 
         The algorithm (Douglas-Peucker) recursively splits the original line
-        into smaller parts and connects these parts’ endpoints
+        into smaller parts and connects these parts' endpoints
         by a straight line. Then, it removes all points whose distance
         to the straight line is smaller than `tolerance`. It does not
         move any points and it always preserves endpoints of

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -855,7 +855,7 @@ def plot_dataframe(
             if scheme is not None:
                 categories = labels
             patches = []
-            for value, cat in enumerate(categories):
+            for i in range(len(categories)):
                 patches.append(
                     Line2D(
                         [0],
@@ -864,7 +864,7 @@ def plot_dataframe(
                         marker="o",
                         alpha=style_kwds.get("alpha", 1),
                         markersize=10,
-                        markerfacecolor=n_cmap.to_rgba(value),
+                        markerfacecolor=n_cmap.to_rgba(i),
                         markeredgewidth=0,
                     )
                 )

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -820,7 +820,7 @@ def test_setitem(item):
 
 def test_equality_ops():
     with pytest.raises(ValueError):
-        P[:5] == P[:7]
+        _ = P[:5] == P[:7]
 
     a1 = from_shapely([points[1], points[2], points[3]])
     a2 = from_shapely([points[1], points[0], points[3]])

--- a/geopandas/tests/test_decorator.py
+++ b/geopandas/tests/test_decorator.py
@@ -10,7 +10,6 @@ def cumsum(whatever):
 
     It computes the cumulative {operation}.
     """
-    ...
 
 
 @doc(

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1300,7 +1300,7 @@ class TestConstructor:
             geometry="geometry",
         )
         check_geodataframe(gdf)
-        gdf.columns == ["geometry", "a"]
+        assert gdf.columns == ["geometry", "a"]
 
         # with non-default index
         gdf = GeoDataFrame(
@@ -1310,7 +1310,7 @@ class TestConstructor:
             geometry="geometry",
         )
         check_geodataframe(gdf)
-        gdf.columns == ["geometry", "a"]
+        assert gdf.columns == ["geometry", "a"]
 
     def test_preserve_series_name(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1300,7 +1300,7 @@ class TestConstructor:
             geometry="geometry",
         )
         check_geodataframe(gdf)
-        assert gdf.columns == ["geometry", "a"]
+        assert list(gdf.columns) == ["geometry", "a"]
 
         # with non-default index
         gdf = GeoDataFrame(
@@ -1310,7 +1310,7 @@ class TestConstructor:
             geometry="geometry",
         )
         check_geodataframe(gdf)
-        assert gdf.columns == ["geometry", "a"]
+        assert list(gdf.columns) == ["geometry", "a"]
 
     def test_preserve_series_name(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,16 +110,14 @@ select = [
     # pycodestyle
     "E",
     "W",
-    # flake8-2020
-    "YTT",
+    # pyupgrade
+    # "UP",
     # flake8-bugbear
     "B",
-    # flake8-quotes
-    "Q",
     # flake8-debugger
     "T10",
-    # flake8-gettext
-    "INT",
+    # flake8-simplify
+    # "SIM",
     # pylint
     "PLC",
     "PLE",
@@ -127,40 +125,30 @@ select = [
     "PLW",
     # misc lints
     "PIE",
-    # flake8-pyi
-    "PYI",
-    # tidy imports
-    "TID",
     # implicit string concatenation
     "ISC",
     # type-checking imports
     "TCH",
     # comprehensions
     "C4",
-    # pygrep-hooks
-    "PGH",
     # Ruff-specific rules
     "RUF",
+    # isort
+    # "I",
 ]
 
-ignore = [ # space before : (needed for how black formats slicing)
-    # "E203",  # not yet implemented
+ignore = [
+    ### Intentionally disabled
     # module level import not at top of file
     "E402",
     # do not assign a lambda expression, use a def
     "E731",
-    # line break before binary operator
-    # "W503",  # not yet implemented
-    # line break after binary operator
-    # "W504",  # not yet implemented
     # mutable-argument-default
     "B006",
     # unused-loop-control-variable
     "B007",
     # get-attr-with-constant
     "B009",
-    # Functions defined inside a loop must not use variables redefined in the loop
-    # "B301",  # not yet implemented
     # Only works with python >=3.10
     "B905",
     # dict literals
@@ -173,46 +161,24 @@ ignore = [ # space before : (needed for how black formats slicing)
     "PLR0912",
     # Too many statements
     "PLR0915",
+    # Magic number
+    "PLR2004",
     # Redefined loop name
     "PLW2901",
     # Global statements are discouraged
     "PLW0603",
-    # Docstrings should not be included in stubs
-    "PYI021",
-    # Use `typing.NamedTuple` instead of `collections.namedtuple`
-    "PYI024",
-    # No builtin `eval()` allowed
-    "PGH001",
     # compare-to-empty-string
     "PLC1901",
-    # Use typing_extensions.TypeAlias for type aliases
-    # "PYI026",  # not yet implemented
-    # Use "collections.abc.*" instead of "typing.*" (PEP 585 syntax)
-    # "PYI027",  # not yet implemented
-    # while int | float can be shortened to float, the former is more explicit
-    # "PYI041",  # not yet implemented
 
-    # Additional checks that don't pass yet
+    ### Additional checks that don't pass yet
     # Useless statement
     "B018",
     # Within an except clause, raise exceptions with ...
     "B904",
-    # Magic number
-    "PLR2004",
     # Consider `elif` instead of `else` then `if` to remove indentation level
     "PLR5501",
-    # ambiguous-unicode-character-string
-    "RUF001",
-    # ambiguous-unicode-character-docstring
-    "RUF002",
-    # ambiguous-unicode-character-comment
-    "RUF003",
     # collection-literal-concatenation
     "RUF005",
-    # pairwise-over-zipped (>=PY310 only)
-    "RUF007",
-    # explicit-f-string-type-conversion
-    "RUF010",
     # Mutable class attributes should be annotated with `typing.ClassVar`,
     "RUF012"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ line-length = 88
 
 [tool.ruff]
 line-length = 88
+target-version = "py39"
+extend-exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]
+
+[tool.ruff.lint]
 select = [
     # pyflakes
     "F",
@@ -138,7 +142,7 @@ select = [
     # Ruff-specific rules
     "RUF",
 ]
-target-version = "py39"
+
 ignore = [ # space before : (needed for how black formats slicing)
     # "E203",  # not yet implemented
     # module level import not at top of file
@@ -226,7 +230,6 @@ ignore = [ # space before : (needed for how black formats slicing)
     # Mutable class attributes should be annotated with `typing.ClassVar`,
     "RUF012"
 ]
-extend-exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "geopandas/__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ line-length = 88
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
 extend-exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,26 +153,12 @@ ignore = [ # space before : (needed for how black formats slicing)
     # "W503",  # not yet implemented
     # line break after binary operator
     # "W504",  # not yet implemented
-    # controversial
+    # mutable-argument-default
     "B006",
-    # controversial
+    # unused-loop-control-variable
     "B007",
-    # controversial
-    "B008",
-    # setattr is used to side-step mypy
+    # get-attr-with-constant
     "B009",
-    # getattr is used to side-step mypy
-    "B010",
-    # tests use assert False
-    "B011",
-    # tests use comparisons but not their returned value
-    "B015",
-    # false positives
-    "B019",
-    # Loop control variable overrides iterable it iterates
-    "B020",
-    # Function definition does not bind loop variable
-    "B023",
     # Functions defined inside a loop must not use variables redefined in the loop
     # "B301",  # not yet implemented
     # Only works with python >=3.10


### PR DESCRIPTION
Some clean-up of our Ruff setup: 

- updating the version (with some minor required changes to the keys in the settings)
- removed a bunch of selected rules we are not really using, and some ignored rules which were actually passing (or passing with only minor positive change)
- I added the UP, SIM and I rule sets commented out in the select section, because I think those might be good to enable in a follow-up later (they are also included in the example recommendation of selection of rules at https://docs.astral.sh/ruff/linter/#rule-selection)

In general, we currently have a huge list of both selects/ignores, and personally I think it will be easier to maintain if we reduce that list (it's OK to not enable every possible rule set, as long as we enable the most important ones, and especially if we have to add a whole bunch of ignores for a specific rule set)

(I want to copy our Ruff setup to dask-geopandas, but therefore thought to first clean it up a bit. It would be good if we can keep this setup somewhat harmonized across the different geopandas repos so reduce the maintenance overhead)