### PR TITLE
BUG:  incorrect warning in read_file for pyogrio when layer keyword is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 1.0.2 (???)
+
+Bug fixes:
+
+- Fix unspecified layer warning being emitted reading multilayer datasets, even
+  when layer is specified (#3378).
+
+
 ## Version 1.0.1 (July 2, 2024)
 
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bug fixes:
 
-- Fix unspecified layer warning being emitted reading multilayer datasets, even
+- Fix unspecified layer warning being emitted while reading multilayer datasets, even
   when layer is specified when using the mask or bbox keywords (#3378).
 - Properly support named aggregations over a geometry column in `GroupBy.agg` (#3368).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Bug fixes:
 
 - Fix unspecified layer warning being emitted reading multilayer datasets, even
-  when layer is specified (#3378).
+  when layer is specified when using the mask or bbox keywords (#3378).
 
 
 ## Version 1.0.1 (July 2, 2024)

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -481,7 +481,7 @@ def _read_file_pyogrio(path_or_bytes, bbox=None, mask=None, rows=None, **kwargs)
 
     if bbox is not None:
         if isinstance(bbox, (GeoDataFrame, GeoSeries)):
-            crs = pyogrio.read_info(path_or_bytes).get("crs")
+            crs = pyogrio.read_info(path_or_bytes, layer=kwargs.get("layer")).get("crs")
             if isinstance(path_or_bytes, IOBase):
                 path_or_bytes.seek(0)
 
@@ -494,7 +494,7 @@ def _read_file_pyogrio(path_or_bytes, bbox=None, mask=None, rows=None, **kwargs)
     if mask is not None:
         # NOTE: mask cannot be used at same time as bbox keyword
         if isinstance(mask, (GeoDataFrame, GeoSeries)):
-            crs = pyogrio.read_info(path_or_bytes).get("crs")
+            crs = pyogrio.read_info(path_or_bytes, layer=kwargs.get("layer")).get("crs")
             if isinstance(path_or_bytes, IOBase):
                 path_or_bytes.seek(0)
 
@@ -526,7 +526,7 @@ def _read_file_pyogrio(path_or_bytes, bbox=None, mask=None, rows=None, **kwargs)
             stacklevel=3,
         )
         ignore_fields = kwargs.pop("ignore_fields")
-        fields = pyogrio.read_info(path_or_bytes)["fields"]
+        fields = pyogrio.read_info(path_or_bytes, layer=kwargs.get("layer"))["fields"]
         include_fields = [col for col in fields if col not in ignore_fields]
         kwargs["columns"] = include_fields
     elif "include_fields" in kwargs:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -228,9 +228,9 @@ def _read_file(
         Keyword args to be passed to the engine, and can be used to write
         to multi-layer data, store data within archives (zip files), etc.
         In case of the "pyogrio" engine, the keyword arguments are passed to
-        `pyogrio.write_dataframe`. In case of the "fiona" engine, the keyword
+        `pyogrio.read_dataframe`. In case of the "fiona" engine, the keyword
         arguments are passed to fiona.open`. For more information on possible
-        keywords, type: ``import pyogrio; help(pyogrio.write_dataframe)``.
+        keywords, type: ``import pyogrio; help(pyogrio.read_dataframe)``.
 
 
     Examples

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1076,6 +1076,7 @@ def test_read_file_mask_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
     assert filtered_df_shape == (2, 5)
 
 
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
 def test_read_file_multi_layer_with_layer_arg_no_warning():
     # While reading a file with multiple layers, if the layer is properly
     # specified, a "Specify layer" warning should not be emitted

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1077,19 +1077,19 @@ def test_read_file_mask_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
 
 
 @pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj not installed")
-def test_read_file_multi_layer_with_layer_arg_no_warning():
+def test_read_file_multi_layer_with_layer_arg_no_warning(tmp_path, engine):
     # While reading a file with multiple layers, if the layer is properly
     # specified, a "Specify layer" warning should not be emitted
     data1 = {"geometry": [Point(1, 2), Point(2, 1)]}
     gdf = geopandas.GeoDataFrame(data1, crs="EPSG:4326")
-    tmpfile_path = tempfile.mktemp(suffix=".gpkg")
-    gdf.to_file(tmpfile_path, layer="layer1", driver="GPKG")
-    gdf.to_file(tmpfile_path, layer="layer2", driver="GPKG")
+    file_path = tmp_path / "out.gpkg"
+    gdf.to_file(file_path, layer="layer1", engine=engine)
+    gdf.to_file(file_path, layer="layer2", engine=engine)
 
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")
-        read_file(tmpfile_path, bbox=gdf, layer="layer1")
-        read_file(tmpfile_path, mask=gdf, layer="layer1")
+        read_file(file_path, bbox=gdf, layer="layer1", engine=engine)
+        read_file(file_path, mask=gdf, layer="layer1", engine=engine)
         specify_layer_warnings = [
             warning
             for warning in captured
@@ -1099,9 +1099,6 @@ def test_read_file_multi_layer_with_layer_arg_no_warning():
         assert (
             len(specify_layer_warnings) == 0
         ), "'Specify layer parameter' warning was raised, but the layer was specified."
-
-    if os.path.exists(tmpfile_path):
-        os.remove(tmpfile_path)
 
 
 def test_read_file_bbox_mask_not_allowed(engine, nybb_filename):

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -5,9 +5,9 @@ import os
 import pathlib
 import shutil
 import tempfile
+import warnings
 from collections import OrderedDict
 from packaging.version import Version
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 from collections import OrderedDict
 from packaging.version import Version
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -1073,6 +1074,33 @@ def test_read_file_mask_gdf_mismatched_crs(df_nybb, engine, nybb_filename):
     filtered_df_shape = filtered_df.shape
     assert full_df_shape != filtered_df_shape
     assert filtered_df_shape == (2, 5)
+
+
+def test_read_file_multi_layer_with_layer_arg_no_warning():
+    # While reading a file with multiple layers, if the layer is properly
+    # specified, a "Specify layer" warning should not be emitted
+    data1 = {"geometry": [Point(1, 2), Point(2, 1)]}
+    gdf = geopandas.GeoDataFrame(data1, crs="EPSG:4326")
+    tmpfile_path = tempfile.mktemp(suffix=".gpkg")
+    gdf.to_file(tmpfile_path, layer="layer1", driver="GPKG")
+    gdf.to_file(tmpfile_path, layer="layer2", driver="GPKG")
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        read_file(tmpfile_path, bbox=gdf, layer="layer1")
+        read_file(tmpfile_path, mask=gdf, layer="layer1")
+        specify_layer_warnings = [
+            warning
+            for warning in captured
+            if warning.category == UserWarning
+            and "specify layer parameter" in str(warning.message).lower()
+        ]
+        assert (
+            len(specify_layer_warnings) == 0
+        ), "'Specify layer parameter' warning was raised, but the layer was specified."
+
+    if os.path.exists(tmpfile_path):
+        os.remove(tmpfile_path)
 
 
 def test_read_file_bbox_mask_not_allowed(engine, nybb_filename):


### PR DESCRIPTION
Bug is described in issue #3377

Solution is to pass down the layer argument from gpd.read_file to pyogrio.read_info to prevent the unwaranted warning.

