### PR TITLE
CI: use pre-commit.ci for linting checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,18 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Linting:
-    runs-on: ubuntu-latest
-
-    # skip scheduled runs on forks
-    if: (github.event_name == 'schedule' && github.repository == 'geopandas/geopandas') || (github.event_name != 'schedule')
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.1
-
   Test:
-    needs: Linting
     name: ${{ matrix.os }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
     autofix_prs: false
-    autoupdate_schedule: weekly
+    autoupdate_schedule: quarterly
 
 files: 'geopandas\/'
 repos:


### PR DESCRIPTION
The linting part of our CI has started failing on the action setup. Given the action is in maintenance mode only and its readme suggests using pre-commit.ci, this PR does exactly that. I have enabled pre-commit.ci for this repo.