### PR TITLE
COMPAT: avoid np.array(.., copy=False) for pandas objects

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1046,8 +1046,8 @@ individually so that features may have different properties
                 f"'{self._geometry_column_name}')."
             )
 
-        ids = np.array(self.index, copy=False)
-        geometries = np.array(self[self._geometry_column_name], copy=False)
+        ids = np.asarray(self.index)
+        geometries = np.asarray(self[self._geometry_column_name])
 
         if not self.columns.is_unique:
             raise ValueError("GeoDataFrame cannot contain duplicated column names.")


### PR DESCRIPTION
Similar as https://github.com/geopandas/geopandas/pull/3235, but now for the remaining cases where we are doing this with pandas objects (now that pandas `main` branch implements the correct numpy semantics).

This should fix the failures on the dev CI build.