### PR TITLE
[WIP] Attempt support for creating GeoPandas arrays from pyarrow.Table.to_pandas()

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -69,6 +69,11 @@ class GeometryDtype(ExtensionDtype):
     def construct_array_type(cls):
         return GeometryArray
 
+    def __from_arrow__(self, array) -> ExtensionArray:
+        from .io import _geoarrow
+
+        return _geoarrow.arrow_to_geometry_array(array)
+
 
 register_extension_dtype(GeometryDtype)
 

--- a/geopandas/io/_geoarrow.py
+++ b/geopandas/io/_geoarrow.py
@@ -511,6 +511,12 @@ def arrow_to_geometry_array(arr):
     if Version(pa.__version__) < Version("14.0.0"):
         raise ValueError("Importing from Arrow requires pyarrow >= 14.0.")
 
+    if type(arr).__name__ == "ChunkedArray":
+        if len(arr) == 0:
+            arr = pa.array([], arr.type)
+        else:
+            arr = pa.concat_arrays(arr.chunks)
+
     schema_capsule, array_capsule = arr.__arrow_c_array__()
     field = pa.Field._import_from_c_capsule(schema_capsule)
     pa_arr = pa.Array._import_from_c_capsule(field.__arrow_c_schema__(), array_capsule)


### PR DESCRIPTION
Just some local changes I'm playing with while working on https://github.com/geoarrow/geoarrow-python/pull/63 . It would be great to return GeoPandas here, although with the current geopandas I get errors if I change:

https://github.com/geoarrow/geoarrow-python/blob/0b7c502699947f97c1ae2036260e4fe819f717ae/geoarrow-types/src/geoarrow/types/type_pyarrow.py#L66-L71

to `GeometryDtype`.