### PR TITLE
BUG: Fix crs representation of GeoArrow metadata

### DIFF
--- a/geopandas/io/_geoarrow.py
+++ b/geopandas/io/_geoarrow.py
@@ -186,7 +186,7 @@ def construct_wkb_array(
     extension_metadata = {"ARROW:extension:name": "geoarrow.wkb"}
     if crs is not None:
         extension_metadata["ARROW:extension:metadata"] = json.dumps(
-            {"crs": crs.to_json()}
+            {"crs": crs.to_json_dict()}
         )
     else:
         # In theory this should not be needed, but otherwise pyarrow < 17
@@ -319,7 +319,7 @@ def construct_geometry_array(
     extension_metadata: dict[str, str] = {}
     if crs is not None:
         extension_metadata["ARROW:extension:metadata"] = json.dumps(
-            {"crs": crs.to_json()}
+            {"crs": crs.to_json_dict()}
         )
     else:
         # In theory this should not be needed, but otherwise pyarrow < 17

--- a/geopandas/io/tests/test_geoarrow.py
+++ b/geopandas/io/tests/test_geoarrow.py
@@ -210,11 +210,11 @@ def test_geoarrow_multiple_geometry_crs(encoding):
     meta1 = json.loads(
         result.schema.field("geometry").metadata[b"ARROW:extension:metadata"]
     )
-    assert json.loads(meta1["crs"])["id"]["code"] == 4326
+    assert meta1["crs"]["id"]["code"] == 4326
     meta2 = json.loads(
         result.schema.field("geom2").metadata[b"ARROW:extension:metadata"]
     )
-    assert json.loads(meta2["crs"])["id"]["code"] == 3857
+    assert meta2["crs"]["id"]["code"] == 3857
 
     roundtripped = GeoDataFrame.from_arrow(result)
     assert_geodataframe_equal(gdf, roundtripped)
@@ -237,7 +237,7 @@ def test_geoarrow_series_name_crs(encoding):
         else b"geoarrow.polygon"
     )
     meta = json.loads(field.metadata[b"ARROW:extension:metadata"])
-    assert json.loads(meta["crs"])["id"]["code"] == 4326
+    assert meta["crs"]["id"]["code"] == 4326
 
     # ensure it also works without a name
     gser = GeoSeries([box(0, 0, 10, 10)])


### PR DESCRIPTION
Before this PR, GeoArrow `"crs"` metadata was a stringified-and-escaped JSON object, whereas a regular JSON object is what other implementations expect (and produce). (Implementations also accept a string that can be passed to PROJ generally, which is probably why this worked before!)

After this PR:

```python
import geopandas
import pyarrow as pa

df = geopandas.GeoDataFrame({"geometry": geopandas.GeoSeries.from_wkt(["POINT (0 1)"], crs="OGC:CRS84")})
pa.table(df.to_arrow()).schema.field(0).metadata
#> {b'ARROW:extension:name': b'geoarrow.wkb',
#>  b'ARROW:extension:metadata': b'{"crs": {"$schema": "https://proj.org/schemas/v0.7/projjson.schema.json", "type"...
```

Closes #3512.