### PR TITLE
Use correct binary dependency of psycopg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 all = [
-    "psycopg-binary>=3.1.0",
+    "psycopg[binary]>=3.1.0",
     "SQLAlchemy>=2.0",
     "geopy",
     "matplotlib>=3.7",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ packaging
 
 # geodatabase access
 psycopg2-binary>=2.8.0
-psycopg-binary>=3.1.0
+psycopg[binary]>=3.1.0
 SQLAlchemy>=2.0
 
 # geocoding


### PR DESCRIPTION
When this was added for version 2, it may have made sense to use `psycopg2-binary`. However, with version 3, the upstream docs [1] say _not_ to use `psycopg-binary`, but the `psycopg[binary]` extra instead.

[1] https://pypi.org/project/psycopg-binary/