### PR TITLE
BUG: Stop geopandas.io.sql._write_postgis() from overriding user-supplied geometry dtype.

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -387,7 +387,8 @@ def _write_postgis(
 
     # Build dtype with Geometry
     if dtype is not None:
-        dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
+        if geom_name not in dtype.keys():
+            dtype[geom_name] = Geometry(geometry_type=geometry_type, srid=srid)
     else:
         dtype = {geom_name: Geometry(geometry_type=geometry_type, srid=srid)}
 


### PR DESCRIPTION
Checks that 'geom_name' is not already a key in the 'dtypes' dictionary to avoid overwrite.

Fixes:
https://github.com/geopandas/geopandas/issues/2612
https://github.com/geopandas/geopandas/issues/2661