### PR TITLE
MAINT: sort imports with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,6 @@ repos:
       rev: "v0.4.4"
       hooks:
         - id: ruff
+          name: sort imports with ruff
+          args: [--select, I, --fix]
+        - id: ruff

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -1,10 +1,10 @@
-from packaging.version import Version
 import importlib
+from packaging.version import Version
 
 import pandas as pd
+
 import shapely
 import shapely.geos
-
 
 # -----------------------------------------------------------------------------
 # pandas compat

--- a/geopandas/_config.py
+++ b/geopandas/_config.py
@@ -6,10 +6,9 @@ with nested options, deprecated options, ..), just the attribute-style dict
 like holding the options and giving a nice repr.
 """
 
+import textwrap
 import warnings
 from collections import namedtuple
-import textwrap
-
 
 Option = namedtuple("Option", "key default_value doc validator callback")
 

--- a/geopandas/_decorator.py
+++ b/geopandas/_decorator.py
@@ -1,7 +1,6 @@
 from textwrap import dedent
 from typing import Callable, Union
 
-
 # doc decorator function ported with modifications from Pandas
 # https://github.com/pandas-dev/pandas/blob/master/pandas/util/_decorators.py
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -6,21 +6,21 @@ from functools import lru_cache
 
 import numpy as np
 import pandas as pd
-import shapely
-import shapely.affinity
-import shapely.geometry
-import shapely.ops
-import shapely.wkt
 from pandas.api.extensions import (
     ExtensionArray,
     ExtensionDtype,
     register_extension_dtype,
 )
 
+import shapely
+import shapely.affinity
+import shapely.geometry
+import shapely.ops
+import shapely.wkt
 from shapely.geometry.base import BaseGeometry
 
-from .sindex import SpatialIndex
 from ._compat import HAS_PYPROJ, requires_pyproj
+from .sindex import SpatialIndex
 
 if HAS_PYPROJ:
     from pyproj import Transformer

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -3,8 +3,9 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-import shapely
 from pandas import DataFrame, Series
+
+import shapely
 from shapely.geometry import MultiPoint, box
 from shapely.geometry.base import BaseGeometry
 
@@ -91,8 +92,8 @@ def _delegate_property(op, this):
 def _delegate_geo_method(op, this, **kwargs):
     # type: (str, GeoSeries) -> GeoSeries
     """Unary operation that returns a GeoSeries"""
-    from .geoseries import GeoSeries
     from .geodataframe import GeoDataFrame
+    from .geoseries import GeoSeries
 
     if isinstance(this, GeoSeries):
         klass, var_name = "GeoSeries", "gs"

--- a/geopandas/conftest.py
+++ b/geopandas/conftest.py
@@ -1,8 +1,9 @@
 import os.path
 
-import pytest
 import geopandas
-from geopandas.tests.util import _NYBB, _NATURALEARTH_LOWRES, _NATURALEARTH_CITIES
+
+import pytest
+from geopandas.tests.util import _NATURALEARTH_CITIES, _NATURALEARTH_LOWRES, _NYBB
 
 
 @pytest.fixture(autouse=True)

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -1,11 +1,12 @@
+from packaging.version import Version
 from statistics import mean
 
-import geopandas
-from shapely.geometry import LineString
 import numpy as np
 import pandas as pd
 
-from packaging.version import Version
+from shapely.geometry import LineString
+
+import geopandas
 
 _MAP_KWARGS = [
     "location",
@@ -277,13 +278,14 @@ def _explore(
                 return cm.get_cmap(_cmap, n_resample)(idx)
 
     try:
+        import re
+
         import branca as bc
         import folium
-        import re
         import matplotlib
-        from matplotlib import colors
         import matplotlib.pyplot as plt
         from mapclassify import classify
+        from matplotlib import colors
 
         # isolate MPL version - GH#2596
         MPL_361 = Version(matplotlib.__version__) >= Version("3.6.1")

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -3,19 +3,20 @@ import warnings
 
 import numpy as np
 import pandas as pd
-import shapely.errors
 from pandas import DataFrame, Series
 
+import shapely.errors
 from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 
+import geopandas.io
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely, to_wkb, to_wkt
 from geopandas.base import GeoPandasBase, is_geometry_type
-from geopandas.geoseries import GeoSeries
-import geopandas.io
 from geopandas.explore import _explore
-from ._decorator import doc
+from geopandas.geoseries import GeoSeries
+
 from ._compat import HAS_PYPROJ, PANDAS_GE_30
+from ._decorator import doc
 
 if PANDAS_GE_30:
     from pandas.core.accessor import Accessor

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typing
-from typing import Optional, Any, Callable, Dict
 import warnings
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -10,13 +10,13 @@ from pandas import Series
 from pandas.core.internals import SingleBlockManager
 
 import shapely
-from shapely.geometry.base import BaseGeometry
 from shapely.geometry import GeometryCollection
+from shapely.geometry.base import BaseGeometry
 
-from geopandas.base import GeoPandasBase, _delegate_property
-from geopandas.plotting import plot_series
-from geopandas.explore import _explore_geoseries
 import geopandas
+from geopandas.base import GeoPandasBase, _delegate_property
+from geopandas.explore import _explore_geoseries
+from geopandas.plotting import plot_series
 
 from . import _compat as compat
 from ._decorator import doc

--- a/geopandas/io/_pyarrow_hotfix.py
+++ b/geopandas/io/_pyarrow_hotfix.py
@@ -2,7 +2,6 @@ from packaging.version import Version
 
 import pyarrow
 
-
 _ERROR_MSG = """\
 Disallowed deserialization of 'arrow.py_extension_type':
 storage_type = {storage_type}

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -1,16 +1,17 @@
-from packaging.version import Version
 import json
 import warnings
