### PR TITLE
DOC: Fix small typos in `io.file`

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -739,7 +739,7 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, metadata, **kwargs
         kwargs["append"] = True
 
     if crs is not None:
-        raise ValueError("Passing 'crs' it not supported with the 'pyogrio' engine.")
+        raise ValueError("Passing 'crs' is not supported with the 'pyogrio' engine.")
 
     # for the fiona engine, this check is done in gdf.iterfeatures()
     if not df.columns.is_unique:

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -462,7 +462,7 @@ def test_to_file_crs(tmpdir, engine, nybb_filename):
     assert result.crs == df.crs
 
     if engine == "pyogrio":
-        with pytest.raises(ValueError, match="Passing 'crs' it not supported"):
+        with pytest.raises(ValueError, match="Passing 'crs' is not supported"):
             df.to_file(tempfilename, crs=3857, engine=engine)
         return
 


### PR DESCRIPTION
Tiny typo fix. 

I saw this as an error message and spotted the typo. 

I didn't update the changelog as I assume this is too small to track. 