### PR TITLE
Resolve geodataframe.py geometry name StrEnum incompatibility

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -204,7 +204,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             if hasattr(geometry, "name") and geometry.name not in ("geometry", None):
                 # __init__ always creates geometry col named "geometry"
                 # rename as `set_geometry` respects the given series name
-                geometry = geometry.rename("geometry")
+                try:
+                    geometry = geometry.rename("geometry")
+                except AttributeError:
+                    # May be StrEnum object, which has name() but not rename()
+                    pass
 
             self.set_geometry(geometry, inplace=True, crs=crs)
 


### PR DESCRIPTION
Eliminates AttributeError when a StrEnum instance is passed as the geometry column name to `GeoDataFrame.__init__` (instead of a more ordinary string instance).

"StrEnum is the same as Enum, but its members are also strings and can be used in most of the same places that a string can be used." [https://docs.python.org/3/library/enum.html#enum.StrEnum](https://docs.python.org/3/library/enum.html#enum.StrEnum)

In the current code, passing a StrEnum instance as the 'geometry' argument to `GeoDataFrame.__init__` causes an AttributeError, because the code finds a `geometry.name` attribute and then incorrectly assumes there will also be a `geometry.rename` method.

A `hasattr(geometry, "rename")' check could be used instead of try/except, if preferred. Thanks!