### PR TITLE
Avoid returning deep copies with pandas 3.0 (with Copy-on-Write)

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1117,7 +1117,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
             geometry columns are encoded to WKB
         """
 
-        df = DataFrame(self.copy())
+        df = DataFrame(self.copy(deep=not PANDAS_GE_30))
 
         # Encode all geometry columns to WKB
         for col in df.columns[df.dtypes == "geometry"]:
@@ -1140,7 +1140,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
             geometry columns are encoded to WKT
         """
 
-        df = DataFrame(self.copy())
+        df = DataFrame(self.copy(deep=not PANDAS_GE_30))
 
         # Encode all geometry columns to WKT
         for col in df.columns[df.dtypes == "geometry"]:
@@ -1426,7 +1426,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
 
         """
         if not inplace:
-            df = self.copy()
+            df = self.copy(deep=not PANDAS_GE_30)
         else:
             df = self
         df.geometry = df.geometry.set_crs(
@@ -1513,7 +1513,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         if inplace:
             df = self
         else:
-            df = self.copy()
+            df = self.copy(deep=not PANDAS_GE_30)
         geom = df.geometry.to_crs(crs=crs, epsg=epsg)
         df.geometry = geom
         if not inplace:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -1066,7 +1066,7 @@ class GeoSeries(GeoPandasBase, Series):
                 "transform the geometries, use 'GeoSeries.to_crs' instead."
             )
         if not inplace:
-            result = self.copy()
+            result = self.copy(deep=not compat.PANDAS_GE_30)
         else:
             result = self
         result.crs = crs

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -65,7 +65,7 @@ def _clip_gdf_with_mask(gdf, mask, sort=False):
 
     # Clip the data with the polygon
     if isinstance(gdf_sub, GeoDataFrame):
-        clipped = gdf_sub.copy()
+        clipped = gdf_sub
         if clipping_by_rectangle:
             clipped.loc[non_point_mask, clipped._geometry_column_name] = (
                 gdf_sub.geometry.values[non_point_mask].clip_by_rect(*mask)
@@ -76,7 +76,7 @@ def _clip_gdf_with_mask(gdf, mask, sort=False):
             )
     else:
         # GeoSeries
-        clipped = gdf_sub.copy()
+        clipped = gdf_sub
         if clipping_by_rectangle:
             clipped[non_point_mask] = gdf_sub.values[non_point_mask].clip_by_rect(*mask)
         else:


### PR DESCRIPTION
Avoiding some deep copies in case of pandas >= 3.0. Starting with pandas 3.0, most methods on a DataFrame (like rename or (re)set_index) will not return a hard copy of the data, but only a shallow copy (protected by Copy-on-Write, to ensure it still behaves as a copy).

We can follow that new behaviour in our own methods, so checking for a few cases where right now we always do a `copy()` of self before adjusting and returning it.