### PR TITLE
ENH: add error message when reading dataset without crs with a GeoDataFrame or GeoSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Bug fixes:
 
 - Fix an issue that showed numpy dtypes in bbox in `to_geo_dict` and `__geo_interface__`. (#3436)
 
+New features and improvements:
+
+- An error message is raised when `read_file` is used wth a GeoDataFrame or GeoSeries mask 
+  to read a source dataset without a defined CRS. (#####)
+
 ## Version 1.0.2 (???)
 
 Bug fixes:

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -495,6 +495,11 @@ def _read_file_pyogrio(path_or_bytes, bbox=None, mask=None, rows=None, **kwargs)
         # NOTE: mask cannot be used at same time as bbox keyword
         if isinstance(mask, GeoDataFrame | GeoSeries):
             crs = pyogrio.read_info(path_or_bytes, layer=kwargs.get("layer")).get("crs")
+
+            if crs is None:
+                raise ValueError("""There is no CRS defined in the source dataset.
+                           This is required when a geodataframe mask is used.""")
+
             if isinstance(path_or_bytes, IOBase):
                 path_or_bytes.seek(0)
 


### PR DESCRIPTION
Issue #3444 raised an error where reading a gdb file without a CRS with a geodataframe mask. The error was quickly identified by it was noted in the thread by maintainers that it would be good to raise an informative error in this case.

