### PR TITLE
CI: Postgis CI ignores exit codes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -101,6 +101,7 @@ jobs:
         run: |
           conda install postgis -c conda-forge
           sh ci/scripts/setup_postgres.sh
+          set -o pipefail
           pytest -v -r fEs --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
       - name: Test docstrings

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -780,7 +780,7 @@ class TestIO:
         # of appending dataframes to postgis that have no CRS as postgis
         # no CRS value is 0.
         engine = engine_postgis
-        df_nybb = df_nybb.set_.crs(None, allow_override=True)
+        df_nybb = df_nybb.set_crs(None, allow_override=True)
         table = "nybb"
 
         write_postgis(df_nybb, con=engine, name=table, if_exists="replace")


### PR DESCRIPTION
I was looking into #3338 and noticed that https://github.com/geopandas/geopandas/actions/runs/9483017108/job/26129164190 is passing, even though the postgis tests are failing. There was a typo added in #3328 that needs fixing is all.
Aiming to make sure the tests fail before I get them passing.

Here's the now failing tests: https://github.com/geopandas/geopandas/actions/runs/9499054652/job/26179125647?pr=3339 - we were swallowing the exit code with some extra bash stuff to check if all the tests were skipped (I guess this is to prevent the tests silently passing if postgis isn't installed)