### PR TITLE
DOC: move aggregations to the relevant API section

### DIFF
--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -101,11 +101,9 @@ Constructive methods and attributes
 
    GeoSeries.boundary
    GeoSeries.buffer
-   GeoSeries.build_area
    GeoSeries.centroid
    GeoSeries.concave_hull
    GeoSeries.convex_hull
-   GeoSeries.delaunay_triangles
    GeoSeries.envelope
    GeoSeries.extract_unique_points
    GeoSeries.force_2d
@@ -115,7 +113,6 @@ Constructive methods and attributes
    GeoSeries.minimum_clearance
    GeoSeries.minimum_rotated_rectangle
    GeoSeries.normalize
-   GeoSeries.polygonize
    GeoSeries.remove_repeated_points
    GeoSeries.reverse
    GeoSeries.sample_points
@@ -124,7 +121,6 @@ Constructive methods and attributes
    GeoSeries.simplify
    GeoSeries.snap
    GeoSeries.transform
-   GeoSeries.voronoi_polygons
 
 Affine transformations
 ----------------------
@@ -155,9 +151,14 @@ Aggregating and exploding
 .. autosummary::
    :toctree: api/
 
-   GeoSeries.union_all
-   GeoSeries.intersection_all
+   GeoSeries.build_area
+   GeoSeries.delaunay_triangles
    GeoSeries.explode
+   GeoSeries.intersection_all
+   GeoSeries.polygonize
+   GeoSeries.union_all
+   GeoSeries.voronoi_polygons
+
 
 Serialization / IO / conversion
 -------------------------------

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1376,6 +1376,7 @@ GeometryCollection
     def offset_curve(self, distance, quad_segs=8, join_style="round", mitre_limit=5.0):
         """Returns a ``LineString`` or ``MultiLineString`` geometry at a
         distance from the object on its right or its left side.
+
         Parameters
         ----------
         distance : float | array-like


### PR DESCRIPTION
Moving methods that behave like aggregations (considering all geoms together) under the aggregations heading.

xref https://github.com/geopandas/geopandas/issues/3201#issuecomment-2118797818