### PR TITLE
BUG: Fix geodataframe constructor not supporting classes with name attributes besides (Geo)Series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.0.2 (???)
+
+Bug fixes:
+
+- Support GeoDataFrame constructor receiving arguments to `geometry` which are not
+  (Geo)Series, but instead should be interpreted as column names (#3384).
+
 ## Version 1.0.0-rc1 (June 17, 2024)
 
 Notes on dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Deprecations and compatibility notes:
 
 - The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
   The upstream method no longer exists in all supported version of pandas (#3394).
->>>>>>> upstream/main
 
 ## Version 1.0.1 (July 2, 2024)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -198,7 +198,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
             ):
                 raise ValueError(crs_mismatch_error)
 
-            if hasattr(geometry, "name") and geometry.name not in ("geometry", None):
+            if isinstance(geometry, pd.Series) and geometry.name not in (
+                "geometry",
+                None,
+            ):
                 # __init__ always creates geometry col named "geometry"
                 # rename as `set_geometry` respects the given series name
                 geometry = geometry.rename("geometry")

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import tempfile
+from enum import Enum
 
 import numpy as np
 import pandas as pd
@@ -1488,6 +1489,19 @@ class TestConstructor:
         expected = pd.concat([df, other_df], axis=1)
         df[other_df.columns] = other_df
         assert_geodataframe_equal(df, expected)
+
+    def test_geometry_colname_enum(self):
+        # ensure that other classes to geometry arg in GeoDataFrame
+        # with `name` attribute are not assumed to be (Geo)Series
+        class Fruit(Enum):
+            apple = 1
+            pear = 2
+
+        df = pd.DataFrame(
+            {Fruit.apple: [1, 2], Fruit.pear: GeoSeries.from_xy([1, 2], [3, 4])}
+        )
+        res = GeoDataFrame(df, geometry=Fruit.pear)
+        assert res.active_geometry_name == Fruit.pear
 
 
 @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="pyproj not available")


### PR DESCRIPTION
Alternate to #3380, have opted for a test using regular enums and not str enums as they're only in the standard library from 3.11 onwards.
