### PR TITLE
Docs: Mention how you can plot the index of a GeoDataFrame

### DIFF
--- a/doc/source/docs/user_guide/mapping.rst
+++ b/doc/source/docs/user_guide/mapping.rst
@@ -54,6 +54,7 @@ GeoPandas makes it easy to create Choropleth maps (maps where the color of each 
     @savefig chicago_population.png
     chicago.plot(column="POP2010");
 
+You can also plot the index of a GeoDataFrame, by passing ``column=gdf.index.values`` (in this example ``column=chicago.index.values``).
 
 Creating a legend
 ~~~~~~~~~~~~~~~~~

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -518,8 +518,8 @@ def plot_dataframe(
     column : str, np.array, pd.Series (default None)
         The name of the dataframe column, np.array, or pd.Series to be plotted.
         If np.array or pd.Series are used then it must have same length as
-        dataframe. Values are used to color the plot. Ignored if `color` is
-        also set.
+        dataframe. Plotting the index is also possible, by passing `column=gdf.index.values`.
+        Values are used to color the plot. Ignored if `color` is also set.
     kind: str
         The kind of plots to produce. The default is to create a map ("geo").
         Other supported kinds of plots from pandas:


### PR DESCRIPTION
Updates the docstring and mapping page of the user guide by mentioning that you can plot a GeoDataFrame using the index for coloring by passing `column=gdf.index.values`.

This avoids having to modify the source code to directly allow `gdf.index` (while that could still be considered if preferred).

Closes #3357.