### PR TITLE
BUG: fix uniform sampling of polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ New features and improvements:
 Bug fixes:
 
 - Fix an issue that showed numpy dtypes in bbox in `to_geo_dict` and `__geo_interface__`. (#3436)
+- Fix an issue in `sample_points` that could occasionally result in non-uniform distribution (#3471å)
 
 New features and improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ New features and improvements:
 Bug fixes:
 
 - Fix an issue that showed numpy dtypes in bbox in `to_geo_dict` and `__geo_interface__`. (#3436)
-- Fix an issue in `sample_points` that could occasionally result in non-uniform distribution (#3471å)
+- Fix an issue in `sample_points` that could occasionally result in non-uniform distribution (#3470)
 
 New features and improvements:
 

--- a/geopandas/tools/_random.py
+++ b/geopandas/tools/_random.py
@@ -1,3 +1,4 @@
+from random import shuffle
 from warnings import warn
 
 import numpy
@@ -86,4 +87,5 @@ def _uniform_polygon(geom, size, generator):
         )
         valid_samples = batch[batch.sindex.query(geom, predicate="contains")]
         candidates.extend(valid_samples)
+    shuffle(candidates)  # avoid the artifacts of STRTree ordering
     return GeoSeries(candidates[:size]).union_all()

--- a/geopandas/tools/_random.py
+++ b/geopandas/tools/_random.py
@@ -1,4 +1,3 @@
-from random import shuffle
 from warnings import warn
 
 import numpy
@@ -87,5 +86,5 @@ def _uniform_polygon(geom, size, generator):
         )
         valid_samples = batch[batch.sindex.query(geom, predicate="contains")]
         candidates.extend(valid_samples)
-    shuffle(candidates)  # avoid the artifacts of STRTree ordering
+    generator.shuffle(candidates)  # avoid the artifacts of STRTree ordering
     return GeoSeries(candidates[:size]).union_all()

--- a/geopandas/tools/tests/test_random.py
+++ b/geopandas/tools/tests/test_random.py
@@ -1,5 +1,7 @@
 import numpy
 
+import shapely
+
 import geopandas
 from geopandas.tools._random import uniform
 
@@ -65,3 +67,21 @@ def test_uniform_generator(polygons):
 
     assert sample.equals(gen_sample)
     assert not sample.equals(gen_sample2)
+
+
+def test_unimodality():  # GH 3470
+    circle = shapely.Point(0, 0).buffer(1)
+    generator = numpy.random.default_rng(seed=1)
+    centers_x = []
+    centers_y = []
+    for i in range(200):
+        pts = shapely.get_coordinates(uniform(circle, size=2**10, rng=generator))
+        centers_x.append(numpy.mean(pts[:, 0]))
+        centers_y.append(numpy.mean(pts[:, 1]))
+
+    numpy.testing.assert_allclose(numpy.mean(centers_x), 0, atol=1e-2)
+    numpy.testing.assert_allclose(numpy.mean(centers_y), 0, atol=1e-2)
+
+    stats = pytest.importorskip("scipy.stats")
+    assert stats.shapiro(centers_x).pvalue > 0.05
+    assert stats.shapiro(centers_y).pvalue > 0.05

--- a/geopandas/tools/tests/test_random.py
+++ b/geopandas/tools/tests/test_random.py
@@ -69,13 +69,14 @@ def test_uniform_generator(polygons):
     assert not sample.equals(gen_sample2)
 
 
-def test_unimodality():  # GH 3470
+@pytest.mark.parametrize("size", range(5, 12))
+def test_unimodality(size):  # GH 3470
     circle = shapely.Point(0, 0).buffer(1)
     generator = numpy.random.default_rng(seed=1)
     centers_x = []
     centers_y = []
-    for i in range(200):
-        pts = shapely.get_coordinates(uniform(circle, size=2**10, rng=generator))
+    for _ in range(200):
+        pts = shapely.get_coordinates(uniform(circle, size=2**size, rng=generator))
         centers_x.append(numpy.mean(pts[:, 0]))
         centers_y.append(numpy.mean(pts[:, 1]))
 


### PR DESCRIPTION
Closes #3470 

It turns out that when we retain the order of points provided by the `STRTree.query`, we break the distribution as the internal structure of the tree propagates to the result.