### PR TITLE
use DeprecationWarning in unary_union deprection

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -851,7 +851,7 @@ class GeometryArray(ExtensionArray):
         warnings.warn(
             "The 'unary_union' attribute is deprecated, "
             "use the 'union_all' method instead.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.union_all()

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2108,7 +2108,7 @@ GeometryCollection
         warn(
             "The 'unary_union' attribute is deprecated, "
             "use the 'union_all()' method instead.",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
 

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -665,7 +665,9 @@ def test_unary_union():
         shapely.geometry.Polygon([(0, 0), (1, 0), (1, 1)]),
     ]
     G = from_shapely(geoms)
-    with pytest.warns(FutureWarning, match="The 'unary_union' attribute is deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="The 'unary_union' attribute is deprecated"
+    ):
         u = G.unary_union()
 
     expected = shapely.geometry.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -508,7 +508,7 @@ class TestGeomMethods:
         p2 = Polygon([(2, 0), (3, 0), (3, 1)])
         g = GeoSeries([p1, p2])
         with pytest.warns(
-            FutureWarning, match="The 'unary_union' attribute is deprecated"
+            DeprecationWarning, match="The 'unary_union' attribute is deprecated"
         ):
             result = g.unary_union
         assert result == g.union_all()


### PR DESCRIPTION
We shall start with DeprecationWarning to give devs time to switch before letting the error bubble up to users. This should change to FutureWarning in 1.1 or later and be enforced in 2.0.

ref https://github.com/geopandas/geopandas/pull/3007#issuecomment-2139516852