### PR TITLE
DOC: replace references to epsg.io with spatialreference.org

### DIFF
--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -252,7 +252,7 @@ One possible way to find out the EPSG code is using pyproj for this:
 value if the match is not perfect)
 
 Further, on websites such as `Spatial Reference <https://spatialreference.org/>`__
-and `epsg.io <https://epsg.io/>`__ the descriptions of many CRS can be found
+and `epsg.org <https://epsg.org/>`__ the descriptions of many CRS can be found
 including their EPSG codes and proj4 string definitions.
 
 **Other formats**
@@ -363,7 +363,7 @@ can be a reason that the CRS object is not equal to the expected EPSG code.
 
 Consider the following example of a Canadian projected CRS EPSG:2953. When
 constructing the CRS object from the WKT string as provided on
-`EPSG:2953 <https://epsg.io/2953>`__:
+`EPSG:2953 <https://spatialreference.org/ref/epsg/2953/>`__:
 
 .. code-block:: python
 

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -57,7 +57,7 @@
     "coordinate reference systems (CRS) of the tiles and the data match.\n",
     "Web map tiles are typically provided in\n",
     "[Web Mercator](https://en.wikipedia.org/wiki/Web_Mercator>)\n",
-    "([EPSG 3857](https://epsg.io/3857)), so let us first check what\n",
+    "([EPSG 3857](https://spatialreference.org/ref/epsg/3857/)), so let us first check what\n",
     "CRS our NYC boroughs are in:"
    ]
   },

--- a/doc/source/gallery/polygon_plotting_with_folium.ipynb
+++ b/doc/source/gallery/polygon_plotting_with_folium.ipynb
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [epsg:2263](https://epsg.io/2263) crs is a projected coordinate reference system with linear units (ft in this case).\n",
+    "The [EPSG:2263](https://spatialreference.org/ref/epsg/2263/) crs is a projected coordinate reference system with linear units (ft in this case).\n",
     "As folium (i.e. leaflet.js) by default accepts values of latitude and longitude (angular units) as input, we need to project the geometry to a geographic coordinate system first."
    ]
   },


### PR DESCRIPTION
https://github.com/OSGeo/PROJ/issues/4170 reminded me that we should stop using epsg.io as the best reference for EPSG codes.