### PR TITLE
TST: explicitly install pytz in test envs

### DIFF
--- a/ci/envs/310-latest-conda-forge.yaml
+++ b/ci/envs/310-latest-conda-forge.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib-base
   - mapclassify

--- a/ci/envs/310-pd20-conda-forge.yaml
+++ b/ci/envs/310-pd20-conda-forge.yaml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib
   - mapclassify

--- a/ci/envs/311-dev.yaml
+++ b/ci/envs/311-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   #- geopy
   - SQLalchemy<2

--- a/ci/envs/311-latest-conda-forge.yaml
+++ b/ci/envs/311-latest-conda-forge.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - fiona
   - matplotlib

--- a/ci/envs/312-latest-conda-forge.yaml
+++ b/ci/envs/312-latest-conda-forge.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - fiona
   - matplotlib

--- a/ci/envs/312-latest-conda-forge_no_pyproj.yaml
+++ b/ci/envs/312-latest-conda-forge_no_pyproj.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - fiona
   - matplotlib

--- a/ci/envs/39-latest-conda-forge.yaml
+++ b/ci/envs/39-latest-conda-forge.yaml
@@ -17,6 +17,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib
   - mapclassify

--- a/ci/envs/39-latest-conda-forge_no_pyogrio.yaml
+++ b/ci/envs/39-latest-conda-forge_no_pyogrio.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pytz
   # - fsspec  # to have one non-minimal build without fsspec
   # optional
   - matplotlib>=3.6

--- a/ci/envs/39-latest-defaults.yaml
+++ b/ci/envs/39-latest-defaults.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib
   #- geopy

--- a/ci/envs/39-minimal.yaml
+++ b/ci/envs/39-minimal.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib=3.5.0
   - mapclassify=2.4.0

--- a/ci/envs/39-pd15-defaults.yaml
+++ b/ci/envs/39-pd15-defaults.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pytz
   # optional
   - matplotlib
   #- geopy

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -10,7 +10,6 @@ from packaging.version import Version
 
 import numpy as np
 import pandas as pd
-import pytz
 from pandas.api.types import is_datetime64_any_dtype
 
 from shapely.geometry import Point, Polygon, box, mapping
@@ -46,6 +45,7 @@ except ImportError:
     fiona = False
     FIONA_GE_19 = False
 
+pytz = pytest.importorskip("pytz")
 
 PYOGRIO_MARK = pytest.mark.skipif(not pyogrio, reason="pyogrio not installed")
 FIONA_MARK = pytest.mark.skipif(not fiona, reason="fiona not installed")
@@ -1399,7 +1399,6 @@ def test_option_io_engine(nybb_filename):
 
 @pytest.mark.skipif(pyogrio, reason="test for pyogrio not installed")
 def test_error_engine_unavailable_pyogrio(tmp_path, df_points, file_path):
-
     with pytest.raises(ImportError, match="the 'read_file' function requires"):
         geopandas.read_file(file_path, engine="pyogrio")
 
@@ -1409,7 +1408,6 @@ def test_error_engine_unavailable_pyogrio(tmp_path, df_points, file_path):
 
 @pytest.mark.skipif(fiona, reason="test for fiona not installed")
 def test_error_engine_unavailable_fiona(tmp_path, df_points, file_path):
-
     with pytest.raises(ImportError, match="the 'read_file' function requires"):
         geopandas.read_file(file_path, engine="fiona")
 


### PR DESCRIPTION
We're not getting pytz in the dev CI env any longer but we use it. So explicitly stating and adding importorskip.