### PR TITLE
DOC/RLS: clean-up sections in 1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,6 @@ Notes on dependencies:
 - The I/O engine now defaults to Pyogrio which is now installed with GeoPandas instead
   of Fiona. (#3223)
 
-API changes:
-
-- `unary_union` attribute is now deprecated and replaced by the `union_all()` method (#3007) allowing
-  opting for a faster union algorithm for coverages (#3151).
-- `align` keyword in binary methods now defaults to `None`, treated as True. Explicit True
-  will silence the warning about mismachted indices. (#3212)
-- The `sjoin` method will now preserve the name of the index of the right
-  GeoDataFrame, if it has one, instead of always using `"index_right"` as the
-  name for the resulting column in the return value (#846, #2144).
-- GeoPandas now raises a ValueError when an unaligned Series is passed as a method
-  argument to avoid confusion of whether the automatic alignment happens or not (#3271).
-
 New methods:
 
 - Added `count_geometries` method from shapely to GeoSeries/GeoDataframe (#3154).
@@ -72,9 +60,16 @@ New features and improvements:
 - The `GeoSeries.fillna` method now supports the `limit` keyword (#3290).
 - Added support for `bbox` covering encoding in geoparquet. Can filter reading of parquet
 files based on a bounding box, and write out a bounding box column to parquet files (#3282)
+- `align` keyword in binary methods now defaults to `None`, treated as True. Explicit True
+  will silence the warning about mismachted indices. (#3212)
 
 Backwards incompatible API changes:
 
+- The `sjoin` method will now preserve the name of the index of the right
+  GeoDataFrame, if it has one, instead of always using `"index_right"` as the
+  name for the resulting column in the return value (#846, #2144).
+- GeoPandas now raises a ValueError when an unaligned Series is passed as a method
+  argument to avoid confusion of whether the automatic alignment happens or not (#3271).
 - The deprecated default value of GeoDataFrame/ GeoSeries `explode(.., index_parts=True)` is now
   set to false for consistency with pandas (#3174).
 - The behaviour of `set_geometry` has been changed when passed a (Geo)Series `ser` with a name.
@@ -85,28 +80,11 @@ Backwards incompatible API changes:
 - `delaunay_triangles` now considers all geometries together when creating the Delaunay trianguation
   instead of performing the operation element-wise. If you want to generate Delaunay
   triangles for each geometry separately, use ``shapely.delaunay_triangles`` instead. (#3273)
-
-
-Potentially breaking changes:
-
-- reading a data source that does not have a geometry field using ``read_file``
+- Reading a data source that does not have a geometry field using ``read_file``
   now returns a Pandas DataFrame instead of a GeoDataFrame with an empty
   ``geometry`` column.
 
-Bug fixes:
-
-- Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a
-  `GeoDataFrame` when the `suffixes` argument is applied to the active
-  geometry column (#2933).
-- Fix bug in `GeoDataFrame` constructor where if `geometry` is given a named
-  `GeoSeries` the name was not used as the active geometry column name (#3237).
-- Fix bug in `GeoSeries` constructor when passing a Series and specifying a `crs` to not change the original input data (#2492).
-- Fix regression preventing reading from file paths containing hashes in `read_file`
-  with the fiona engine (#3280). An analgous fix for pyogrio is included in
-  pyogrio 0.8.1.
-- Fix `to_parquet` to write correct metadata in case of 3D geometries (#2824).
-
-Deprecations and compatibility notes:
+Enforced deprecations:
 
 - The deprecation of `geopandas.datasets` has been enforced and the module has been
   removed. New sample datasets are now available in the
@@ -128,7 +106,11 @@ Deprecations and compatibility notes:
     method directly instead.
   - Removed deprecated GeoSeries/GeoDataFrame `.plot` parameters `axes` and `colormap`, instead use
     `ax` and `cmap` respectively.
-- Fixes for compatibility with psycopg (#3167).
+
+New deprecations:
+
+- `unary_union` attribute is now deprecated and replaced by the `union_all()` method (#3007) allowing
+  opting for a faster union algorithm for coverages (#3151).
 - The ``include_fields`` and ``ignore_fields`` keywords in ``read_file()`` are deprecated
   for the default pyogrio engine. Currently those are translated to the ``columns`` keyword
   for backwards compatibility, but you should directly use the ``columns`` keyword instead
@@ -145,6 +127,20 @@ Deprecations and compatibility notes:
   ```
 - The `geopandas.use_pygeos` option has been deprecated and will be removed in GeoPandas
   1.1 (#3283)
+
+Bug fixes:
+
+- Fix `GeoDataFrame.merge()` incorrectly returning a `DataFrame` instead of a
+  `GeoDataFrame` when the `suffixes` argument is applied to the active
+  geometry column (#2933).
+- Fix bug in `GeoDataFrame` constructor where if `geometry` is given a named
+  `GeoSeries` the name was not used as the active geometry column name (#3237).
+- Fix bug in `GeoSeries` constructor when passing a Series and specifying a `crs` to not change the original input data (#2492).
+- Fix regression preventing reading from file paths containing hashes in `read_file`
+  with the fiona engine (#3280). An analgous fix for pyogrio is included in
+  pyogrio 0.8.1.
+- Fix `to_parquet` to write correct metadata in case of 3D geometries (#2824).
+- Fixes for compatibility with psycopg (#3167).
 
 ## Version 0.14.4 (April 26, 2024)
 


### PR DESCRIPTION
Grouping all items that are actually breaking, separating from new deprecations and enforced deprecations. And moved bug fixes section to the end.