### PR TITLE
CLN: cleanup old version guards

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -10,7 +10,6 @@ import shapely.geos
 # pandas compat
 # -----------------------------------------------------------------------------
 
-PANDAS_GE_15 = Version(pd.__version__) >= Version("1.5.0")
 PANDAS_GE_20 = Version(pd.__version__) >= Version("2.0.0")
 PANDAS_GE_202 = Version(pd.__version__) >= Version("2.0.2")
 PANDAS_GE_21 = Version(pd.__version__) >= Version("2.1.0")

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -1,5 +1,4 @@
 import warnings
-from packaging.version import Version
 from statistics import mean
 
 import numpy as np
@@ -292,10 +291,6 @@ def _explore(
         from mapclassify import classify
         from matplotlib import colormaps as cm
         from matplotlib import colors
-
-        # check for minimum version of folium
-        if Version(folium.__version__) < Version("0.12.0"):
-            raise ImportError
 
     except (ImportError, ModuleNotFoundError):
         raise ImportError(

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing
 import warnings
-from packaging.version import Version
 from typing import Any
 
 import numpy as np
@@ -1445,8 +1444,6 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         ]
 
         """
-        import pyarrow as pa
-
         from geopandas.io._geoarrow import (
             GeoArrowArray,
             construct_geometry_array,
@@ -1456,9 +1453,6 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         field_name = self.name if self.name is not None else ""
 
         if geometry_encoding.lower() == "geoarrow":
-            if Version(pa.__version__) < Version("10.0.0"):
-                raise ValueError("Converting to 'geoarrow' requires pyarrow >= 10.0.")
-
             field, geom_arr = construct_geometry_array(
                 np.array(self.array),
                 include_z=include_z,

--- a/geopandas/io/_geoarrow.py
+++ b/geopandas/io/_geoarrow.py
@@ -137,9 +137,6 @@ def geopandas_to_arrow(
     geometry_encoding_dict = {}
 
     if geometry_encoding.lower() == "geoarrow":
-        if Version(pa.__version__) < Version("10.0.0"):
-            raise ValueError("Converting to 'geoarrow' requires pyarrow >= 10.0.")
-
         # Encode all geometry columns to GeoArrow
         for i, col in zip(geometry_indices, geometry_columns):
             field, geom_arr = construct_geometry_array(

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -481,11 +481,6 @@ def _to_feather(df, path, index=None, compression=None, schema_version=None, **k
     feather = import_optional_dependency(
         "pyarrow.feather", extra="pyarrow is required for Feather support."
     )
-    # TODO move this into `import_optional_dependency`
-    import pyarrow
-
-    if Version(pyarrow.__version__) < Version("0.17.0"):
-        raise ImportError("pyarrow >= 0.17 required for Feather support")
 
     path = _expand_user(path)
     table = _geopandas_to_arrow(df, index=index, schema_version=schema_version)
@@ -568,14 +563,7 @@ def _get_filesystem_path(path, filesystem=None, storage_options=None):
 
     If the filesystem is not None then it's just returned as is.
     """
-    import pyarrow
-
-    if (
-        isinstance(path, str)
-        and storage_options is None
-        and filesystem is None
-        and Version(pyarrow.__version__) >= Version("5.0.0")
-    ):
+    if isinstance(path, str) and storage_options is None and filesystem is None:
         # Use the native pyarrow filesystem if possible.
         try:
             from pyarrow.fs import FileSystem
@@ -841,13 +829,7 @@ def _read_feather(path, columns=None, **kwargs):
     feather = import_optional_dependency(
         "pyarrow.feather", extra="pyarrow is required for Feather support."
     )
-    # TODO move this into `import_optional_dependency`
-    import pyarrow
-
     import geopandas.io._pyarrow_hotfix  # noqa: F401
-
-    if Version(pyarrow.__version__) < Version("0.17.0"):
-        raise ImportError("pyarrow >= 0.17 required for Feather support")
 
     path = _expand_user(path)
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -45,18 +45,7 @@ import pyarrow.parquet as pq
 from pyarrow import feather
 
 
-@pytest.fixture(
-    params=[
-        "parquet",
-        pytest.param(
-            "feather",
-            marks=pytest.mark.skipif(
-                Version(pyarrow.__version__) < Version("0.17.0"),
-                reason="needs pyarrow >= 0.17",
-            ),
-        ),
-    ]
-)
+@pytest.fixture(params=["parquet", pytest.param("feather")])
 def file_format(request):
     if request.param == "parquet":
         return read_parquet, GeoDataFrame.to_parquet
@@ -487,10 +476,6 @@ def test_parquet_compression(compression, tmpdir, naturalearth_lowres):
     assert_geodataframe_equal(df, pq_df)
 
 
-@pytest.mark.skipif(
-    Version(pyarrow.__version__) < Version("0.17.0"),
-    reason="Feather only supported for pyarrow >= 0.17",
-)
 @pytest.mark.parametrize("compression", ["uncompressed", "lz4", "zstd"])
 def test_feather_compression(compression, tmpdir, naturalearth_lowres):
     """Using compression options should not raise errors, and should
@@ -705,10 +690,6 @@ def test_default_geo_col_writes(tmp_path):
     assert_frame_equal(df, pq_df)
 
 
-@pytest.mark.skipif(
-    Version(pyarrow.__version__) >= Version("0.17.0"),
-    reason="Feather only supported for pyarrow >= 0.17",
-)
 def test_feather_arrow_version(tmpdir, naturalearth_lowres):
     df = read_file(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.feather")
@@ -755,10 +736,6 @@ def test_non_fsspec_url_with_storage_options_raises(naturalearth_lowres):
         read_parquet(naturalearth_lowres, storage_options={"foo": "bar"})
 
 
-@pytest.mark.skipif(
-    Version(pyarrow.__version__) < Version("5.0.0"),
-    reason="pyarrow.fs requires pyarrow>=5.0.0",
-)
 def test_prefers_pyarrow_fs():
     filesystem, _ = _get_filesystem_path("file:///data.parquet")
     assert isinstance(filesystem, pyarrow.fs.LocalFileSystem)

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -690,16 +690,6 @@ def test_default_geo_col_writes(tmp_path):
     assert_frame_equal(df, pq_df)
 
 
-def test_feather_arrow_version(tmpdir, naturalearth_lowres):
-    df = read_file(naturalearth_lowres)
-    filename = os.path.join(str(tmpdir), "test.feather")
-
-    with pytest.raises(
-        ImportError, match="pyarrow >= 0.17 required for Feather support"
-    ):
-        df.to_feather(filename)
-
-
 def test_fsspec_url(naturalearth_lowres):
     _ = pytest.importorskip("fsspec")
     import fsspec.implementations.memory

--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -25,7 +25,7 @@ from pandas.tests.extension import base as extension_tests
 import shapely.geometry
 from shapely.geometry import Point
 
-from geopandas._compat import PANDAS_GE_15, PANDAS_GE_21, PANDAS_GE_22
+from geopandas._compat import PANDAS_GE_21, PANDAS_GE_22
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 
 import pytest
@@ -557,16 +557,10 @@ class TestComparisonOps(extension_tests.BaseComparisonOpsTests):
 
 
 class TestMethods(extension_tests.BaseMethodsTests):
-    @pytest.mark.skipif(
-        not PANDAS_GE_15, reason="sorting index not yet working with older pandas"
-    )
     @pytest.mark.parametrize("dropna", [True, False])
     def test_value_counts(self, all_data, dropna):
         pass
 
-    @pytest.mark.skipif(
-        not PANDAS_GE_15, reason="sorting index not yet working with older pandas"
-    )
     def test_value_counts_with_normalize(self, data):
         pass
 


### PR DESCRIPTION
Follow up to #3371 after I noticed in #3413 that we still had a compat version defined for pandas 1.5. Using the pyproject.toml as the source of truth here