+from packaging.version import Version
 
 import numpy as np
 from pandas import DataFrame, Series
 
 import shapely
 
-from geopandas._compat import import_optional_dependency
-from geopandas.array import from_wkb, from_shapely
-from geopandas import GeoDataFrame
 import geopandas
+from geopandas import GeoDataFrame
+from geopandas._compat import import_optional_dependency
+from geopandas.array import from_shapely, from_wkb
+
 from .file import _expand_user
 
 METADATA_VERSION = "1.0.0"
@@ -693,6 +694,7 @@ def _read_feather(path, columns=None, **kwargs):
     )
     # TODO move this into `import_optional_dependency`
     import pyarrow
+
     import geopandas.io._pyarrow_hotfix  # noqa: F401
 
     if Version(pyarrow.__version__) < Version("0.17.0"):

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -1,12 +1,16 @@
-from io import IOBase
 import os
+import urllib.request
+import warnings
+from io import IOBase
 from packaging.version import Version
 from pathlib import Path
-import warnings
+
+# Adapted from pandas.io.common
+from urllib.parse import urlparse as parse_url
+from urllib.parse import uses_netloc, uses_params, uses_relative
 
 import numpy as np
 import pandas as pd
-from geopandas.io.util import vsi_path
 from pandas.api.types import is_integer_dtype
 
 import shapely
@@ -14,13 +18,8 @@ from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry
 
 from geopandas import GeoDataFrame, GeoSeries
