### PR TITLE
BUG: allow appending df with no CRS to postgis with no CRS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Bug fixes:
   pyogrio 0.8.1.
 - Fix `to_parquet` to write correct metadata in case of 3D geometries (#2824).
 - Fixes for compatibility with psycopg (#3167).
+- Fix to allow appending dataframes with no CRS to PostGIS tables with no CRS (#3328)
 
 ## Version 0.14.4 (April 26, 2024)
 

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -231,7 +231,7 @@ def _get_geometry_type(gdf):
 
 def _get_srid_from_crs(gdf):
     """
-    Get EPSG code from CRS if available. If not, return -1.
+    Get EPSG code from CRS if available. If not, return 0.
     """
 
     # Use geoalchemy2 default for srid
@@ -257,7 +257,7 @@ def _get_srid_from_crs(gdf):
             warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
     if srid is None:
-        srid = -1
+        srid = 0
         warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
     return srid

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -774,6 +774,20 @@ class TestIO:
             write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
+    def test_append_without_crs(self, engine_postgis, df_nybb):
+        engine = engine_postgis
+        df_nybb.crs = None
+        table = "nybb"
+        write_postgis(df_nybb, con=engine, name=table, if_exists="replace")
+
+        # Reproject
+        df_nybb2 = df_nybb
+
+        # # Should raise error when appending
+        # with pytest.raises(ValueError, match="CRS of the target table"):
+        write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
+
+    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
     @pytest.mark.xfail(
         compat.PANDAS_GE_20 and not compat.PANDAS_GE_202,
         reason="Duplicate columns are dropped in read_sql with pandas 2.0.0 and 2.0.1",

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -775,6 +775,10 @@ class TestIO:
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
     def test_append_without_crs(self, engine_postgis, df_nybb):
+        # This test was included in #3328 when the default value for no
+        # CRS was changed from an SRID of -1 to 0. This resolves issues
+        # of appending dataframes to postgis that have no CRS as postgis
+        # no CRS value is 0.
         engine = engine_postgis
         df_nybb.crs = None
         table = "nybb"

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -782,13 +782,11 @@ class TestIO:
         engine = engine_postgis
         df_nybb.crs = None
         table = "nybb"
+
         write_postgis(df_nybb, con=engine, name=table, if_exists="replace")
+        # append another dataframe with no crs
 
-        # Reproject
         df_nybb2 = df_nybb
-
-        # # Should raise error when appending
-        # with pytest.raises(ValueError, match="CRS of the target table"):
         write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -780,7 +780,7 @@ class TestIO:
         # of appending dataframes to postgis that have no CRS as postgis
         # no CRS value is 0.
         engine = engine_postgis
-        df_nybb.crs = None
+        df_nybb = df_nybb.set_.crs(None, allow_override=True)
         table = "nybb"
 
         write_postgis(df_nybb, con=engine, name=table, if_exists="replace")


### PR DESCRIPTION
small one to close out #2158, #2763, and stale MR #2159

Changing the default no CRS value to 0 to be consistent with postgis. There are a few different proposed approaches to this floating about the above issues/PRs, but this one is based on the comments in #2159 . It is not clear to me why -1 was selected as the no CRS value in the first place, so I may be missing some important context.

**EDIT**

Looking at shapely.get_srid(), it returns a -1 if it is run on None, but 0 when on a geometry with no CRS. The docstring does only specify -1 for 'not-a-geometry value' but does not specify 0 is the no CRS value. Perhaps this misinterpretation was the origin of using -1 as the no CRS value here?