### PR TITLE
TST: Use explicit copy to eliminate the warning.

### DIFF
--- a/geopandas/tests/test_merge.py
+++ b/geopandas/tests/test_merge.py
@@ -133,7 +133,7 @@ class TestMerging:
         with pytest.warns(
             UserWarning, match=r"CRS not set for some of the concatenation inputs.*"
         ):
-            partial_none_case = self.gdf[["geometry"]]
+            partial_none_case = self.gdf[["geometry"]].copy()
             partial_none_case.iloc[0] = None
             pd.concat([single_geom_col, partial_none_case])
 


### PR DESCRIPTION
Removes the warning:
```
/home/runner/work/geopandas/geopandas/geopandas/tests/test_merge.py:137: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
    partial_none_case.iloc[0] = None
```