-
-# Adapted from pandas.io.common
-from urllib.parse import urlparse as parse_url
-from urllib.parse import uses_netloc, uses_params, uses_relative
-import urllib.request
-
-from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
+from geopandas._compat import HAS_PYPROJ, PANDAS_GE_20
+from geopandas.io.util import vsi_path
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -26,7 +26,7 @@ def _get_conn(conn_or_engine):
     -------
     Connection
     """
-    from sqlalchemy.engine.base import Engine, Connection
+    from sqlalchemy.engine.base import Connection, Engine
 
     if isinstance(conn_or_engine, Connection):
         if not conn_or_engine.in_transaction():
@@ -293,8 +293,8 @@ def _convert_to_ewkb(gdf, geom_name, srid):
 
 
 def _psql_insert_copy(tbl, conn, keys, data_iter):
-    import io
     import csv
+    import io
 
     s_buf = io.StringIO()
     writer = csv.writer(s_buf)

--- a/geopandas/io/tests/generate_legacy_storage_files.py
+++ b/geopandas/io/tests/generate_legacy_storage_files.py
@@ -27,8 +27,9 @@ import sys
 
 import pandas as pd
 
-import geopandas
 from shapely.geometry import Point
+
+import geopandas
 
 
 def create_pickle_data():

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1,23 +1,24 @@
 from __future__ import absolute_import
 
-from itertools import product
 import json
-from packaging.version import Version
 import os
 import pathlib
+from itertools import product
+from packaging.version import Version
 
-import pytest
-from pandas import DataFrame, read_parquet as pd_read_parquet
-from pandas.testing import assert_frame_equal
 import numpy as np
-import shapely
-from shapely.geometry import box, Point, MultiPolygon
+from pandas import DataFrame
+from pandas import read_parquet as pd_read_parquet
 
+import shapely
+from shapely.geometry import MultiPolygon, Point, box
 
 import geopandas
-from geopandas import GeoDataFrame, read_file, read_parquet, read_feather
+from geopandas import GeoDataFrame, read_feather, read_file, read_parquet
+from geopandas._compat import HAS_PYPROJ
 from geopandas.array import to_wkb
 from geopandas.io.arrow import (
+    METADATA_VERSION,
     SUPPORTED_VERSIONS,
     _create_metadata,
     _decode_metadata,
@@ -27,12 +28,12 @@ from geopandas.io.arrow import (
     _remove_id_from_member_of_ensembles,
     _validate_dataframe,
     _validate_metadata,
-    METADATA_VERSION,
 )
+
+import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import mock
-from geopandas._compat import HAS_PYPROJ
-
+from pandas.testing import assert_frame_equal
 
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
@@ -476,7 +477,7 @@ def test_parquet_invalid_metadata(tmpdir, geo_meta, error, naturalearth_lowres):
     control the metadata that is written for this test.
     """
 
-    from pyarrow import parquet, Table
+    from pyarrow import Table, parquet
 
     df = read_file(naturalearth_lowres)
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -5,22 +5,24 @@ import pathlib
 import shutil
 import tempfile
 from collections import OrderedDict
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
-import pytest
 import pytz
-from packaging.version import Version
 from pandas.api.types import is_datetime64_any_dtype
-from pandas.testing import assert_series_equal, assert_frame_equal
+
 from shapely.geometry import Point, Polygon, box, mapping
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
-from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
-from geopandas.io.file import _detect_driver, _EXTENSION_TO_DRIVER, PYOGRIO_GE_081
+from geopandas._compat import HAS_PYPROJ, PANDAS_GE_20
+from geopandas.io.file import _EXTENSION_TO_DRIVER, PYOGRIO_GE_081, _detect_driver
+
+import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 try:
     import pyogrio

