### PR TITLE
TST/ENH: Continuation of #3282, add testing coverage and fixes

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -867,11 +867,12 @@ def _convert_bbox_to_parquet_filter(bbox, bbox_column_name):
 
 
 def _check_if_covering_in_geo_metadata(geo_metadata):
-    return "covering" in geo_metadata["columns"]["geometry"].keys()
+    return "covering" in next(iter(geo_metadata["columns"].values()))
 
 
 def _get_bbox_encoding_column_name(geo_metadata):
-    return geo_metadata["columns"]["geometry"]["covering"]["bbox"]["xmin"][0]
+    covering = next(iter(geo_metadata["columns"].values()))["covering"]
+    return covering["bbox"]["xmin"][0]
 
 
 def _get_non_bbox_columns(schema, geo_metadata):

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -349,6 +349,11 @@ def _geopandas_to_arrow(
     )
 
     if write_covering_bbox:
+        if bbox_encoding_fieldname in df.columns:
+            raise ValueError(
+                f'An existing column "{bbox_encoding_fieldname}" already \
+                    exists in the dataframe. Please rename to write covering bbox.'
+            )
         bounds = df.bounds
         bbox_array = StructArray.from_arrays(
             [bounds["minx"], bounds["miny"], bounds["maxx"], bounds["maxy"]],

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1228,7 +1228,9 @@ def test_read_parquet_filters_without_bbox(tmpdir, naturalearth_lowres, filters)
     assert result["name"].values.tolist() == ["Burkina Faso", "Mozambique", "Albania"]
 
 
-def test_write_parquet_file(tmpdir, naturalearth_lowres):
+def test_read_parquet_file_with_custom_bbox_encoding_fieldname(
+    tmpdir, naturalearth_lowres
+):
     import pyarrow.parquet as pq
 
     df = read_file(naturalearth_lowres)
@@ -1245,6 +1247,28 @@ def test_write_parquet_file(tmpdir, naturalearth_lowres):
 
     pq_table = pq.read_table(filename)
     assert "custom_bbox_name" in pq_table.schema.names
+
+    pq_df = read_parquet(filename, bbox=(0, 0, 10, 10))
+    assert pq_df["name"].values.tolist() == [
+        "France",
+        "Benin",
+        "Nigeria",
+        "Cameroon",
+        "Togo",
+        "Ghana",
+        "Burkina Faso",
+        "Gabon",
+        "Eq. Guinea",
+    ]
+
+
+def test_read_parquet_with_bbox_filter_with_custom_geometry_name(
+    tmpdir, naturalearth_lowres
+):
+    df = read_file(naturalearth_lowres)
+    df = df.rename_geometry("custom_geometry_label")
+    filename = os.path.join(str(tmpdir), "test.pq")
+    df.to_parquet(filename, write_covering_bbox=True)
 
     pq_df = read_parquet(filename, bbox=(0, 0, 10, 10))
     assert pq_df["name"].values.tolist() == [

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1282,3 +1282,12 @@ def test_read_parquet_with_bbox_filter_with_custom_geometry_name(
         "Gabon",
         "Eq. Guinea",
     ]
+
+
+def test_to_parquet_with_existing_bbox_column(tmpdir, naturalearth_lowres):
+    df = read_file(naturalearth_lowres)
+    df = df.assign(bbox=[0] * len(df))
+    filename = os.path.join(str(tmpdir), "test.pq")
+
+    with pytest.raises(ValueError):
+        df.to_parquet(filename, write_covering_bbox=True)


### PR DESCRIPTION
Resolves #3308

This is a continuation of #3282 to address 3 items:

**-     ensure this is robust for the geometry column name (no hardcoded "geometry")**
The was an implicit hardcoding that occurred when checking of the covering encoding was in the metadata, and when seeking the bbox encoding field name. My approach assumes that there will only be one entry for the geo_metadata columns, which I assume to be a valid assumption as there can only be one active geometry.

**-     test reading a file that uses a different column name as "bbox"**
The code as it is addresses this by looking at the metadata to discover the field name. To facilitate testing of this, some refactoring was done to add the field name as a kwarg in the private functions. This still maintains "bbox" as the only allowable fieldname when writing, but this refactor facilitated writing the tests. Hope that is acceptable.

**-     test writing in case your geodataframe already has a bbox column**
When testing, no error showed when writing the parquet file, but an error was raised when reading - it was not a very descriptive error but seems to be attributed to two fields having identical names. A ValueError has been added if the dataframe already has a column with the name "bbox" and the user has `write_bbox_covering=True`.

One thing that I wanted to confirm is that we don't want the user to be able to specify their own `bbox` column? So they can put in their own custom bounds that they calculate or modify themselves for whatever reason - in which case I should be parsing their `bbox` column to ensure formatting is appropriate and pushing that in, instead of calculating it for the user?