### PR TITLE
TEMP: fix dev ci

### DIFF
--- a/ci/envs/311-dev.yaml
+++ b/ci/envs/311-dev.yaml
@@ -24,7 +24,7 @@ dependencies:
     - geopy
     - mapclassify>=2.4.0
     # dev versions of packages
-    - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
+    - --pre --prefer-binary --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
     - numpy>=2.0.0.dev
     - fiona
     - pandas


### PR DESCRIPTION
Opening this just to get an actual run of our dev CI (pyarrow had an issue with its wheels, causing those to not be uploaded but only the sdist, which then caused us to try to install the sdist, which then obviously fails).

I am fixing pyarrow wheel uploading today, so normally this should be fixed by tomorrow automatically as well.