### PR TITLE
In `GeoDataFrame.to_parquet` rename `geoarrow` keyword argument to `native`

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1333,12 +1333,15 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         compression : {'snappy', 'gzip', 'brotli', 'lz4', 'zstd', None}, \
 default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        geometry_encoding : {'WKB', 'geoarrow'}, default 'WKB'
-            The encoding to use for the geometry columns. Defaults to "WKB"
-            for maximum interoperability. Specify "geoarrow" to use one of the
-            native GeoArrow-based single-geometry type encodings.
-            Note: the "geoarrow" option is part of the newer GeoParquet 1.1
-            specification, should be considered as experimental, and may not
+        geometry_encoding : {'WKB', 'native', 'geoarrow'}, default 'WKB'
+            The encoding to use for the geometry columns. Defaults to "WKB" for maximum
+            interoperability. Specify "native" (or, for backwards compatibility,
+            "geoarrow")  to use one of the native single-geometry type encodings.
+
+            The native GeoParquet encodings are similar to the layout of GeoArrow.
+
+            Note: the "native" option is part of the newer GeoParquet 1.1
+            specification. It should be considered experimental, and may not
             be supported by all readers.
         write_covering_bbox : bool, default False
             Writes the bounding box column for each row entry with column

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -417,9 +417,9 @@ def _to_parquet(
         output except `RangeIndex` which is stored as metadata only.
     compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
         Name of the compression to use. Use ``None`` for no compression.
-    geometry_encoding : {'WKB', 'geoarrow'}, default 'WKB'
+    geometry_encoding : {'WKB', 'native', 'geoarrow'}, default 'WKB'
         The encoding to use for the geometry columns. Defaults to "WKB"
-        for maximum interoperability. Specify "geoarrow" to use one of the
+        for maximum interoperability. Specify "native" or "geoarrow" to use one of the
         native GeoArrow-based single-geometry type encodings.
     schema_version : {'0.1.0', '0.4.0', '1.0.0', '1.1.0', None}
         GeoParquet specification version; if not provided will default to
@@ -434,6 +434,10 @@ def _to_parquet(
     parquet = import_optional_dependency(
         "pyarrow.parquet", extra="pyarrow is required for Parquet support."
     )
+
+    # Map "native" to "geoarrow", required for the _geopandas_to_arrow function
+    if geometry_encoding == "native":
+        geometry_encoding = "geoarrow"
 
     path = _expand_user(path)
     table = _geopandas_to_arrow(


### PR DESCRIPTION
I've had multiple people ask me what the `geometry_encoding="geoarrow"` keyword does. We're writing to GeoParquet... but this is GeoArrow in GeoParquet? Huh? 

I think the term "GeoArrow" is too overloaded, where here it refers to the "geoarrow-like" geometry encoding, rather than the in-memory format. I think it would be clearer to have users refer to the GeoParquet encoding as "native" rather than "geoarrow".