### PR TITLE
DOC: Documentation tidy up

### DIFF
--- a/doc/source/docs/reference/geodataframe.rst
+++ b/doc/source/docs/reference/geodataframe.rst
@@ -3,8 +3,8 @@ GeoDataFrame
 ============
 .. currentmodule:: geopandas
 
-A ``GeoDataFrame`` is a tabular data structure that contains a column
-which contains a ``GeoSeries`` storing geometry.
+A ``GeoDataFrame`` is a tabular data structure that contains at least
+one ``GeoSeries`` column storing geometry.
 
 Constructor
 -----------

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -25,7 +25,8 @@ of only one shape (like a single polygon) or multiple shapes that are
 meant to be thought of as one observation (like the many polygons that
 make up the State of Hawaii or a country like Indonesia).
 
-GeoPandas has three basic classes of geometric objects (which are actually *shapely* objects):
+GeoPandas has three basic classes of geometric objects (which are actually
+`Shapely <https://shapely.readthedocs.io/en/stable/manual.html>`__ objects):
 
 * Points / Multi-Points
 * Lines / Multi-Lines
@@ -82,9 +83,14 @@ GeoDataFrame
 
 A :class:`GeoDataFrame` is a tabular data structure that contains a :class:`GeoSeries`.
 
-The most important property of a :class:`GeoDataFrame` is that it always has one :class:`GeoSeries` column that holds a special status. This :class:`GeoSeries` is referred to as the :class:`GeoDataFrame`'s "geometry". When a spatial method is applied to a :class:`GeoDataFrame` (or a spatial attribute like ``area`` is called), this commands will always act on the "geometry" column.
+The most important property of a :class:`GeoDataFrame` is that it always has one :class:`GeoSeries` column that
+holds a special status - the "active geometry column". When a spatial method is applied to a
+:class:`GeoDataFrame` (or a spatial attribute like ``area`` is called), these operations will always act on the
+active geometry column.
 
-The "geometry" column -- no matter its name -- can be accessed through the :attr:`~GeoDataFrame.geometry` attribute (``gdf.geometry``), and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name``.
+The active geometry column -- no matter the name of the corresponding :class:`GeoSeries` --
+can be accessed through the :attr:`~GeoDataFrame.geometry` attribute (``gdf.geometry``),
+and the name of the ``geometry`` column can be found by typing ``gdf.geometry.name`` or ``gdf.active_geometry_name``.
 
 A :class:`GeoDataFrame` may also contain other columns with geometrical (shapely) objects, but only one column can be the active geometry at a time. To change which column is the active geometry column, use the :meth:`GeoDataFrame.set_geometry` method.
 
@@ -136,9 +142,14 @@ Now, you create centroids and make it the geometry:
 Attributes and methods
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Any of the attributes calls or methods described for a :class:`GeoSeries` will work on a :class:`GeoDataFrame` -- effectively, they are just applied to the "geometry" :class:`GeoSeries`.
+Any of the attributes calls or methods described for a :class:`GeoSeries` will work on a :class:`GeoDataFrame` -- they are just applied to the active geometry column :class:`GeoSeries`.
 
-However, :class:`GeoDataFrames <GeoDataFrame>` also have a few extra methods for input and output which are described on the :doc:`Reading and writing files <io>` page and for geocoding with are described in :doc:`Geocoding <geocoding>`.
+However, :class:`GeoDataFrames <GeoDataFrame>` also have a number few extra methods for:
+* file input and output, describe on the :doc:`Reading and writing files <io>` page
+* :doc:`spatial joins <mergingdata.spatial-joins>`
+* :doc:`spatial aggregations <user_guide/aggregation_with_dissolve>`
+* :doc:`geocoding <geocoding>`
+
 
 
 .. ipython:: python

--- a/doc/source/docs/user_guide/data_structures.rst
+++ b/doc/source/docs/user_guide/data_structures.rst
@@ -145,10 +145,11 @@ Attributes and methods
 Any of the attributes calls or methods described for a :class:`GeoSeries` will work on a :class:`GeoDataFrame` -- they are just applied to the active geometry column :class:`GeoSeries`.
 
 However, :class:`GeoDataFrames <GeoDataFrame>` also have a number few extra methods for:
-* file input and output, describe on the :doc:`Reading and writing files <io>` page
-* :doc:`spatial joins <mergingdata.spatial-joins>`
-* :doc:`spatial aggregations <user_guide/aggregation_with_dissolve>`
-* :doc:`geocoding <geocoding>`
+
+* :doc:`Reading and writing files <io>`
+* :ref:`Spatial joins <mergingdata.spatial-joins>`
+* :doc:`Spatial aggregations <aggregation_with_dissolve>`
+* :doc:`Geocoding <geocoding>`
 
 
 
