### PR TITLE
Do not hardcode GeoDataFrame for easier subclassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features and improvements:
 - Add ``grid_size`` parameter to ``union_all`` and ``dissolve`` (#3445).
 - `GeoDataFrame.plot` now supports `pd.Index` as an input for the `column` keyword (#3463).
 - Avoid change of the plot aspect when plotting missing values (#3438).
+- GeoDataFrame no longer hard-codes the class internally, allowing easier subclassing (#3505).
 
 Bug fixes:
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1908,7 +1908,7 @@ default 'snappy'
             result.__class__ = GeoSeries
         elif isinstance(result, DataFrame):
             if (result.dtypes == "geometry").sum() > 0:
-                result.__class__ = self.__class__
+                result.__class__ = type(self)
                 if geo_col in result:
                     result._geometry_column_name = geo_col
             else:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1967,7 +1967,7 @@ default 'snappy'
     def copy(self, deep: bool = True) -> GeoDataFrame:
         copied = super().copy(deep=deep)
         if type(copied) is pd.DataFrame:
-            copied.__class__ = self.__class__
+            copied.__class__ = type(self)
             copied._geometry_column_name = self._geometry_column_name
         return copied
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2258,7 +2258,9 @@ default 'snappy'
         )
 
         # Aggregate
-        aggregated_geometry = GeoDataFrame(g, geometry=self.geometry.name, crs=self.crs)
+        aggregated_geometry = self._constructor(
+            g, geometry=self.geometry.name, crs=self.crs
+        )
         # Recombine
         aggregated = aggregated_geometry.join(aggregated_data)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2260,7 +2260,7 @@ default 'snappy'
         )
 
         # Aggregate
-        aggregated_geometry = self._constructor(
+        aggregated_geometry = self.__class__(
             g, geometry=self.geometry.name, crs=self.crs
         )
         # Recombine

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1924,7 +1924,7 @@ default 'snappy'
             result.__class__ = GeoSeries
         elif isinstance(result, DataFrame):
             if (result.dtypes == "geometry").sum() > 0:
-                result.__class__ = GeoDataFrame
+                result.__class__ = self.__class__
                 if geo_col in result:
                     result._geometry_column_name = geo_col
             else:
@@ -1983,7 +1983,7 @@ default 'snappy'
     def copy(self, deep: bool = True) -> GeoDataFrame:
         copied = super().copy(deep=deep)
         if type(copied) is pd.DataFrame:
-            copied.__class__ = GeoDataFrame
+            copied.__class__ = self.__class__
             copied._geometry_column_name = self._geometry_column_name
         return copied
 
@@ -2038,7 +2038,7 @@ default 'snappy'
             return _geodataframe_constructor_with_fallback(
                 pd.DataFrame._from_mgr(mgr, axes)
             )
-        gdf = GeoDataFrame._from_mgr(mgr, axes)
+        gdf = self._from_mgr(mgr, axes)
         # _from_mgr doesn't preserve metadata (expect __finalize__ to be called)
         # still need to mimic __init__ behaviour with geometry=None
         if (gdf.columns == "geometry").sum() == 1:  # only if "geometry" is single col

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2260,9 +2260,7 @@ default 'snappy'
         )
 
         # Aggregate
-        aggregated_geometry = type(self)(
-            g, geometry=self.geometry.name, crs=self.crs
-        )
+        aggregated_geometry = type(self)(g, geometry=self.geometry.name, crs=self.crs)
         # Recombine
         aggregated = aggregated_geometry.join(aggregated_data)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2260,7 +2260,7 @@ default 'snappy'
         )
 
         # Aggregate
-        aggregated_geometry = self.__class__(
+        aggregated_geometry = type(self)(
             g, geometry=self.geometry.name, crs=self.crs
         )
         # Recombine

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2031,7 +2031,7 @@ default 'snappy'
 
     @property
     def _constructor(self) -> DataFrame | GeoDataFrame:
-        return self.__class__._geodataframe_constructor_with_fallback
+        return self._geodataframe_constructor_with_fallback
 
     def _constructor_from_mgr(self, mgr, axes) -> DataFrame | GeoDataFrame:
         # replicate _geodataframe_constructor_with_fallback behaviour

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -674,7 +674,6 @@ class TestGeometryArrayCRS:
         arr = from_shapely(self.geoms, crs=27700)
         df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
         df2 = df.astype({"col1": str})
-        print(type(df), type(df2))
         assert df2.crs == self.osgb
 
     def test_apply(self):

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -674,6 +674,7 @@ class TestGeometryArrayCRS:
         arr = from_shapely(self.geoms, crs=27700)
         df = GeoDataFrame({"col1": [0, 1]}, geometry=arr)
         df2 = df.astype({"col1": str})
+        print(type(df), type(df2))
         assert df2.crs == self.osgb
 
     def test_apply(self):

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1674,6 +1674,8 @@ def test_inheritance(dfs):
         dfc,
         dfc.iloc[[0]],
         dfc.loc[dfc.col1 == 1],
+        dfc.rename_geometry("geometry2"),
+        dfc.dissolve(),
         dfc[["col2", "geometry"]],
         dfc.copy(),
     ]

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1653,3 +1653,31 @@ def test_reduce_geometry_array():
     This warning is issued with pandas 2.2.2 (tested).
     """
     GeoDataFrame({"geometry": []}).all()
+
+
+class GDFChild(GeoDataFrame):
+    @property
+    def _constructor(self):
+        return GDFChild
+
+    def custom_method(self):
+        return "this is a custom output"
+
+
+def test_inheritance(dfs):
+    df, _ = dfs
+    df.loc[:, "col2"] = ["a"] * len(df)
+
+    dfc = GDFChild(df)
+
+    children = [
+        dfc,
+        dfc.iloc[[0]],
+        dfc.loc[dfc.col1 == 1],
+        dfc[["col2", "geometry"]],
+        dfc.copy(),
+    ]
+
+    for v in children:
+        assert isinstance(v, GDFChild)
+        assert v.custom_method() == "this is a custom output"

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1656,10 +1656,6 @@ def test_reduce_geometry_array():
 
 
 class GDFChild(GeoDataFrame):
-    @property
-    def _constructor(self):
-        return GDFChild
-
     def custom_method(self):
         return "this is a custom output"
 

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1690,3 +1690,7 @@ def test_inheritance(dfs):
     for v in children:
         assert isinstance(v, GDFChild)
         assert v.custom_method() == "this is a custom output"
+
+    df2 = dfc2.drop(columns=["geometry2"])
+
+    assert not isinstance(df2, GDFChild)

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1670,14 +1670,21 @@ def test_inheritance(dfs):
 
     dfc = GDFChild(df)
 
+    dfc2 = dfc.rename_geometry("geometry2")
+
     children = [
         dfc,
         dfc.iloc[[0]],
         dfc.loc[dfc.col1 == 1],
-        dfc.rename_geometry("geometry2"),
         dfc.dissolve(),
         dfc[["col2", "geometry"]],
         dfc.copy(),
+        dfc2,
+        dfc2.iloc[[0]],
+        dfc2.loc[dfc.col1 == 1],
+        dfc2.dissolve(),
+        dfc2[["col2", "geometry2"]],
+        dfc2.copy(),
     ]
 
     for v in children:


### PR DESCRIPTION
At the moment, subclassing ``GeoDataFrame`` requires to patch a few more functions than just ``_constructor`` so that the new object does not switch back to ``GeoDataFrame`` after several operations like ``__getitem__``, ``.loc`` or ``copy``.

In the spirit of the previous discussion and PR on the same topic (#2750), I'd propose to use the object class/method rather than directly ``GeoDataFrame`` in the affected functions.