### PR TITLE
BUG: raise proper error message when exporting empty GeoDataFrame to geoarrow

### DIFF
--- a/geopandas/io/_geoarrow.py
+++ b/geopandas/io/_geoarrow.py
@@ -279,11 +279,18 @@ def construct_geometry_array(
     # NOTE: this implementation returns a (field, array) pair so that it can set the
     # extension metadata on the field without instantiating extension types into the
     # global pyarrow registry
+
+    mask = shapely.is_missing(shapely_arr)
+    if len(shapely_arr) == 0 or mask.all():
+        raise NotImplementedError(
+            "Converting an empty or all-missing GeoDataFrame to the 'geoarrow' "
+            "encoding is not yet supported."
+        )
+
     geom_type, coords, offsets = shapely.to_ragged_array(
         shapely_arr, include_z=include_z
     )
 
-    mask = shapely.is_missing(shapely_arr)
     if mask.any():
         if (
             geom_type == GeometryType.POINT


### PR DESCRIPTION
See https://github.com/geopandas/geopandas/issues/3407

This at least raises an informative error message. But we should also consider defaulting to some geometry type.