@@ -161,8 +162,7 @@ However, :class:`GeoDataFrames <GeoDataFrame>` also have a number few extra meth
 Display options
 ---------------
 
-GeoPandas has an ``options`` attribute with currently a single configuration
-option to control:
+GeoPandas has an ``options`` attribute with global configuration attributes:
 
 .. ipython:: python
 

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -106,7 +106,7 @@ Affine transformations
 
 
 Examples of geometric manipulations
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. sourcecode:: python
 

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -73,7 +73,7 @@ supported by that project::
 You can also read path objects::
 
     import pathlib
-    path_object = pathlib.path(filename)
+    path_object = pathlib.Path(filename)
     df = geopandas.read_file(path_object)
 
 Reading subsets of the data
@@ -173,21 +173,23 @@ Load in a subset of data with a `SQL WHERE clause <https://gdal.org/user/ogr_sql
         where="subborough='Coney Island'",
     )
 
-Supported drivers
-~~~~~~~~~~~~~~~~~
+Supported drivers / file formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using pyogrio, all drivers supported by the GDAL installation are enabled,
 and you can check those with::
 
     import pyogrio; pyogrio.list_drivers()
 
-Fiona only exposes the default drivers. To display those, type::
+where the values indicate whether reading, writing or both are supported for
+a given driver.
+Fiona only exposes a default subset of drivers. To display those, type::
 
     import fiona; fiona.supported_drivers
 
 There is a `list of available drivers <https://github.com/Toblerity/Fiona/blob/master/fiona/drvsupport.py>`_
-which are unexposed but supported (depending on the GDAL-build). You can activate
-these on runtime by updating the `supported_drivers` dictionary like::
+which are unexposed by default but may be supported (depending on the GDAL-build). You can activate
+these at runtime by updating the `supported_drivers` dictionary like::
 
     fiona.supported_drivers["NAS"] = "raw"
 
@@ -271,10 +273,10 @@ the spatial information.
 
 .. note::
 
-    This is tracking version 1.0.0 of the GeoParquet specification at:
+    The GeoParquet specification is developed at:
     https://github.com/opengeospatial/geoparquet.
 
-    Previous versions are still supported as well. By default, the latest
-    version is used when writing files (older versions can be specified using
-    the ``schema_version`` keyword), and GeoPandas supports reading files
-    of any version.
+    By default, the latest
+    version is used when writing files, but older versions can be specified using
+    the ``schema_version`` keyword. GeoPandas supports reading files
+    encoded using any GeoParquet version.

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -77,7 +77,7 @@ that initially has only area ID for each geometry by merging it with a :class:`~
    chicago_shapes = chicago_shapes.merge(chicago_names, on='NID')
    chicago_shapes.head()
 
-
+.. _mergingdata.spatial-joins:
 Spatial joins
 ----------------
 

--- a/doc/source/docs/user_guide/mergingdata.rst
+++ b/doc/source/docs/user_guide/mergingdata.rst
@@ -78,6 +78,7 @@ that initially has only area ID for each geometry by merging it with a :class:`~
    chicago_shapes.head()
 
 .. _mergingdata.spatial-joins:
+
 Spatial joins
 ----------------
 

--- a/doc/source/getting_started.md
+++ b/doc/source/getting_started.md
@@ -29,7 +29,7 @@ conda install -c conda-forge geopandas
 
 ### Detailed instructions
 
-Do you prefer ``pip install`` or installation from source? Or specific version? See
+Do you prefer ``pip install`` or installation from source? Or want to install a specific version? See
 {doc}`detailed instructions <getting_started/install>`.
 
 ### What now?
@@ -37,7 +37,7 @@ Do you prefer ``pip install`` or installation from source? Or specific version? 
 - If you don't have GeoPandas yet, check {doc}`Installation <getting_started/install>`.
 - If you have never used GeoPandas and want to get familiar with it and its core
   functionality quickly, see {doc}`Getting Started Tutorial <getting_started/introduction>`.
-- Detailed illustration how to work with different parts of GeoPandas, how to make maps,
+- Detailed illustration of how to work with different parts of GeoPandas, make maps,
   manage projections, spatially merge data or geocode are part of our
   {doc}`User Guide <docs/user_guide>`.
 - And if you are interested in the complete

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -16,7 +16,7 @@ To install GeoPandas and all its dependencies, we recommend to use the `conda`_
 package manager. This can be obtained by installing the
 `Anaconda Distribution`_ (a free Python distribution for data science), or
 through `miniconda`_ (minimal distribution only containing Python and the
-`conda`_ package manager). See also the `installation docs
+`conda`_ package manager). See also the `Conda installation docs
 <https://conda.io/docs/user-guide/install/download.html>`__ for more information
 on how to install Anaconda or miniconda locally.
 
