### PR TITLE
COMPAT: include keepdims GeometryArray._reduce

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 geopandas/_version.py export-subst
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,8 @@ geopandas/datasets/ne_110m_admin_0_countries.zip
 doc/source/getting_started/my_file.geojson
 
 .ruff_cache
-.env
+.env# pixi environments
+.pixi
+*.egg-info
+pixi.toml
+pixi.lock

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,8 @@ geopandas/datasets/ne_110m_admin_0_countries.zip
 doc/source/getting_started/my_file.geojson
 
 .ruff_cache
-.env# pixi environments
+.env
+# pixi environments
 .pixi
 *.egg-info
 pixi.toml

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1637,7 +1637,7 @@ class GeometryArray(ExtensionArray):
         data = np.concatenate([ga._data for ga in to_concat])
         return GeometryArray(data, crs=_get_common_crs(to_concat))
 
-    def _reduce(self, name, skipna=True, **kwargs):
+    def _reduce(self, name, skipna=True, keepdims=False, **kwargs):
         # including the base class version here (that raises by default)
         # because this was not yet defined in pandas 0.23
         if name in ("any", "all"):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1647,7 +1647,7 @@ def test_reduce_geometry_array():
         [
             {"geometry": Point(x, y), "value1": x + y, "value2": x * y}
             for x, y in zip(range(N), range(N))
-            ]
-            )
+        ]
+    )
     mask = geodf["value1"].duplicated(keep=False)
     geodf[mask].dropna(subset=["geometry"])

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1642,12 +1642,4 @@ def test_reduce_geometry_array():
     and its `_reduce` is overridden in `GeometryArray`.
     This warning is issued with pandas 2.2.2 (tested).
     """
-    N = 10
-    geodf = GeoDataFrame(
-        [
-            {"geometry": Point(x, y), "value1": x + y, "value2": x * y}
-            for x, y in zip(range(N), range(N))
-        ]
-    )
-    mask = geodf["value1"].duplicated(keep=False)
-    geodf[mask].dropna(subset=["geometry"])
+    GeoDataFrame({"geometry": []}).all()

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1629,3 +1629,25 @@ def test_set_geometry_supply_arraylike(dfs, geo_col_name):
         res4 = df.set_geometry(centroids, drop=True)
     assert res4.active_geometry_name == "centroids"
     assert geo_col_name in res4.columns
+
+
+@pytest.mark.filterwarnings("error::FutureWarning")
+def test_reduce_geometry_array():
+    """
+    Check for a FutureWarning.
+
+    `geopandas.array.GeometryArray._reduce` issues a FutureWarning if
+    the parameter `keepdims` is not set.
+    `GeometryArray` inherits from `pandas.api.extensions.ExtensionArray`
+    and its `_reduce` is overiden in `GeometryArray`.
+    This warning is issued with pandas 2.2.2 (tested).
+    """
+    N = 10
+    geodf = GeoDataFrame(
+        [
+            {"geometry": Point(x, y), "value1": x + y, "value2": x * y}
+            for x, y in zip(range(N), range(N))
+            ]
+            )
+    mask = geodf["value1"].duplicated(keep=False)
+    geodf[mask].dropna(subset=["geometry"])

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1639,7 +1639,7 @@ def test_reduce_geometry_array():
     `geopandas.array.GeometryArray._reduce` issues a FutureWarning if
     the parameter `keepdims` is not set.
     `GeometryArray` inherits from `pandas.api.extensions.ExtensionArray`
-    and its `_reduce` is overiden in `GeometryArray`.
+    and its `_reduce` is overridden in `GeometryArray`.
     This warning is issued with pandas 2.2.2 (tested).
     """
     N = 10


### PR DESCRIPTION
`geopandas.array.GeometryArray._reduce` issues a FutureWarning if the parameter `keepdims` is not set. `GeometryArray` inherits from `pandas.api.extensions.ExtensionArray` and its `_reduce` is overridden in `GeometryArray`.  Setting `keepdims=False` in `GeometryArray._reduce` turns off this warning. 

See issue #3403 for details.