### PR TITLE
BUG: Explore json non serialisable index fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bug fixes:
 
-- Support a named datetime index in `explore()` (#3360).
+- Support a named datetime or object dtype index in `explore()` (#3360).
 
 ## Version 1.0.0 (June 24, 2024)
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -335,10 +335,12 @@ def _explore(
     ].union(gdf.columns[gdf.dtypes == "object"])
 
     if len(json_not_supported_cols) > 0:
-        gdf = gdf.astype({c: "str" for c in json_not_supported_cols})
+        gdf = gdf.astype({c: "string" for c in json_not_supported_cols})
 
-    if is_datetime64_any_dtype(gdf.index) or (gdf.index.dtype == "object"):
-        gdf.index = gdf.index.astype("str")
+    if not isinstance(gdf.index, pd.MultiIndex) and (
+        is_datetime64_any_dtype(gdf.index) or (gdf.index.dtype == "object")
+    ):
+        gdf.index = gdf.index.astype("string")
 
     # create folium.Map object
     if m is None:

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -335,9 +335,9 @@ def _explore(
     ].union(gdf.columns[gdf.dtypes == "object"])
 
     if len(json_not_supported_cols) > 0:
-        gdf = gdf.astype({c: "string" for c in json_not_supported_cols})
+        gdf = gdf.astype({c: "str" for c in json_not_supported_cols})
 
-    if is_datetime64_any_dtype(gdf.index):
+    if is_datetime64_any_dtype(gdf.index) or (gdf.index.dtype == "object"):
         gdf.index = gdf.index.astype("str")
 
     # create folium.Map object

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -320,20 +320,22 @@ class TestExplore:
 
     def test_non_json_serialisable(self):
         df = self.nybb.copy().head(2)
-        uuid1 = uuid.UUID("12345678123456781234567812345678")
-        uuid2 = uuid.UUID("12345678123456781234567812345679")
+
+        u1 = "12345678-1234-5678-1234-567812345678"
+        uuid1 = uuid.UUID(u1)
+        u2 = "12345678-1234-5678-1234-567812345679"
+        uuid2 = uuid.UUID(u2)
         df["object"] = [uuid1, uuid2]
         m1 = df.explore("object")
 
         out1_str = self._fetch_map_string(m1)
-        assert (
-            '"__folium_color":"#9edae5","object":"12345678-1234-5678-1234-567812345679"}'
-            in out1_str
-        )
-        assert (
-            '"__folium_color":"#1f77b4","object":"12345678-1234-5678-1234-567812345678"'
-            in out1_str
-        )
+        assert f'"__folium_color":"#9edae5","object":"{u2}"' in out1_str
+        assert f'"__folium_color":"#1f77b4","object":"{u1}"' in out1_str
+        df2 = df.set_index("object")
+        m2 = df2.explore()
+        out2_str = self._fetch_map_string(m2)
+        assert f'"object":"{u2}"' in out2_str
+        assert f'"object":"{u1}"' in out2_str
 
     def test_string(self):
         df = self.nybb.copy()


### PR DESCRIPTION
small follow up to #3360.

I also swapped the astype call for the index from str to string for consistency with the columns - this will mean that NA values are preserved in the JSON (I also looked at going from string to str to keep nan /None / pd.NA but we already explicitly test NA behaviour and this would break that)