### PR TITLE
Introducing GeoPandas Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/geopandas/geopandas/main)
 [![DOI](https://zenodo.org/badge/11002815.svg)](https://zenodo.org/badge/latestdoi/11002815)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20GeoPandas%20Guru-006BFF)](https://gurubase.io/g/geopandas)
 
 GeoPandas
 ---------


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GeoPandas Guru](https://gurubase.io/g/geopandas) to Gurubase. GeoPandas Guru uses the data from this repo and data from the [docs](http://geopandas.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "GeoPandas Guru", which highlights that GeoPandas now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GeoPandas Guru in Gurubase, just let me know that's totally fine.