@@ -38,7 +38,8 @@ which packages can be installed, in addition to the "*defaults*" channel
 provided by Anaconda.
 Depending on what other packages you are working with, the *defaults* channel
 or *conda-forge* channel may be better for your needs (e.g. some packages are
-available on *conda-forge* and not on *defaults*).
+available on *conda-forge* and not on *defaults*). Generally, *conda-forge* is
+more up to date with the latest versions of geospatial python packages.
 
 GeoPandas and all its dependencies are available on the *conda-forge*
 channel, and can be installed as::
@@ -163,6 +164,7 @@ For plotting, these additional packages may be used:
 
 - `matplotlib`_ (>= 3.5.0)
 - `mapclassify`_ (>= 2.4.0)
+- `folium`_ (for interactive plotting)
 
 
 .. _PyPI: https://pypi.python.org/pypi/geopandas
@@ -210,3 +212,5 @@ For plotting, these additional packages may be used:
 .. _packaging: https://packaging.pypa.io/en/latest/
 
 .. _pointpats: https://pysal.org/pointpats/
+
+.. _folium: https://python-visualization.github.io/folium/stable/

--- a/doc/source/getting_started/introduction.ipynb
+++ b/doc/source/getting_started/introduction.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "GeoPandas, as the name suggests, extends the popular data science library [pandas](https://pandas.pydata.org) by adding support for geospatial data. If you are not familiar with `pandas`, we recommend taking a quick look at its [Getting started documentation](https://pandas.pydata.org/docs/getting_started/index.html#getting-started) before proceeding.\n",
     "\n",
-    "The core data structure in GeoPandas is the `geopandas.GeoDataFrame`, a subclass of `pandas.DataFrame`, that can store geometry columns and perform spatial operations. The `geopandas.GeoSeries`, a subclass of `pandas.Series`, handles the geometries. Therefore, your `GeoDataFrame` is a combination of `pandas.Series`, with traditional data (numerical, boolean, text etc.), and `geopandas.GeoSeries`, with geometries (points, polygons etc.). You can have as many columns with geometries as you wish; there's no limit unlike some typical desktop GIS software.\n",
+    "The core data structure in GeoPandas is the `geopandas.GeoDataFrame`, a subclass of `pandas.DataFrame`, that can store geometry columns and perform spatial operations. The `geopandas.GeoSeries`, a subclass of `pandas.Series`, handles the geometries. Therefore, your `GeoDataFrame` is a combination of `pandas.Series`, with traditional data (numerical, boolean, text etc.), and `geopandas.GeoSeries`, with geometries (points, polygons etc.). You can have as many columns with geometries as you wish; unlike in some typical desktop GIS software.\n",
     "\n",
     "![geodataframe schema](../_static/dataframe.svg)\n",
     "\n",

--- a/doc/source/getting_started/introduction.ipynb
+++ b/doc/source/getting_started/introduction.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "Each `GeoSeries` can contain any geometry type (you can even mix them within a single array) and has a `GeoSeries.crs` attribute, which stores information about the projection (CRS stands for Coordinate Reference System). Therefore, each `GeoSeries` in a `GeoDataFrame` can be in a different projection, allowing you to have, for example, multiple versions (different projections) of the same geometry.\n",
     "\n",
-    "Only one `GeoSeries` in a `GeoDataFrame` is considered the _active_ geometry, which means that all geometric operations applied to a `GeoDataFrame` operate on this _active_ column.\n",
+    "Only one `GeoSeries` in a `GeoDataFrame` is considered the _active geometry column_, which means that all geometric operations applied to a `GeoDataFrame` operate on this column.\n",
     "The active geometry column is accessed via the `GeoDataFrame.geometry` attribute.\n",
     "\n",
     "\n",
