### PR TITLE
BUG: Properly handle geometry_encoding if None and add docs

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -122,6 +122,9 @@ def _create_metadata(
     schema_version : {'0.1.0', '0.4.0', '1.0.0-beta.1', '1.0.0', None}
         GeoParquet specification version; if not provided will default to
         latest supported version.
+    geometry_encoding : dict, default None
+        GeoParquet encoding per geometry column.
+        Defaults to "WKB" for columns that are not present in the dictionary.
     write_covering_bbox : bool, default False
         Writes the bounding box column for each row entry with column
         name 'bbox'. Writing a bbox column can be computationally
@@ -166,7 +169,7 @@ def _create_metadata(
                 _remove_id_from_member_of_ensembles(crs)
 
         column_metadata[col] = {
-            "encoding": geometry_encoding[col],
+            "encoding": geometry_encoding[col] if geometry_encoding is not None and col in geometry_encoding else "WKB",
             "crs": crs,
             geometry_types_name: geometry_types,
         }

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -169,7 +169,11 @@ def _create_metadata(
                 _remove_id_from_member_of_ensembles(crs)
 
         column_metadata[col] = {
-            "encoding": geometry_encoding[col] if geometry_encoding is not None and col in geometry_encoding else "WKB",
+            "encoding": (
+                geometry_encoding[col]
+                if geometry_encoding and col in geometry_encoding
+                else "WKB"
+            ),
             "crs": crs,
             geometry_types_name: geometry_types,
         }

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -94,6 +94,11 @@ def test_create_metadata(naturalearth_lowres):
     # specifying non-WKB encoding sets default schema to 1.1.0
     metadata = _create_metadata(df, geometry_encoding={"geometry": "point"})
     assert metadata["version"] == "1.1.0"
+    assert metadata["columns"]["geometry"]["encoding"] == "point"
+
+    # check that providing no geometry encoding defaults to WKB
+    metadata = _create_metadata(df)
+    assert metadata["columns"]["geometry"]["encoding"] == "WKB"
 
 
 def test_create_metadata_with_z_geometries():


### PR DESCRIPTION
The geometry_column defaults to None, but in the following code this may lead to issues.
Add documentation for the parameter.