### PR TITLE
[WIP] ENH: add preliminary support for using spherely as geometry engine

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -7,10 +7,9 @@ from pandas import DataFrame, Series
 
 import shapely
 from shapely.geometry import MultiPoint, box
-from shapely.geometry.base import BaseGeometry
 
 from . import _compat as compat
-from .array import GeometryArray, GeometryDtype, points_from_xy
+from .array import BaseGeometryArray, GeometryArray, GeometryDtype, points_from_xy
 
 
 def is_geometry_type(data):
@@ -50,10 +49,10 @@ def _delegate_binary_method(op, this, other, align, *args, **kwargs):
         else:
             other = other.geometry
 
-        a_this = GeometryArray(this.values)
-        other = GeometryArray(other.values)
-    elif isinstance(other, BaseGeometry):
-        a_this = GeometryArray(this.values)
+        a_this = this.values
+        other = other.values
+    elif isinstance(other, this.dtype.type):
+        a_this = this.values
     else:
         raise TypeError(type(this), type(other))
 
@@ -79,9 +78,9 @@ def _binary_op(op, this, other, align, *args, **kwargs):
 
 def _delegate_property(op, this):
     # type: (str, GeoSeries) -> GeoSeries/Series
-    a_this = GeometryArray(this.geometry.values)
+    a_this = this.geometry.values
     data = getattr(a_this, op)
-    if isinstance(data, GeometryArray):
+    if isinstance(data, BaseGeometryArray):
         from .geoseries import GeoSeries
 
         return GeoSeries(data, index=this.index, crs=this.crs)
@@ -115,7 +114,7 @@ def _delegate_geo_method(op, this, **kwargs):
                 )
             kwargs[key] = np.asarray(val)
 
-    a_this = GeometryArray(this.geometry.values)
+    a_this = this.geometry.values
     data = getattr(a_this, op)(**kwargs)
     return GeoSeries(data, index=this.index, crs=this.crs)
 

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -10,7 +10,7 @@ from shapely.geometry import mapping, shape
 from shapely.geometry.base import BaseGeometry
 
 import geopandas.io
-from geopandas.array import GeometryArray, GeometryDtype, from_shapely, to_wkb, to_wkt
+from geopandas.array import GeometryArray, GeometryDtype, from_shapely, to_wkt
 from geopandas.base import GeoPandasBase, is_geometry_type
 from geopandas.explore import _explore
 from geopandas.geoseries import GeoSeries
@@ -1187,7 +1187,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
 
         # Encode all geometry columns to WKB
         for col in df.columns[df.dtypes == "geometry"]:
-            df[col] = to_wkb(df[col].values, hex=hex, **kwargs)
+            df[col] = df[col].values.to_wkb(hex=hex, **kwargs)
 
         return df
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -26,7 +26,6 @@ from .array import (
     from_wkb,
     from_wkt,
     points_from_xy,
-    to_wkb,
     to_wkt,
 )
 from .base import is_geometry_type
@@ -1338,7 +1337,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         --------
         GeoSeries.to_wkt
         """
-        return Series(to_wkb(self.array, hex=hex, **kwargs), index=self.index)
+        return Series(self.array.to_wkb(hex=hex, **kwargs), index=self.index)
 
     def to_wkt(self, **kwargs) -> Series:
         """

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -14,7 +14,6 @@ from shapely.geometry import LineString, MultiPolygon, Point, Polygon, box
 import geopandas
 from geopandas import GeoDataFrame, read_feather, read_file, read_parquet
 from geopandas._compat import HAS_PYPROJ
-from geopandas.array import to_wkb
 from geopandas.io.arrow import (
     METADATA_VERSION,
     SUPPORTED_VERSIONS,
@@ -525,7 +524,7 @@ def test_parquet_missing_metadata(tmpdir, naturalearth_lowres):
     df = DataFrame(df)
 
     # convert the geometry column so we can extract later
-    df["geometry"] = to_wkb(df["geometry"].values)
+    df["geometry"] = df["geometry"].to_wkb()
 
     filename = os.path.join(str(tmpdir), "test.pq")
 
@@ -586,7 +585,7 @@ def test_parquet_invalid_metadata(tmpdir, geo_meta, error, naturalearth_lowres):
 
     # convert to DataFrame and encode geometry to WKB
     df = DataFrame(df)
-    df["geometry"] = to_wkb(df["geometry"].values)
+    df["geometry"] = df["geometry"].to_wkb()
 
     table = Table.from_pandas(df)
     metadata = table.schema.metadata


### PR DESCRIPTION
Very much work-in-progress POC of using spherely in geopandas as another geometry engine.

While there are many things to do or improve (implementing some basic things like astype and to_crs, but also just making the NotImplementedErrors more informative with a clear message, or changing them to a TypeError if we think it will never be implemented for spherical geometries; move common parts to a base class, etc), the current PR already does allow some basic things. See https://gist.github.com/jorisvandenbossche/2e8ecee0d109b77e03c45fca7bac385a for an overview.

The approach currently taken here is: have a separate ExtensionArray class (currently called `GeographyArray`), while keeping the single `GeometryDtype` class but parametrizing it with an `engine` parameter (currently with values "planar" (default) and "spherical"; one question with this approach is if we want to describe the type of the engine (planar vs spherical) vs the package being used (shapely vs spherely). 
This means you can do something like to convert an existing geometry column to use the spherical support:

```python
geoseries.astype(geopandas.GeometryDtype(engine="spherical")
# or the shorter string alias if we want to enable this
geoseries.astype("geometry[spherical]")
```

Of course, we could also add a dedicated method for this conversion (`as_spherical` or `to_spherical` or something like that) if that might be easier to use vs the generic type casting.