--- a/geopandas/io/tests/test_file_geom_types_drivers.py
+++ b/geopandas/io/tests/test_file_geom_types_drivers.py
@@ -12,11 +12,10 @@ from shapely.geometry import (
 import geopandas
 from geopandas import GeoDataFrame
 
-from geopandas.testing import assert_geodataframe_equal
-import pytest
-
 from .test_file import FIONA_MARK, PYOGRIO_MARK
 
+import pytest
+from geopandas.testing import assert_geodataframe_equal
 
 # Credit: Polygons below come from Montreal city Open Data portal
 # http://donnees.ville.montreal.qc.ca/dataset/unites-evaluation-fonciere
@@ -275,8 +274,9 @@ def test_to_file_roundtrip(tmpdir, geodataframe, ogr_driver, engine):
 
         # This if statement can be removed once minimal fiona version >= 1.8.20
         if engine == "fiona":
-            import fiona
             from packaging.version import Version
+
+            import fiona
 
             if Version(fiona.__version__) < Version("1.8.20"):
                 pytest.skip("SQLite driver only available from version 1.8.20")

--- a/geopandas/io/tests/test_infer_schema.py
+++ b/geopandas/io/tests/test_infer_schema.py
@@ -1,5 +1,8 @@
 from collections import OrderedDict
 
+import numpy as np
+import pandas as pd
+
 from shapely.geometry import (
     LineString,
     MultiLineString,
@@ -9,11 +12,10 @@ from shapely.geometry import (
     Polygon,
 )
 
-import pandas as pd
-import pytest
-import numpy as np
 from geopandas import GeoDataFrame
 from geopandas.io.file import infer_schema
+
+import pytest
 
 # Credit: Polygons below come from Montreal city Open Data portal
 # http://donnees.ville.montreal.qc.ca/dataset/unites-evaluation-fonciere

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -12,12 +12,13 @@ from importlib.util import find_spec
 import pandas as pd
 
 import geopandas
-from geopandas import GeoDataFrame, read_file, read_postgis
-
 import geopandas._compat as compat
-from geopandas.io.sql import _get_conn as get_conn, _write_postgis as write_postgis
-from geopandas.tests.util import create_postgis, create_spatialite, validate_boro_df
+from geopandas import GeoDataFrame, read_file, read_postgis
+from geopandas.io.sql import _get_conn as get_conn
+from geopandas.io.sql import _write_postgis as write_postgis
+
 import pytest
+from geopandas.tests.util import create_postgis, create_spatialite, validate_boro_df
 
 try:
     from sqlalchemy import text
@@ -156,7 +157,7 @@ def drop_table_if_exists(conn_or_engine, table):
 
 @pytest.fixture
 def df_mixed_single_and_multi():
-    from shapely.geometry import Point, LineString, MultiLineString
+    from shapely.geometry import LineString, MultiLineString, Point
 
     df = geopandas.GeoDataFrame(
         {
@@ -173,7 +174,7 @@ def df_mixed_single_and_multi():
 
 @pytest.fixture
 def df_geom_collection():
-    from shapely.geometry import Point, LineString, Polygon, GeometryCollection
+    from shapely.geometry import GeometryCollection, LineString, Point, Polygon
 
     df = geopandas.GeoDataFrame(
         {
@@ -204,7 +205,7 @@ def df_linear_ring():
 
 @pytest.fixture
 def df_3D_geoms():
-    from shapely.geometry import Point, LineString, Polygon
+    from shapely.geometry import LineString, Point, Polygon
 
     df = geopandas.GeoDataFrame(
         {

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1,13 +1,12 @@
 import warnings
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
-from pandas.plotting import PlotAccessor
 from pandas import CategoricalDtype
+from pandas.plotting import PlotAccessor
 
 import geopandas
-
-from packaging.version import Version
 
 from ._decorator import doc
 
@@ -61,8 +60,9 @@ def _expand_kwargs(kwargs, multiindex):
     it (in place) to the correct length/formats with help of 'multiindex', unless
     the value appears to already be a valid (single) value for the key.
     """
-    from matplotlib.colors import is_color_like
     from typing import Iterable
+
+    from matplotlib.colors import is_color_like
 
     scalar_kwargs = ["marker", "path_effects"]
     for att, value in kwargs.items():
@@ -843,9 +843,9 @@ def plot_dataframe(
         if "fmt" in legend_kwds:
             legend_kwds.pop("fmt")
 
-        from matplotlib.lines import Line2D
-        from matplotlib.colors import Normalize
         from matplotlib import cm
+        from matplotlib.colors import Normalize
+        from matplotlib.lines import Line2D
 
         norm = style_kwds.get("norm", None)
         if not norm:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -1,9 +1,10 @@
 import numpy as np
+
 import shapely
 from shapely.geometry.base import BaseGeometry
 
-from . import array, geoseries
 from . import _compat as compat
+from . import array, geoseries
 
 PREDICATES = {p.name for p in shapely.strtree.BinaryPredicate} | {None}
 

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -7,25 +7,24 @@ import pandas as pd
 import shapely
 import shapely.affinity
 import shapely.geometry
-from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 import shapely.wkb
 import shapely.wkt
 from shapely import geos_version
+from shapely.geometry.base import CAP_STYLE, JOIN_STYLE
 
 import geopandas
+from geopandas._compat import HAS_PYPROJ
 from geopandas.array import (
     GeometryArray,
+    _check_crs,
+    _crs_mismatch_warn,
     from_shapely,
     from_wkb,
     from_wkt,
     points_from_xy,
     to_wkb,
     to_wkt,
-    _check_crs,
-    _crs_mismatch_warn,
 )
-
-from geopandas._compat import HAS_PYPROJ
 
 import pytest
 

--- a/geopandas/tests/test_compat.py
+++ b/geopandas/tests/test_compat.py
@@ -1,6 +1,6 @@
-import pytest
-
 from geopandas._compat import import_optional_dependency
+
+import pytest
 
 
 def test_import_optional_dependency_present():

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -3,11 +3,13 @@ import warnings
 
 import numpy as np
 import pandas as pd
-import pytest
-from shapely.geometry import Point, Polygon, LineString
 
-from geopandas import GeoSeries, GeoDataFrame, points_from_xy, read_file
-from geopandas.array import from_shapely, from_wkb, from_wkt, GeometryArray
+from shapely.geometry import LineString, Point, Polygon
+
+from geopandas import GeoDataFrame, GeoSeries, points_from_xy, read_file
+from geopandas.array import GeometryArray, from_shapely, from_wkb, from_wkt
+
+import pytest
 from geopandas.testing import assert_geodataframe_equal
 
 pyproj = pytest.importorskip("pyproj")

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -5,12 +5,11 @@ import pandas as pd
 
 import geopandas
 from geopandas import GeoDataFrame, read_file
+from geopandas._compat import HAS_PYPROJ, PANDAS_GE_15, PANDAS_GE_20, PANDAS_GE_30
 
-from pandas.testing import assert_frame_equal
 import pytest
-
-from geopandas._compat import PANDAS_GE_15, PANDAS_GE_20, PANDAS_GE_30, HAS_PYPROJ
 from geopandas.testing import assert_geodataframe_equal, geom_almost_equals
+from pandas.testing import assert_frame_equal
 
 
 @pytest.fixture

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -1,11 +1,14 @@
-import geopandas as gpd
-import numpy as np
-import pandas as pd
-import pytest
-import shapely
 from packaging.version import Version
 
+import numpy as np
+import pandas as pd
+
+import shapely
+
+import geopandas as gpd
 from geopandas._compat import HAS_PYPROJ
+
+import pytest
 
 folium = pytest.importorskip("folium")
 branca = pytest.importorskip("branca")
@@ -13,9 +16,8 @@ matplotlib = pytest.importorskip("matplotlib")
 mapclassify = pytest.importorskip("mapclassify")
 geodatasets = pytest.importorskip("geodatasets")
 
-from matplotlib import cm
-from matplotlib import colors
 from branca.colormap import StepColormap
+from matplotlib import cm, colors
 
 BRANCA_05 = Version(branca.__version__) > Version("0.4.2")
 FOLIUM_G_014 = Version(folium.__version__) > Version("0.14.0")

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -19,16 +19,16 @@ import operator
 
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_series_equal, assert_frame_equal
 from pandas.tests.extension import base as extension_tests
 
 import shapely.geometry
 from shapely.geometry import Point
 
-from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 from geopandas._compat import PANDAS_GE_15, PANDAS_GE_21, PANDAS_GE_22
+from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 
 import pytest
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 # -----------------------------------------------------------------------------
 # Compat with extension tests in older pandas versions

--- a/geopandas/tests/test_geocode.py
+++ b/geopandas/tests/test_geocode.py
@@ -3,15 +3,14 @@ import pandas as pd
 from shapely.geometry import Point
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas._compat import HAS_PYPROJ
 from geopandas.tools import geocode, reverse_geocode
 from geopandas.tools.geocoding import _prepare_geocode_result
 
+import pytest
+from geopandas.testing import assert_geodataframe_equal
 from geopandas.tests.util import assert_geoseries_equal, mock
 from pandas.testing import assert_series_equal
-from geopandas.testing import assert_geodataframe_equal
-import pytest
-
-from geopandas._compat import HAS_PYPROJ
 
 geopy = pytest.importorskip("geopy")
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -9,14 +9,14 @@ import pandas as pd
 from shapely.geometry import Point, Polygon, box
 
 import geopandas
+import geopandas._compat as compat
 from geopandas import GeoDataFrame, GeoSeries, points_from_xy, read_file
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 
+import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from geopandas.tests.util import PACKAGE_DIR, validate_boro_df
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
-import geopandas._compat as compat
-import pytest
 
 
 @pytest.fixture

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -2,11 +2,9 @@ import string
 import warnings
 
 import numpy as np
-import pytest
-import shapely
-from numpy.testing import assert_array_equal
 from pandas import DataFrame, Index, MultiIndex, Series, concat
-from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
+
+import shapely
 from shapely import wkt
 from shapely.geometry import (
     LinearRing,
@@ -22,10 +20,14 @@ from shapely.geometry.collection import GeometryCollection
 from shapely.ops import unary_union
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas._compat import HAS_PYPROJ
 from geopandas.base import GeoPandasBase
+
+import pytest
 from geopandas.testing import assert_geodataframe_equal
 from geopandas.tests.util import assert_geoseries_equal, geom_almost_equals, geom_equals
-from geopandas._compat import HAS_PYPROJ
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 
 def assert_array_dtype_equal(a, b, *args, **kwargs):

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -6,9 +6,7 @@ import tempfile
 import warnings
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pandas as pd
-from pandas.testing import assert_index_equal
 
 from shapely.geometry import (
     GeometryCollection,
@@ -21,15 +19,16 @@ from shapely.geometry import (
 )
 from shapely.geometry.base import BaseGeometry
 
-from geopandas import GeoSeries, GeoDataFrame, read_file, clip
-from geopandas.array import GeometryArray, GeometryDtype
 import geopandas._compat as compat
-from geopandas.testing import assert_geoseries_equal, geom_almost_equals
-
-from geopandas.tests.util import geom_equals
+from geopandas import GeoDataFrame, GeoSeries, clip, read_file
 from geopandas._compat import HAS_PYPROJ
-from pandas.testing import assert_series_equal
+from geopandas.array import GeometryArray, GeometryDtype
+
 import pytest
+from geopandas.testing import assert_geoseries_equal, geom_almost_equals
+from geopandas.tests.util import geom_equals
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_index_equal, assert_series_equal
 
 
 class TestSeries:

--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -1,15 +1,15 @@
 import warnings
 
 import pandas as pd
-import pytest
-
-from geopandas._compat import PANDAS_GE_21, HAS_PYPROJ
-from geopandas.testing import assert_geodataframe_equal
-from pandas.testing import assert_index_equal
 
 from shapely.geometry import Point
 
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas._compat import HAS_PYPROJ, PANDAS_GE_21
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal
+from pandas.testing import assert_index_equal
 
 
 class TestMerging:

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -1,12 +1,13 @@
+import numpy as np
 import pandas as pd
-import pytest
 
 from shapely.geometry import Point
-import numpy as np
 
-from geopandas import GeoDataFrame, GeoSeries
-from geopandas.testing import assert_geodataframe_equal
 import geopandas
+from geopandas import GeoDataFrame, GeoSeries
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal
 
 pyproj = pytest.importorskip("pyproj")
 

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -4,14 +4,14 @@ import numpy as np
 import pandas as pd
 
 from shapely import make_valid
-from shapely.geometry import Point, Polygon, LineString, GeometryCollection, box
+from shapely.geometry import GeometryCollection, LineString, Point, Polygon, box
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, overlay, read_file
-from geopandas._compat import PANDAS_GE_20, HAS_PYPROJ
+from geopandas._compat import HAS_PYPROJ, PANDAS_GE_20
 
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 try:
     from fiona.errors import DriverError

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -1,22 +1,22 @@
 import os
-from packaging.version import Version
 import warnings
+from packaging.version import Version
 
 import numpy as np
-from numpy.testing import assert_array_equal
 import pandas as pd
 
 import shapely
-from shapely.geometry import Point, GeometryCollection, LineString, LinearRing
+from shapely.geometry import GeometryCollection, LinearRing, LineString, Point
 
 import geopandas
-from geopandas import GeoDataFrame, GeoSeries
 import geopandas._compat as compat
+from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import from_shapely
 
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
-from pandas.testing import assert_frame_equal, assert_series_equal
 import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 
 @pytest.fixture

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1,26 +1,25 @@
 import itertools
-from packaging.version import Version
 import warnings
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
 
 from shapely.affinity import rotate
 from shapely.geometry import (
-    MultiPolygon,
-    Polygon,
-    LineString,
-    LinearRing,
-    Point,
-    MultiPoint,
-    MultiLineString,
     GeometryCollection,
+    LinearRing,
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
     box,
 )
 
-
-from geopandas import GeoDataFrame, GeoSeries, read_file
 import geopandas._compat as compat
+from geopandas import GeoDataFrame, GeoSeries, read_file
 from geopandas.plotting import GeoplotAccessor
 
 import pytest
@@ -1463,8 +1462,9 @@ class TestPlotCollections:
         )
 
     def test_points(self):
-        from geopandas.plotting import _plot_point_collection
         from matplotlib.collections import PathCollection
+
+        from geopandas.plotting import _plot_point_collection
 
         fig, ax = plt.subplots()
         coll = _plot_point_collection(ax, self.points)
@@ -1531,8 +1531,9 @@ class TestPlotCollections:
         # _check_colors(self.N, coll.get_edgecolors(), expected_colors)
 
     def test_linestrings(self):
-        from geopandas.plotting import _plot_linestring_collection
         from matplotlib.collections import LineCollection
+
+        from geopandas.plotting import _plot_linestring_collection
 
         fig, ax = plt.subplots()
         coll = _plot_linestring_collection(ax, self.lines)
@@ -1614,8 +1615,9 @@ class TestPlotCollections:
         ax.cla()
 
     def test_polygons(self):
-        from geopandas.plotting import _plot_polygon_collection
         from matplotlib.collections import PatchCollection
+
+        from geopandas.plotting import _plot_polygon_collection
 
         fig, ax = plt.subplots()
         coll = _plot_polygon_collection(ax, self.polygons)
@@ -1826,8 +1828,9 @@ def test_column_values():
 def test_polygon_patch():
     # test adapted from descartes by Sean Gillies
     # (BSD license, https://pypi.org/project/descartes).
-    from geopandas.plotting import _PolygonPatch
     from matplotlib.patches import PathPatch
+
+    from geopandas.plotting import _PolygonPatch
 
     polygon = (
         Point(0, 0).buffer(10.0).difference(MultiPoint([(-5, 0), (5, 0)]).buffer(3.0))

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -1,9 +1,8 @@
 from math import sqrt
 
 import numpy as np
-import pytest
+
 import shapely
-from numpy.testing import assert_array_equal
 from shapely.geometry import (
     GeometryCollection,
     LineString,
@@ -16,6 +15,9 @@ from shapely.geometry import (
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, read_file
 from geopandas import _compat as compat
+
+import pytest
+from numpy.testing import assert_array_equal
 
 
 class TestSeriesSindex:

--- a/geopandas/tests/test_testing.py
+++ b/geopandas/tests/test_testing.py
@@ -1,17 +1,17 @@
 import warnings
 
 import numpy as np
-
-from shapely.geometry import Point, Polygon
 import pandas as pd
 from pandas import DataFrame, Series
 
+from shapely.geometry import Point, Polygon
+
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas._compat import HAS_PYPROJ
 from geopandas.array import from_shapely
 
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
-from geopandas._compat import HAS_PYPROJ
 import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 s1 = GeoSeries(
     [

--- a/geopandas/tools/__init__.py
+++ b/geopandas/tools/__init__.py
@@ -1,8 +1,8 @@
+from .clip import clip
 from .geocoding import geocode, reverse_geocode
 from .overlay import overlay
 from .sjoin import sjoin, sjoin_nearest
 from .util import collect
-from .clip import clip
 
 __all__ = [
     "collect",

--- a/geopandas/tools/_random.py
+++ b/geopandas/tools/_random.py
@@ -1,6 +1,7 @@
 from warnings import warn
 
 import numpy
+
 from shapely.geometry import MultiPoint
 
 from geopandas.array import from_shapely, points_from_xy

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -10,7 +10,8 @@ import warnings
 
 import numpy as np
 import pandas.api.types
-from shapely.geometry import Polygon, MultiPolygon, box
+
+from shapely.geometry import MultiPolygon, Polygon, box
 
 from geopandas import GeoDataFrame, GeoSeries
 from geopandas.array import _check_crs, _crs_mismatch_warn

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import time
+from collections import defaultdict
 
 import pandas as pd
 
@@ -120,8 +120,8 @@ def reverse_geocode(points, provider=None, **kwargs):
 
 def _query(data, forward, provider, throttle_time, **kwargs):
     # generic wrapper for calls over lists to geopy Geocoders
-    from geopy.geocoders.base import GeocoderQueryError
     from geopy.geocoders import get_geocoder_for_service
+    from geopy.geocoders.base import GeocoderQueryError
 
     if forward:
         if not isinstance(data, pd.Series):

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas.array import _check_crs, _crs_mismatch_warn
 from geopandas._compat import PANDAS_GE_30
+from geopandas.array import _check_crs, _crs_mismatch_warn
 
 
 def _ensure_geometry_column(df):

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -1,13 +1,13 @@
+import warnings
 from functools import partial
 from typing import Optional
-import warnings
 
 import numpy as np
 import pandas as pd
 
 from geopandas import GeoDataFrame
-from geopandas.array import _check_crs, _crs_mismatch_warn
 from geopandas._compat import PANDAS_GE_30
+from geopandas.array import _check_crs, _crs_mismatch_warn
 
 
 def sjoin(

--- a/geopandas/tools/tests/test_clip.py
+++ b/geopandas/tools/tests/test_clip.py
@@ -5,24 +5,23 @@ import pandas as pd
 
 import shapely
 from shapely.geometry import (
-    Polygon,
-    Point,
-    LineString,
-    LinearRing,
     GeometryCollection,
+    LinearRing,
+    LineString,
     MultiPoint,
+    Point,
+    Polygon,
     box,
 )
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries, clip
 from geopandas._compat import HAS_PYPROJ
+from geopandas.tools.clip import _mask_is_list_like_rectangle
 
+import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from pandas.testing import assert_index_equal
-import pytest
-
-from geopandas.tools.clip import _mask_is_list_like_rectangle
 
 mask_variants_single_rectangle = [
     "single_rectangle_gdf",

--- a/geopandas/tools/tests/test_hilbert_curve.py
+++ b/geopandas/tools/tests/test_hilbert_curve.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from shapely.geometry import Point
 from shapely.wkt import loads
 

--- a/geopandas/tools/tests/test_random.py
+++ b/geopandas/tools/tests/test_random.py
@@ -1,8 +1,9 @@
-import pytest
 import numpy
-import geopandas
 
+import geopandas
 from geopandas.tools._random import uniform
+
+import pytest
 
 
 @pytest.fixture

--- a/geopandas/tools/tests/test_sjoin.py
+++ b/geopandas/tools/tests/test_sjoin.py
@@ -3,24 +3,24 @@ from typing import Sequence
 
 import numpy as np
 import pandas as pd
-import shapely
 
-from shapely.geometry import Point, Polygon, GeometryCollection, box
+import shapely
+from shapely.geometry import GeometryCollection, Point, Polygon, box
 
 import geopandas
 import geopandas._compat as compat
 from geopandas import (
     GeoDataFrame,
     GeoSeries,
+    points_from_xy,
     read_file,
     sjoin,
     sjoin_nearest,
-    points_from_xy,
 )
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
-from pandas.testing import assert_frame_equal, assert_series_equal, assert_index_equal
 import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 
 @pytest.fixture()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ select = [
     # Ruff-specific rules
     "RUF",
     # isort
-    # "I",
+    "I",
 ]
 
 ignore = [
@@ -183,4 +183,21 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"geopandas/__init__.py" = ["F401"]
+"geopandas/__init__.py" = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+extra-standard-library = ["packaging"]
+
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "geo",
+  "first-party",
+  "local-folder",
+  "testing"
+]
+
+[tool.ruff.lint.isort.sections]
+"geo" = ["shapely", "pyproj"]
+"testing" = ["pytest", "pandas.testing", "numpy.testing", "geopandas.tests", "geopandas.testing"]


### PR DESCRIPTION
Sorting imports is one of the things in our linting setup that we don't yet do (and that several other projects I contribute to do with isort). I think it would be nice to add this as well (with automatic fixing, like the formatting), not having to think about import sorting. 

(I was also rebasing some older PRs that had made changes to imports, and fixing the conflicts in the import section was actually the hardest part. I think automating the formatting for imports should make this a bit easier as well)

I am using ruff here instead of isort given that ruff supports this as well (I think they don't support all tweaking optioms of isort, but we don't need that), but adding it as a separate pre-commit hook to enable the auto-fixing.

I added some custom configuration for the import ordering, to keep the automated sorting as close as possible to our current practices and so to keep the amount of changes limited. But we could also go with just the default settings.