### PR TITLE
BUG: support datetime in named index in explore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.0.1
+
+Bug fixes:
+
+- Support a named datetime index in `explore()` (#3360).
+
 ## Version 1.0.0 (June 24, 2024)
 
 Notes on dependencies:
@@ -63,7 +69,7 @@ New features and improvements:
   other non JSON serializable objects (#3261).
 - The `GeoSeries.fillna` method now supports the `limit` keyword (#3290).
 - Added ``on_attribute`` option argument to the ``sjoin()``
-  method, allowing to restrict joins to the observations with 
+  method, allowing to restrict joins to the observations with
   matching attributes. (#3231)
 - Added support for `bbox` covering encoding in geoparquet. Can filter reading of parquet
 files based on a bounding box, and write out a bounding box column to parquet files (#3282).
@@ -74,7 +80,7 @@ files based on a bounding box, and write out a bounding box column to parquet fi
 - Added ``autolim`` keyword argument to ``GeoSeries.plot()`` and ``GeoDataFrame.plot()`` (#2817).
 - Added `metadata` parameter to `GeoDataFrame.to_file` (#2850)
 - Updated documentation to clarify that passing a named (Geo)Series as the `geometry`
-  argument to the GeoDataFrame constructor will not use the name but will always  
+  argument to the GeoDataFrame constructor will not use the name but will always
   produce a GeoDataFrame with an active geometry column named "geometry" (#3337).
 - `read_postgis` will query the spatial_ref_sys table to determine the CRS authority
   instead of its current behaviour of assuming EPSG. In the event the spiatal_ref_sys
@@ -95,7 +101,7 @@ Backwards incompatible API changes:
   the previous active geometry column name. This means that if the new and old names are
   different, then both columns will be preserved in the GeoDataFrame. To replicate the previous
   behaviour, you can instead call `gdf.set_geometry(ser.rename(gdf.active_geometry_name))` (#3237).
-  Note that this behaviour change does not affect the `GeoDataframe` constructor, passing a named 
+  Note that this behaviour change does not affect the `GeoDataframe` constructor, passing a named
   GeoSeries `ser` to `GeoDataFrame(df, geometry=ser)` will always produce a GeoDataFrame with a
   geometry column named "geometry" to preserve backwards compatibility. If you would like to
   instead propagate the name of `ser` when constructing a GeoDataFrame, you can instead call

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -337,6 +337,9 @@ def _explore(
     if len(json_not_supported_cols) > 0:
         gdf = gdf.astype({c: "string" for c in json_not_supported_cols})
 
+    if is_datetime64_any_dtype(gdf.index):
+        gdf.index = gdf.index.astype("str")
+
     # create folium.Map object
     if m is None:
         # Get bounds to specify location and map extent

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -312,6 +312,12 @@ class TestExplore:
         assert '"__folium_color":"#9edae5","datetime":"2025-01-0101:22:00"' in out1_str
         assert '"__folium_color":"#1f77b4","datetime":"2022-01-0101:22:00"' in out1_str
 
+        df2 = df.set_index("datetime")
+        m2 = df2.explore()
+        out2_str = self._fetch_map_string(m2)
+        assert '"datetime":"2025-01-0101:22:00"' in out2_str
+        assert '"datetime":"2022-01-0101:22:00"' in out2_str
+
     def test_non_json_serialisable(self):
         df = self.nybb.copy().head(2)
         uuid1 = uuid.UUID("12345678123456781234567812345678")


### PR DESCRIPTION
As per @anitagraser's report in #2378, this snippet caused JSON serialisation error even though we say we support datetime.

```py
import pandas as pd
import shapely
import geopandas as gpd

df = gpd.GeoDataFrame(
    index=[pd.Timestamp("2018-01-01 12:02:00"), pd.Timestamp("2018-01-02 12:02:00")],
    geometry=[shapely.Point(0, 0), shapely.Point(2, 0)],
)
df.index.name = "t"
df.explore()
```

Interestingly enough, non-named datetime index was fine. Only named caused issues.

Fixed by explicitly checking for index dtype and converting as we do with columns.