### PR TITLE
ENH: add support for pd.Index for column kwarg in geodataframe.plot()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ files based on a bounding box, and write out a bounding box column to parquet fi
   instead of its current behaviour of assuming EPSG. In the event the spiatal_ref_sys
   table is not present, or the SRID is not present, `read_postgis` will fallback
   on assuming EPSG CRS authority. (#3329)
+- `plot_dataframe` now supports pd.Index as a column to permit colouring based on the
+   geodataframe's index ``GeoDataFrame.plot(column=GeoDataFrame.index). (#TBA)
 
 Backwards incompatible API changes:
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -514,10 +514,11 @@ def plot_dataframe(
 
     Parameters
     ----------
-    column : str, np.array, pd.Series (default None)
-        The name of the dataframe column, np.array, or pd.Series to be plotted.
-        If np.array or pd.Series are used then it must have same length as
-        dataframe. Values are used to color the plot. Ignored if `color` is
+    column : str, np.array, pd.Series, pd.Index (default None)
+        The name of the dataframe column, np.array, pd.Series, or pd.Index
+        to be plotted. If np.array, pd.Series, or pd.Index are used then it
+        must have same length as dataframe.
+        Values are used to color the plot. Ignored if `color` is
         also set.
     kind: str
         The kind of plots to produce. The default is to create a map ("geo").
@@ -699,11 +700,13 @@ def plot_dataframe(
         )
 
     # To accept pd.Series and np.arrays as column
-    if isinstance(column, np.ndarray | pd.Series):
+    if isinstance(column, np.ndarray | pd.Series | pd.Index):
         if column.shape[0] != df.shape[0]:
             raise ValueError(
                 "The dataframe and given column have different number of rows."
             )
+        elif isinstance(column, pd.Index):
+            values = column.values
         else:
             values = column
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1833,7 +1833,7 @@ def test_column_values():
     # Build test data
     t1 = Polygon([(0, 0), (1, 0), (1, 1)])
     t2 = Polygon([(1, 0), (2, 0), (2, 1)])
-    polys = GeoSeries([t1, t2], index=list("AB"))
+    polys = GeoSeries([t1, t2], index=[0, 1])
     df = GeoDataFrame({"geometry": polys, "values": [0, 1]})
 
     # Test with continuous values
@@ -1853,6 +1853,11 @@ def test_column_values():
     colors_series = ax.collections[0].get_facecolors()
     np.testing.assert_array_equal(colors, colors_series)
     ax = df.plot(column=df["values"].values, categorical=True)
+    colors_array = ax.collections[0].get_facecolors()
+    np.testing.assert_array_equal(colors, colors_array)
+
+    # Test with pd.Index
+    ax = df.plot(column=df.index, categorical=True)
     colors_array = ax.collections[0].get_facecolors()
     np.testing.assert_array_equal(colors, colors_array)
 


### PR DESCRIPTION
In #3357, a user raised it would be nice to have better support for plotting colours based on the index and suggested a few different methods. @martinfleis  agreed and suggested allowing the `column` kwarg in `gdf.plot()` to accept `pd.Index` types would be the preferred approach.

This PR allows feeding `pd.Index` as a type to the `column` kwarg