### PR TITLE
COMPAT: Delete the `GeoSeries.append` method (removed in pandas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Bug fixes:
 
 - Fix an issue that showed numpy dtypes in bbox in `to_geo_dict` and `__geo_interface__`. (#3436)
 
+Deprecations and compatibility notes:
+
+- The `GeoSeries.append` method wrapping the removed pandas `Series.append` method has been
+  removed (#3460).
+
 ## Version 1.0.2 (???)
 
 Bug fixes:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -233,9 +233,6 @@ class GeoSeries(GeoPandasBase, Series):
         if not self.crs:
             self.crs = crs
 
-    def append(self, *args, **kwargs) -> GeoSeries:
-        return self._wrapped_pandas_method("append", *args, **kwargs)
-
     @GeoPandasBase.crs.setter
     def crs(self, value):
         if self.crs is not None:

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -71,18 +71,6 @@ class TestSeriesSindex:
         s = GeoSeries([t1, t2, sq])
         assert s.sindex.size == 3
 
-    @pytest.mark.filterwarnings("ignore:The series.append method is deprecated")
-    @pytest.mark.skipif(compat.PANDAS_GE_20, reason="append removed in pandas 2.0")
-    def test_polygons_append(self):
-        t1 = Polygon([(0, 0), (1, 0), (1, 1)])
-        t2 = Polygon([(0, 0), (1, 1), (0, 1)])
-        sq = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        s = GeoSeries([t1, t2, sq])
-        t = GeoSeries([t1, t2, sq], [3, 4, 5])
-        s = s.append(t)
-        assert len(s) == 6
-        assert s.sindex.size == 6
-
     def test_lazy_build(self):
         s = GeoSeries([Point(0, 0)])
         assert s.values._sindex is None


### PR DESCRIPTION
Similar to #3394

Calling `append` on a geoseries raises `AttributeError: 'super' object has no attribute 'append'`.

The upstream method has been removed in [pandas 2.0](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes), the minimum supported version in pyproject.toml