### PR TITLE
COMPAT: Delete the `GeoSeries.select` method (removed in pandas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Bug fixes:
 
 - Properly support named aggregations over a geometry column in `GroupBy.agg` (#3368).
 
+Deprecations and compatibility notes:
+
+- The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
+  The upstream method no longer exists in all supported version of pandas (#3394).
+
 ## Version 1.0.1 (July 2, 2024)
 
 Bug fixes:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -735,10 +735,6 @@ class GeoSeries(GeoPandasBase, Series):
         return self._wrapped_pandas_method("take", *args, **kwargs)
 
     @doc(pd.Series)
-    def select(self, *args, **kwargs):
-        return self._wrapped_pandas_method("select", *args, **kwargs)
-
-    @doc(pd.Series)
     def apply(self, func, convert_dtype: Optional[bool] = None, args=(), **kwargs):
         if convert_dtype is not None:
             kwargs["convert_dtype"] = convert_dtype


### PR DESCRIPTION
Closes #3393 