### PR TITLE
DOC: Document missing_kwds in `explore`

### DIFF
--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -205,7 +205,7 @@ def _explore(
         Style to be passed to folium highlight_function. Uses the same keywords
         as ``style_kwds``. When empty, defaults to ``{"fillOpacity": 0.75}``.
     missing_kwds : dict (default {})
-        Additional style for missing values (NaN):
+        Additional style for missing values:
 
         color : str
             Color of NaN values. Defaults to ``None``, which uses Folium's default.

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -204,6 +204,13 @@ def _explore(
     highlight_kwds : dict (default {})
         Style to be passed to folium highlight_function. Uses the same keywords
         as ``style_kwds``. When empty, defaults to ``{"fillOpacity": 0.75}``.
+    missing_kwds : dict (default {})
+        Additional style for missing values (NaN):
+
+        color : str
+            Color of NaN values. Defaults to ``None``, which uses Folium's default.
+        label : str (default "NaN")
+            Legend entry for missing values.
     tooltip_kwds : dict (default {})
         Additional keywords to be passed to :class:`folium.features.GeoJsonTooltip`,
         e.g. ``aliases``, ``labels``, or ``sticky``.

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -208,7 +208,7 @@ def _explore(
         Additional style for missing values:
 
         color : str
-            Color of NaN values. Defaults to ``None``, which uses Folium's default.
+            Color of missing values. Defaults to ``None``, which uses Folium's default.
         label : str (default "NaN")
             Legend entry for missing values.
     tooltip_kwds : dict (default {})


### PR DESCRIPTION
The documentation for `missing_kwds` in `explore` was missing.