@@ -66,7 +66,7 @@
    "source": [
     "### Writing files\n",
     "\n",
-    "To write a `GeoDataFrame` back to file use `GeoDataFrame.to_file()`. By default, the file format is inferred by the file extension (.shp for Shapefile, .geojson for GeoJSON), but you can specify this explicitly with the `driver` keyword."
+    "To write a `GeoDataFrame` back to file use `GeoDataFrame.to_file()`. By default, the file format is inferred by the file extension (e.g. `.shp` for Shapefile, `.geojson` for GeoJSON), but you can specify this explicitly with the `driver` keyword."
    ]
   },
   {

--- a/doc/source/getting_started/introduction.ipynb
+++ b/doc/source/getting_started/introduction.ipynb
@@ -15,13 +15,14 @@
     "\n",
     "GeoPandas, as the name suggests, extends the popular data science library [pandas](https://pandas.pydata.org) by adding support for geospatial data. If you are not familiar with `pandas`, we recommend taking a quick look at its [Getting started documentation](https://pandas.pydata.org/docs/getting_started/index.html#getting-started) before proceeding.\n",
     "\n",
-    "The core data structure in GeoPandas is the `geopandas.GeoDataFrame`, a subclass of `pandas.DataFrame`, that can store geometry columns and perform spatial operations. The `geopandas.GeoSeries`, a subclass of `pandas.Series`, handles the geometries. Therefore, your `GeoDataFrame` is a combination of `pandas.Series`, with traditional data (numerical, boolean, text etc.), and `geopandas.GeoSeries`, with geometries (points, polygons etc.). You can have as many columns with geometries as you wish; there's no limit typical for desktop GIS software.\n",
+    "The core data structure in GeoPandas is the `geopandas.GeoDataFrame`, a subclass of `pandas.DataFrame`, that can store geometry columns and perform spatial operations. The `geopandas.GeoSeries`, a subclass of `pandas.Series`, handles the geometries. Therefore, your `GeoDataFrame` is a combination of `pandas.Series`, with traditional data (numerical, boolean, text etc.), and `geopandas.GeoSeries`, with geometries (points, polygons etc.). You can have as many columns with geometries as you wish; there's no limit unlike some typical desktop GIS software.\n",
     "\n",
     "![geodataframe schema](../_static/dataframe.svg)\n",
     "\n",
     "Each `GeoSeries` can contain any geometry type (you can even mix them within a single array) and has a `GeoSeries.crs` attribute, which stores information about the projection (CRS stands for Coordinate Reference System). Therefore, each `GeoSeries` in a `GeoDataFrame` can be in a different projection, allowing you to have, for example, multiple versions (different projections) of the same geometry.\n",
     "\n",
     "Only one `GeoSeries` in a `GeoDataFrame` is considered the _active_ geometry, which means that all geometric operations applied to a `GeoDataFrame` operate on this _active_ column.\n",
+    "The active geometry column is accessed via the `GeoDataFrame.geometry` attribute.\n",
     "\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
@@ -65,7 +66,7 @@
    "source": [
     "### Writing files\n",
     "\n",
-    "To write a `GeoDataFrame` back to file use `GeoDataFrame.to_file()`. The default file format is Shapefile, but you can specify your own with the `driver` keyword."
+    "To write a `GeoDataFrame` back to file use `GeoDataFrame.to_file()`. By default, the file format is inferred by the file extension (.shp for Shapefile, .geojson for GeoJSON), but you can specify this explicitly with the `driver` keyword."
    ]
   },
   {

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -77,8 +77,8 @@ crs_mismatch_error = (
 
 class GeoDataFrame(GeoPandasBase, DataFrame):
     """
-    A GeoDataFrame object is a pandas.DataFrame that has a column
-    with geometry. In addition to the standard DataFrame constructor arguments,
+    A GeoDataFrame object is a pandas.DataFrame that has one or more columns
+    containing geometry. In addition to the standard DataFrame constructor arguments,
     GeoDataFrame also accepts the following keyword arguments:
 
     Parameters

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -88,9 +88,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
         such as an authority string (eg "EPSG:4326") or a WKT string.
     geometry : str or array-like (optional)
-        If str, column to use as active geometry column. If array-like, it will be
-        added as new column named 'geometry' column on GeoDataFrame and set as the
-        active geometry column. Note that if ``geometry`` is a (Geo)Series with a
+        Value to use as the active geometry column.
+        If str, treated as column name to use. If array-like, it will be
+        added as new column named 'geometry' on the GeoDataFrame and set as the
+        active geometry column.
+
+        Note that if ``geometry`` is a (Geo)Series with a
         name, the name will not be used, a column named "geometry" will still be
         added. To preserve the name, you can use :meth:`~GeoDataFrame.rename_geometry`
         to update the geometry column name.


### PR DESCRIPTION
I was really meaning to do this a few months ago and just ran out of time. Hoping this is non controvertial changes. Not particularly attached to any so happy to revert segments if there isn't consensus. The main things I've changed are:
* Tightening up the dicussion of active geometry columns vs "geometry" columns. I think now that we've discussed this a bit more and have `active_geometry_name` as a property we've got a proper way to refer to this, while the user guide still refers to a "geometry" column (which I think perhaps should have been `geometry` column in the old language anyway)
* IO introduction for to_file now says you don't need to specify a driver if you give a file extension
* Trying to avoid language which gets out of date where possible (referring to geoparquet 1.0.0, saying that geopandas.options only has a single option)
* Updating some text to reflect that a GeoDataFrame supports more than one geometry column