### PR TITLE
ENH: Use ruff for formatting instead of black + update to 0.5.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,10 @@ ci:
 
 files: 'geopandas\/'
 repos:
-    - repo: https://github.com/psf/black
-      rev: 24.2.0
-      hooks:
-          - id: black
-            language_version: python3
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: "v0.4.4"
+      rev: "v0.5.5"
       hooks:
+        - id: ruff-format
         - id: ruff
           name: sort imports with ruff
           args: [--select, I, --fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Style
 
 - GeoPandas follows [the PEP 8
   standard](http://www.python.org/dev/peps/pep-0008/) and uses
-  [ruff](https://beta.ruff.rs/docs/) to ensure a consistent
+  [ruff](https://docs.astral.sh/ruff/) to ensure a consistent
   code format throughout the project.
 
 - Imports should be grouped with standard library imports first,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@ Style
 
 - GeoPandas follows [the PEP 8
   standard](http://www.python.org/dev/peps/pep-0008/) and uses
-  [Black](https://black.readthedocs.io/en/stable/) and
   [ruff](https://beta.ruff.rs/docs/) to ensure a consistent
   code format throughout the project.
 
@@ -57,7 +56,7 @@ Style
   imports when necessary in tests.
 
 - You can set up [pre-commit hooks](https://pre-commit.com/) to
-  automatically run `black` and `ruff` when you make a git
+  automatically run `ruff` when you make a git
   commit. This can be done by installing `pre-commit`:
 
     $ python -m pip install pre-commit
@@ -67,7 +66,7 @@ Style
 
     $ pre-commit install
 
-  Then `black` and `ruff` will be run automatically each time you
+  Then `ruff` will be run automatically each time you
   commit changes. You can skip these checks with `git commit
   --no-verify`. You can also configure your local git clone to have
   `git blame` ignore the commits that introduced large formatting-only

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -32,7 +32,7 @@ In particular, when submitting a pull request:
   line of a docstring should be a standalone summary.  Parameters and
   return values should be documented explicitly.
 
-- Follow PEP 8 when possible. We use `ruff <https://beta.ruff.rs/docs/>`_
+- Follow PEP 8 when possible. We use `ruff <https://docs.astral.sh/ruff/>`_
   to ensure a consistent code format throughout the project. For more details
   see :ref:`below <contributing_style>`.
 
@@ -321,14 +321,15 @@ Style Guide & Linting
 ---------------------
 
 GeoPandas follows the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_
-standard and uses `ruff <https://beta.ruff.rs/docs/>`_ to ensure a consistent
+standard and uses `ruff <https://docs.astral.sh/ruff/>`_ to ensure a consistent
 code format throughout the project.
 
 Continuous Integration (GitHub Actions) will run those tools and
 report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself::
 
-   ruff geopandas
+   ruff format geopandas
+   ruff check geopandas
    git diff upstream/main -u -- "*.py" | ruff .
 
 to auto-format your code. Additionally, many editors have plugins that will

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -32,11 +32,9 @@ In particular, when submitting a pull request:
   line of a docstring should be a standalone summary.  Parameters and
   return values should be documented explicitly.
 
-- Follow PEP 8 when possible. We use `Black
-  <https://black.readthedocs.io/en/stable/>`_ and `ruff
-  <https://beta.ruff.rs/docs/>`_ to ensure a consistent code
-  format throughout the project. For more details see
-  :ref:`below <contributing_style>`.
+- Follow PEP 8 when possible. We use `ruff <https://beta.ruff.rs/docs/>`_
+  to ensure a consistent code format throughout the project. For more details
+  see :ref:`below <contributing_style>`.
 
 - Imports should be grouped with standard library imports first,
   3rd-party libraries next, and GeoPandas imports third.  Within each
@@ -322,24 +320,24 @@ You can find a pull request (or PR) tutorial in the `GitHub's Help Docs <https:/
 Style Guide & Linting
 ---------------------
 
-GeoPandas follows the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ standard
-and uses `Black <https://black.readthedocs.io/en/stable/>`_ and
-`ruff <https://beta.ruff.rs/docs/>`_ to ensure a consistent code
-format throughout the project.
+GeoPandas follows the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_
+standard and uses `ruff <https://beta.ruff.rs/docs/>`_ to ensure a consistent
+code format throughout the project.
 
 Continuous Integration (GitHub Actions) will run those tools and
 report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself::
 
-   black geopandas
+   ruff geopandas
    git diff upstream/main -u -- "*.py" | ruff .
 
 to auto-format your code. Additionally, many editors have plugins that will
-apply ``black`` as you edit files.
+apply ``ruff`` as you edit files.
 
 Optionally (but recommended), you can setup `pre-commit hooks <https://pre-commit.com/>`_
-to automatically run ``black`` and ``ruff`` when you make a git commit. If you did not
-use the provided development environment in ``environment-dev.yml``, you must first install ``pre-commit``::
+to automatically run ``ruff`` when you make a git commit. If you did not
+use the provided development environment in ``environment-dev.yml``, you must
+first install ``pre-commit``::
 
    $ python -m pip install pre-commit
 
@@ -348,9 +346,8 @@ From the root of the geopandas repository, you should then install the
 
    $ pre-commit install
 
-Then ``black`` and ``ruff`` will be run automatically
-each time you commit changes. You can skip these checks with
-``git commit --no-verify``.
+Then ``ruff`` will be run automatically each time you commit changes. You can
+skip these checks with ``git commit --no-verify``.
 
 Commit message conventions
 --------------------------

--- a/doc/source/community/contributing.rst
+++ b/doc/source/community/contributing.rst
@@ -330,7 +330,7 @@ submitting code to run the check yourself::
 
    ruff format geopandas
    ruff check geopandas
-   git diff upstream/main -u -- "*.py" | ruff .
+   git diff upstream/main -u -- "*.py" | ruff check .
 
 to auto-format your code. Additionally, many editors have plugins that will
 apply ``ruff`` as you edit files.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,6 +16,7 @@ dependencies:
     - pytest-xdist
     - fsspec
     - codecov
+
     # styling
     - pre-commit
     - ruff==0.5.5

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,8 +17,8 @@ dependencies:
     - fsspec
     - codecov
     # styling
-    - black
     - pre-commit
+    - ruff==0.5.5
 
     # optional
     - folium

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -48,9 +48,7 @@ def import_optional_dependency(name: str, extra: str = ""):
     module
     """
     msg = """Missing optional dependency '{name}'. {extra}  "
-        "Use pip or conda to install {name}.""".format(
-        name=name, extra=extra
-    )
+        "Use pip or conda to install {name}.""".format(name=name, extra=extra)
 
     if not isinstance(name, str):
         raise ValueError(

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -650,13 +650,13 @@ def _explore(
         ~(gdf.geometry.isna() | gdf.geometry.is_empty)  # drop missing or empty geoms
     ].__geo_interface__
     for feature in feature_collection["features"]:
-        for k in feature["properties"]:
+        for prop in feature["properties"]:
             # escape the curly braces in values
-            if isinstance(feature["properties"][k], str):
-                feature["properties"][k] = re.sub(
+            if isinstance(feature["properties"][prop], str):
+                feature["properties"][prop] = re.sub(
                     r"\{{2,}",
                     lambda x: "{% raw %}" + x.group(0) + "{% endraw %}",
-                    feature["properties"][k],
+                    feature["properties"][prop],
                 )
 
     # add dataframe to map

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -718,7 +718,7 @@ class GeoSeries(GeoPandasBase, Series):
     def _wrapped_pandas_method(self, mtd, *args, **kwargs):
         """Wrap a generic pandas method to ensure it returns a GeoSeries"""
         val = getattr(super(), mtd)(*args, **kwargs)
-        if isinstance(val, Series):
+        if type(val) is Series:
             val.__class__ = GeoSeries
             val.crs = self.crs
         return val

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -718,7 +718,7 @@ class GeoSeries(GeoPandasBase, Series):
     def _wrapped_pandas_method(self, mtd, *args, **kwargs):
         """Wrap a generic pandas method to ensure it returns a GeoSeries"""
         val = getattr(super(), mtd)(*args, **kwargs)
-        if type(val) == Series:
+        if isinstance(val, Series):
             val.__class__ = GeoSeries
             val.crs = self.crs
         return val

--- a/geopandas/io/_geoarrow.py
+++ b/geopandas/io/_geoarrow.py
@@ -179,7 +179,6 @@ def construct_wkb_array(
     field_name: str = "geometry",
     crs: Optional[str] = None,
 ) -> Tuple[pa.Field, pa.Array]:
-
     if shapely.geos_version > (3, 10, 0):
         kwargs = {"flavor": "iso"}
     else:
@@ -488,7 +487,6 @@ def arrow_to_geopandas(table, geometry=None):
         if ext_name == "geoarrow.wkb":
             geom_arr = from_wkb(np.array(table[col]), crs=crs)
         elif ext_name.split(".")[1] in GEOARROW_ENCODINGS:
-
             geom_arr = from_shapely(
                 construct_shapely_array(table[col].combine_chunks(), ext_name), crs=crs
             )
@@ -526,7 +524,6 @@ def arrow_to_geometry_array(arr):
     if ext_name == "geoarrow.wkb":
         geom_arr = from_wkb(np.array(pa_arr), crs=crs)
     elif ext_name.split(".")[1] in GEOARROW_ENCODINGS:
-
         geom_arr = from_shapely(construct_shapely_array(pa_arr, ext_name), crs=crs)
     else:
         raise ValueError(f"Unknown GeoArrow extension type: {ext_name}")

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -894,7 +894,6 @@ def _get_bbox_encoding_column_name(geo_metadata):
 
 
 def _get_non_bbox_columns(schema, geo_metadata):
-
     bbox_column_name = _get_bbox_encoding_column_name(geo_metadata)
     columns = schema.names
     if bbox_column_name in columns:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -761,7 +761,7 @@ def infer_schema(df):
     }
 
     def convert_type(column, in_type):
-        if in_type == object:
+        if in_type is object:
             return "str"
         if in_type.name.startswith("datetime64"):
             # numpy datetime type regardless of frequency

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -13,7 +13,7 @@ from urllib.parse import uses_netloc, uses_params, uses_relative
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_integer_dtype
+from pandas.api.types import is_integer_dtype, is_object_dtype
 
 import shapely
 from shapely.geometry import mapping
@@ -761,7 +761,7 @@ def infer_schema(df):
     }
 
     def convert_type(column, in_type):
-        if in_type is object:
+        if is_object_dtype(in_type):
             return "str"
         if in_type.name.startswith("datetime64"):
             # numpy datetime type regardless of frequency

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -13,7 +13,7 @@ from urllib.parse import uses_netloc, uses_params, uses_relative
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_integer_dtype, is_object_dtype
+from pandas.api.types import is_datetime64_any_dtype, is_integer_dtype, is_object_dtype
 
 import shapely
 from shapely.geometry import mapping
@@ -763,7 +763,7 @@ def infer_schema(df):
     def convert_type(column, in_type):
         if is_object_dtype(in_type):
             return "str"
-        if in_type.name.startswith("datetime64"):
+        if is_datetime64_any_dtype(in_type):
             # numpy datetime type regardless of frequency
             return "datetime"
         if str(in_type) in types:

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -715,7 +715,7 @@ def test_feather_arrow_version(tmpdir, naturalearth_lowres):
 
 
 def test_fsspec_url(naturalearth_lowres):
-    fsspec = pytest.importorskip("fsspec")
+    _ = pytest.importorskip("fsspec")
     import fsspec.implementations.memory
 
     class MyMemoryFileSystem(fsspec.implementations.memory.MemoryFileSystem):
@@ -1020,7 +1020,6 @@ def test_read_parquet_geoarrow(geometry_type):
     ["point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon"],
 )
 def test_geoarrow_roundtrip(tmp_path, geometry_type):
-
     df = geopandas.read_parquet(
         DATA_PATH
         / "arrow"

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1399,7 +1399,6 @@ def test_option_io_engine(nybb_filename):
 
 @pytest.mark.skipif(pyogrio, reason="test for pyogrio not installed")
 def test_error_engine_unavailable_pyogrio(tmp_path, df_points, file_path):
-
     with pytest.raises(ImportError, match="the 'read_file' function requires"):
         geopandas.read_file(file_path, engine="pyogrio")
 
@@ -1409,7 +1408,6 @@ def test_error_engine_unavailable_pyogrio(tmp_path, df_points, file_path):
 
 @pytest.mark.skipif(fiona, reason="test for fiona not installed")
 def test_error_engine_unavailable_fiona(tmp_path, df_points, file_path):
-
     with pytest.raises(ImportError, match="the 'read_file' function requires"):
         geopandas.read_file(file_path, engine="fiona")
 

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1093,7 +1093,7 @@ def test_read_file_multi_layer_with_layer_arg_no_warning(tmp_path, engine):
         specify_layer_warnings = [
             warning
             for warning in captured
-            if warning.category == UserWarning
+            if warning.category is UserWarning
             and "specify layer parameter" in str(warning.message).lower()
         ]
         assert (

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -274,9 +274,7 @@ class TestIO:
         create_postgis(con, df_nybb, geom_col=orig_geom)
 
         sql = """SELECT borocode, boroname, shape_leng, shape_area,
-                    {} as {} FROM nybb;""".format(
-            orig_geom, out_geom
-        )
+                    {} as {} FROM nybb;""".format(orig_geom, out_geom)
         df = read_postgis(sql, con, geom_col=out_geom)
 
         validate_boro_df(df)

--- a/geopandas/tests/test_api.py
+++ b/geopandas/tests/test_api.py
@@ -30,9 +30,7 @@ mods = blacklist & set(m.split('.')[0] for m in sys.modules)
 if mods:
     sys.stderr.write('err: geopandas should not import: {{}}'.format(', '.join(mods)))
     sys.exit(len(mods))
-""".format(
-        blacklist
-    )
+""".format(blacklist)
     call = [sys.executable, "-c", code]
     returncode = subprocess.run(call, check=False).returncode
     assert returncode == 0

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -338,7 +338,7 @@ def test_dissolve_multi_agg(nybb_polydf, merged_shapes):
     merged_shapes[("BoroCode", "max")] = [5, 2]
     merged_shapes[("BoroName", "count")] = [3, 2]
 
-    with warnings.catch_warnings(record=True) as record:
+    with warnings.catch_warnings(action="error"):
         test = nybb_polydf.dissolve(
             by="manhattan_bronx",
             aggfunc={
@@ -347,7 +347,6 @@ def test_dissolve_multi_agg(nybb_polydf, merged_shapes):
             },
         )
     assert_geodataframe_equal(test, merged_shapes)
-    assert len(record) == 0
 
 
 def test_coverage_dissolve(nybb_polydf):

--- a/geopandas/tests/test_dissolve.py
+++ b/geopandas/tests/test_dissolve.py
@@ -338,7 +338,8 @@ def test_dissolve_multi_agg(nybb_polydf, merged_shapes):
     merged_shapes[("BoroCode", "max")] = [5, 2]
     merged_shapes[("BoroName", "count")] = [3, 2]
 
-    with warnings.catch_warnings(action="error"):
+    with warnings.catch_warnings():
+        warnings.simplefilter(action="error")
         test = nybb_polydf.dissolve(
             by="manhattan_bronx",
             aggfunc={
@@ -346,6 +347,7 @@ def test_dissolve_multi_agg(nybb_polydf, merged_shapes):
                 "BoroName": "count",
             },
         )
+
     assert_geodataframe_equal(test, merged_shapes)
 
 

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -19,6 +19,7 @@ import operator
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_object_dtype
 from pandas.tests.extension import base as extension_tests
 
 import shapely.geometry
@@ -395,7 +396,7 @@ class TestReshaping(extension_tests.BaseReshapingTests):
 
             expected = obj_ser.unstack(level=level, fill_value=data.dtype.na_value)
             if obj == "series":
-                assert all(isinstance(x, object) for x in expected.dtypes)
+                assert all(is_object_dtype(x) for x in expected.dtypes)
             # <------------ next line is added
             expected[expected.isna()] = None
             # ------------->

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -335,7 +335,6 @@ class TestConstructors(extension_tests.BaseConstructorsTests):
 
 
 class TestReshaping(extension_tests.BaseReshapingTests):
-
     # NOTE: this test is copied from pandas/tests/extension/base/reshaping.py
     # because starting with pandas 3.0 the assert_frame_equal is strict regarding
     # the exact missing value (None vs NaN)
@@ -396,7 +395,7 @@ class TestReshaping(extension_tests.BaseReshapingTests):
 
             expected = obj_ser.unstack(level=level, fill_value=data.dtype.na_value)
             if obj == "series":
-                assert (expected.dtypes == object).all()
+                assert (expected.dtypes is object).all()
             # <------------ next line is added
             expected[expected.isna()] = None
             # ------------->

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -395,7 +395,7 @@ class TestReshaping(extension_tests.BaseReshapingTests):
 
             expected = obj_ser.unstack(level=level, fill_value=data.dtype.na_value)
             if obj == "series":
-                assert (expected.dtypes is object).all()
+                assert all(isinstance(x, object) for x in expected.dtypes)
             # <------------ next line is added
             expected[expected.isna()] = None
             # ------------->

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -426,7 +426,7 @@ class TestDataFrame:
         df_nogeom = pd.DataFrame(df.drop("geometry", axis=1))
         res1, res2 = df.align(df_nogeom, axis=0)
         assert_geodataframe_equal(res1, df)
-        assert type(res2) == pd.DataFrame
+        assert isinstance(res2, pd.DataFrame)
         assert_frame_equal(res2, df_nogeom)
 
         # same as above but now with actual alignment
@@ -454,7 +454,7 @@ class TestDataFrame:
         exp2_nogeom = pd.DataFrame(exp2.drop("geometry", axis=1))
         res1, res2 = df1.align(df2_nogeom, axis=0)
         assert_geodataframe_equal(res1, exp1)
-        assert type(res2) == pd.DataFrame
+        assert isinstance(res2, pd.DataFrame)
         assert_frame_equal(res2, exp2_nogeom)
 
     @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="Requires pyproj")
@@ -852,7 +852,7 @@ class TestDataFrame:
             geometry=points_from_xy(df["longitude"], df["latitude"]),
             crs=self.df.crs,
         )
-        assert type(df) == pd.DataFrame
+        assert isinstance(df, pd.DataFrame)
         assert "geometry" not in df
         assert_frame_equal(df, df_copy)
         assert isinstance(gf, GeoDataFrame)
@@ -1229,7 +1229,7 @@ class TestConstructor:
         gpdf = GeoDataFrame(data)
         pddf = pd.DataFrame(data)
         check_geodataframe(gpdf)
-        assert type(pddf) == pd.DataFrame
+        assert isinstance(pddf, pd.DataFrame)
 
         for df in [gpdf, pddf]:
             res = GeoDataFrame(df)
@@ -1290,17 +1290,17 @@ class TestConstructor:
         # keeps GeoDataFrame class (no DataFrame)
         data = {"A": range(3), "B": np.arange(3.0)}
         df = GeoDataFrame(data)
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
 
         gdf = GeoDataFrame({"x": [1]})
         assert list(gdf.x) == [1]
 
     def test_empty(self):
         df = GeoDataFrame()
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
 
         df = GeoDataFrame({"A": [], "B": []}, geometry=[])
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
 
     def test_column_ordering(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -426,7 +426,7 @@ class TestDataFrame:
         df_nogeom = pd.DataFrame(df.drop("geometry", axis=1))
         res1, res2 = df.align(df_nogeom, axis=0)
         assert_geodataframe_equal(res1, df)
-        assert isinstance(res2, pd.DataFrame)
+        assert type(res2) is pd.DataFrame
         assert_frame_equal(res2, df_nogeom)
 
         # same as above but now with actual alignment
@@ -454,7 +454,7 @@ class TestDataFrame:
         exp2_nogeom = pd.DataFrame(exp2.drop("geometry", axis=1))
         res1, res2 = df1.align(df2_nogeom, axis=0)
         assert_geodataframe_equal(res1, exp1)
-        assert isinstance(res2, pd.DataFrame)
+        assert type(res2) is pd.DataFrame
         assert_frame_equal(res2, exp2_nogeom)
 
     @pytest.mark.skipif(not compat.HAS_PYPROJ, reason="Requires pyproj")
@@ -852,10 +852,10 @@ class TestDataFrame:
             geometry=points_from_xy(df["longitude"], df["latitude"]),
             crs=self.df.crs,
         )
-        assert isinstance(df, pd.DataFrame)
+        assert type(df) is pd.DataFrame
         assert "geometry" not in df
         assert_frame_equal(df, df_copy)
-        assert isinstance(gf, GeoDataFrame)
+        assert type(gf) is GeoDataFrame
         assert hasattr(gf, "geometry")
 
         # ensure mutating columns in gf doesn't update df
@@ -1229,7 +1229,7 @@ class TestConstructor:
         gpdf = GeoDataFrame(data)
         pddf = pd.DataFrame(data)
         check_geodataframe(gpdf)
-        assert isinstance(pddf, pd.DataFrame)
+        assert type(pddf) is pd.DataFrame
 
         for df in [gpdf, pddf]:
             res = GeoDataFrame(df)
@@ -1290,17 +1290,17 @@ class TestConstructor:
         # keeps GeoDataFrame class (no DataFrame)
         data = {"A": range(3), "B": np.arange(3.0)}
         df = GeoDataFrame(data)
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
 
         gdf = GeoDataFrame({"x": [1]})
         assert list(gdf.x) == [1]
 
     def test_empty(self):
         df = GeoDataFrame()
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
 
         df = GeoDataFrame({"A": [], "B": []}, geometry=[])
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
 
     def test_column_ordering(self):
         geoms = [Point(1, 1), Point(2, 2), Point(3, 3)]

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -855,7 +855,7 @@ class TestDataFrame:
         assert type(df) is pd.DataFrame
         assert "geometry" not in df
         assert_frame_equal(df, df_copy)
-        assert type(gf) is GeoDataFrame
+        assert isinstance(gf, GeoDataFrame)
         assert hasattr(gf, "geometry")
 
         # ensure mutating columns in gf doesn't update df

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -713,7 +713,7 @@ class TestConstructor:
         )
         s = s.explode(index_parts=True)
         df = s.reset_index()
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
         # name None -> 0, otherwise name preserved
         assert df.geometry.name == (name if name is not None else 0)
         assert df.crs == s.crs
@@ -723,7 +723,7 @@ class TestConstructor:
     def test_to_frame(self, name, crs):
         s = GeoSeries([Point(0, 0), Point(1, 1)], name=name, crs=crs)
         df = s.to_frame()
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
         # name None -> 0, otherwise name preserved
         expected_name = name if name is not None else 0
         assert df.geometry.name == expected_name
@@ -732,7 +732,7 @@ class TestConstructor:
 
         # if name is provided to to_frame, it should override
         df2 = s.to_frame(name="geom")
-        assert isinstance(df, GeoDataFrame)
+        assert type(df) is GeoDataFrame
         assert df2.geometry.name == "geom"
         assert df2.crs == s.crs
 

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -713,7 +713,7 @@ class TestConstructor:
         )
         s = s.explode(index_parts=True)
         df = s.reset_index()
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
         # name None -> 0, otherwise name preserved
         assert df.geometry.name == (name if name is not None else 0)
         assert df.crs == s.crs
@@ -723,7 +723,7 @@ class TestConstructor:
     def test_to_frame(self, name, crs):
         s = GeoSeries([Point(0, 0), Point(1, 1)], name=name, crs=crs)
         df = s.to_frame()
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
         # name None -> 0, otherwise name preserved
         expected_name = name if name is not None else 0
         assert df.geometry.name == expected_name
@@ -732,7 +732,7 @@ class TestConstructor:
 
         # if name is provided to to_frame, it should override
         df2 = s.to_frame(name="geom")
-        assert type(df) == GeoDataFrame
+        assert isinstance(df, GeoDataFrame)
         assert df2.geometry.name == "geom"
         assert df2.crs == s.crs
 

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -369,7 +369,7 @@ def test_constructor_sliced_row_slices(df2, column_set):
     assert isinstance(df_subset, GeoDataFrame)
     res = df_subset.loc[0]
     # row slices shouldn't be GeoSeries, even if they have a geometry col
-    assert type(res) == pd.Series
+    assert isinstance(res, pd.Series)
     if "geometry" in column_set:
         assert not isinstance(res.geometry, pd.Series)
         assert res.geometry == Point(0, 0)
@@ -380,25 +380,25 @@ def test_constructor_sliced_column_slices(df2):
     geo_idx = df2.columns.get_loc("geometry")
     sub = df2.head(1)
     # column slices should be GeoSeries if of geometry type
-    assert type(sub.iloc[:, geo_idx]) == GeoSeries
-    assert type(sub.iloc[[0], geo_idx]) == GeoSeries
+    assert isinstance(sub.iloc[:, geo_idx], GeoSeries)
+    assert isinstance(sub.iloc[[0], geo_idx], GeoSeries)
     sub = df2.head(2)
-    assert type(sub.iloc[:, geo_idx]) == GeoSeries
-    assert type(sub.iloc[[0, 1], geo_idx]) == GeoSeries
+    assert isinstance(sub.iloc[:, geo_idx], GeoSeries)
+    assert isinstance(sub.iloc[[0, 1], geo_idx], GeoSeries)
 
     # check iloc row slices are pd.Series instead
-    assert type(df2.iloc[0, :]) == pd.Series
+    assert isinstance(df2.iloc[0, :], pd.Series)
 
 
 def test_constructor_sliced_in_pandas_methods(df2):
     # constructor sliced is used in many places, checking a sample of non
     # geometry cases are sensible
-    assert type(df2.count()) == pd.Series
+    assert isinstance(df2.count(), pd.Series)
     # drop the secondary geometry columns as not hashable
     hashable_test_df = df2.drop(columns=["geometry2", "geometry3"])
-    assert type(hashable_test_df.duplicated()) == pd.Series
-    assert type(df2.quantile(numeric_only=True)) == pd.Series
-    assert type(df2.memory_usage()) == pd.Series
+    assert isinstance(hashable_test_df.duplicated(), pd.Series)
+    assert isinstance(df2.quantile(numeric_only=True), pd.Series)
+    assert isinstance(df2.memory_usage(), pd.Series)
 
 
 def test_merge_preserve_geodataframe():

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -369,7 +369,7 @@ def test_constructor_sliced_row_slices(df2, column_set):
     assert isinstance(df_subset, GeoDataFrame)
     res = df_subset.loc[0]
     # row slices shouldn't be GeoSeries, even if they have a geometry col
-    assert isinstance(res, pd.Series)
+    assert type(res) is pd.Series
     if "geometry" in column_set:
         assert not isinstance(res.geometry, pd.Series)
         assert res.geometry == Point(0, 0)
@@ -380,25 +380,25 @@ def test_constructor_sliced_column_slices(df2):
     geo_idx = df2.columns.get_loc("geometry")
     sub = df2.head(1)
     # column slices should be GeoSeries if of geometry type
-    assert isinstance(sub.iloc[:, geo_idx], GeoSeries)
-    assert isinstance(sub.iloc[[0], geo_idx], GeoSeries)
+    assert type(sub.iloc[:, geo_idx]) is GeoSeries
+    assert type(sub.iloc[[0], geo_idx]) is GeoSeries
     sub = df2.head(2)
-    assert isinstance(sub.iloc[:, geo_idx], GeoSeries)
-    assert isinstance(sub.iloc[[0, 1], geo_idx], GeoSeries)
+    assert type(sub.iloc[:, geo_idx]) is GeoSeries
+    assert type(sub.iloc[[0, 1], geo_idx]) is GeoSeries
 
     # check iloc row slices are pd.Series instead
-    assert isinstance(df2.iloc[0, :], pd.Series)
+    assert type(df2.iloc[0, :]) is pd.Series
 
 
 def test_constructor_sliced_in_pandas_methods(df2):
     # constructor sliced is used in many places, checking a sample of non
     # geometry cases are sensible
-    assert isinstance(df2.count(), pd.Series)
+    assert type(df2.count()) is pd.Series
     # drop the secondary geometry columns as not hashable
     hashable_test_df = df2.drop(columns=["geometry2", "geometry3"])
-    assert isinstance(hashable_test_df.duplicated(), pd.Series)
-    assert isinstance(df2.quantile(numeric_only=True), pd.Series)
-    assert isinstance(df2.memory_usage(), pd.Series)
+    assert type(hashable_test_df.duplicated()) is pd.Series
+    assert type(df2.quantile(numeric_only=True)) is pd.Series
+    assert type(df2.memory_usage()) is pd.Series
 
 
 def test_merge_preserve_geodataframe():

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -160,7 +160,7 @@ def test_reindex(s, df):
     assert_frame_equal(res, df[["value1", "geometry"]])
 
     res = df.reindex(columns=["value1", "value2"])
-    assert type(res) == pd.DataFrame
+    assert isinstance(res, pd.DataFrame)
     assert_frame_equal(res, df[["value1", "value2"]])
 
 
@@ -464,7 +464,7 @@ def test_isna(NA):
     s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)], index=[2, 4, 5], name="tt")
     exp = pd.Series([False, True, False], index=[2, 4, 5], name="tt")
     res = s2.isnull()
-    assert type(res) == pd.Series
+    assert isinstance(res, pd.Series)
     assert_series_equal(res, exp)
     res = s2.isna()
     assert_series_equal(res, exp)

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -160,7 +160,7 @@ def test_reindex(s, df):
     assert_frame_equal(res, df[["value1", "geometry"]])
 
     res = df.reindex(columns=["value1", "value2"])
-    assert isinstance(res, pd.DataFrame)
+    assert type(res) is pd.DataFrame
     assert_frame_equal(res, df[["value1", "value2"]])
 
 
@@ -464,7 +464,7 @@ def test_isna(NA):
     s2 = GeoSeries([Point(0, 0), NA, Point(2, 2)], index=[2, 4, 5], name="tt")
     exp = pd.Series([False, True, False], index=[2, 4, 5], name="tt")
     res = s2.isnull()
-    assert isinstance(res, pd.Series)
+    assert type(res) is pd.Series
     assert_series_equal(res, exp)
     res = s2.isna()
     assert_series_equal(res, exp)

--- a/geopandas/tests/util.py
+++ b/geopandas/tests/util.py
@@ -126,16 +126,12 @@ def create_postgis(con, df, srid=None, geom_col="geom"):
             boroname     varchar(40),
             shape_leng   float,
             shape_area   float
-            );""".format(
-            geom_col=geom_col, geom_schema=geom_schema
-        )
+            );""".format(geom_col=geom_col, geom_schema=geom_schema)
         cursor.execute(sql)
 
         for i, row in df.iterrows():
             sql = """INSERT INTO nybb VALUES ({}, %s, %s, %s, %s
-            );""".format(
-                geom_insert
-            )
+            );""".format(geom_insert)
             cursor.execute(
                 sql,
                 (

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -111,7 +111,11 @@ def sjoin(
 
     on_attribute = _maybe_make_list(on_attribute)
 
-    _basic_checks(left_df, right_df, how, lsuffix, rsuffix, on_attribute=on_attribute),
+    (
+        _basic_checks(
+            left_df, right_df, how, lsuffix, rsuffix, on_attribute=on_attribute
+        ),
+    )
 
     indices = _geom_predicate_query(
         left_df, right_df, predicate, distance, on_attribute=on_attribute

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -111,11 +111,7 @@ def sjoin(
 
     on_attribute = _maybe_make_list(on_attribute)
 
-    (
-        _basic_checks(
-            left_df, right_df, how, lsuffix, rsuffix, on_attribute=on_attribute
-        ),
-    )
+    _basic_checks(left_df, right_df, how, lsuffix, rsuffix, on_attribute=on_attribute)
 
     indices = _geom_predicate_query(
         left_df, right_df, predicate, distance, on_attribute=on_attribute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,6 @@ filterwarnings = [
     "ignore:Cannot set the CRS, falling back to None:UserWarning:geopandas",
 ]
 
-[tool.black]
-line-length = 88
-
 [tool.ruff]
 line-length = 88
 extend-exclude = ["doc/*", "benchmarks/*", "versioneer.py", "geopandas/_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dev = [
     "pytest-cov",
     "pytest-xdist",
     "codecov",
-    "black",
     "pre-commit",
+    "ruff",
 ]
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,8 +26,8 @@ pytest-xdist
 codecov
 
 # styling
-black
 pre-commit
+ruff
 
 # PostGIS writing
 GeoAlchemy2


### PR DESCRIPTION
- update ruff to 0.5.5
    - apply needed changes in code to comply to new rules
- replace black formatting by ruff-format
    - apply relevant changes in code
    - update contributing docs

Didn't activate `pyupgrade` nor `pydocstyle` yet to keep PR managable.