### PR TITLE
BUG: Fix constructor crash with column named crs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New features and improvements:
 - `GeoDataFrame.plot` now supports `pd.Index` as an input for the `column` keyword (#3463).
 - Avoid change of the plot aspect when plotting missing values (#3438).
 - Improve performance of `overlay` with `how=identity` (#3504).
-- Fix another ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502)
+- Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502)
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features and improvements:
 - Add ``grid_size`` parameter to ``union_all`` and ``dissolve`` (#3445).
 - `GeoDataFrame.plot` now supports `pd.Index` as an input for the `column` keyword (#3463).
 - Avoid change of the plot aspect when plotting missing values (#3438).
+- Fix another ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502)
 
 Bug fixes:
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1960,7 +1960,7 @@ default 'snappy'
             or (key == "geometry" and self._geometry_column_name is None)
         ):
             if pd.api.types.is_scalar(value) or isinstance(value, BaseGeometry):
-                value = [value for _ in range(self.shape[0])]
+                value = [value] * self.shape[0]
 
             crs = getattr(self, "crs", None)
             # if we don't have a GeoDataframe yet and there is a column named crs,

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1572,6 +1572,22 @@ def test_geodataframe_crs_colname():
     assert gdf["crs"].iloc[0] == 1
     assert getattr(gdf, "crs") is None
 
+    # https://github.com/geopandas/geopandas/issues/3501
+    gdf = GeoDataFrame({"crs": [1]}, geometry=[Point(1, 1)])
+    assert gdf.crs is None
+    assert gdf["crs"].iloc[0] == 1
+    assert getattr(gdf, "crs") is None
+
+    # test multiindex handling
+    df = pd.DataFrame([[1, 0], [0, 1]], columns=[["crs", "crs"], ["x", "y"]])
+    x_col = df["crs", "x"]
+    y_col = df["crs", "y"]
+
+    gdf = GeoDataFrame(df, geometry=points_from_xy(x_col, y_col))
+    assert gdf.crs is None
+    assert gdf["crs"].iloc[0].to_list() == [1, 0]
+    assert getattr(gdf, "crs") is None
+
 
 @pytest.mark.parametrize("geo_col_name", ["geometry", "polygons"])
 def test_set_geometry_supply_colname(dfs, geo_col_name):


### PR DESCRIPTION
Closes #3501.

This issue comes up because the fix in #2577 uses `_geometry_column_name` to discern if we already should a GeoDataFrame.crs attribute. But in `set_geometry` we set the name before we do the setitem so this doesn't work.