### PR TITLE
DOC: remove datasets module from API reference

### DIFF
--- a/doc/source/docs/reference/tools.rst
+++ b/doc/source/docs/reference/tools.rst
@@ -14,5 +14,3 @@ Tools
    tools.reverse_geocode
    tools.collect
    points_from_xy
-   datasets.available
-   datasets.get_path


### PR DESCRIPTION
Given the whole module is now deprecated and there are not datasets, I suppose there's no point in keeping it in the API reference anymore.