### PR TITLE
DEPR: remove deprecated geom_almost_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Deprecations and compatibility notes:
 
 - The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
   The upstream method no longer exists in all supported version of pandas (#3394).
+- The `GeoSeries.geom_almost_equals` method has been removed. Use
+  `GeoSeries.geom_equals_exact` instead.
 
 New features and improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Deprecations and compatibility notes:
 - The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
   The upstream method no longer exists in all supported version of pandas (#3394).
 - The `GeoSeries.geom_almost_equals` method has been removed. Use
-  `GeoSeries.geom_equals_exact` instead.
+  `GeoSeries.geom_equals_exact` instead (#3522).
 
 New features and improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Deprecations and compatibility notes:
 
 - The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
   The upstream method no longer exists in all supported version of pandas (#3394).
-- The `GeoSeries.geom_almost_equals` method has been removed. Use
+- The deprecated `GeoSeries.geom_almost_equals` method has been removed. Use
   `GeoSeries.geom_equals_exact` instead (#3522).
 
 New features and improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ Deprecations and compatibility notes:
 
 - The `GeoSeries.select` method wrapping the pandas `Series.select` method has been removed.
   The upstream method no longer exists in all supported version of pandas (#3394).
-- The deprecated `GeoSeries.geom_almost_equals` method has been removed. Use
-  `GeoSeries.geom_equals_exact` instead (#3522).
+- The deprecated `geom_almost_equals` method has been removed. Use
+  `geom_equals_exact` instead (#3522).
 
 New features and improvements:
 

--- a/benchmarks/geom_methods.py
+++ b/benchmarks/geom_methods.py
@@ -57,7 +57,6 @@ class Bench:
                 "touches",
                 "within",
                 "geom_equals",
-                "geom_almost_equals",
                 "geom_equals_exact",
             )
         ],
@@ -77,7 +76,6 @@ class Bench:
                 "touches",
                 "within",
                 "geom_equals",
-                "geom_almost_equals",
             )
         ],
     )  # 'geom_equals_exact')])

--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -69,7 +69,6 @@ Binary predicates
    GeoSeries.disjoint
    GeoSeries.dwithin
    GeoSeries.geom_equals
-   GeoSeries.geom_almost_equals
    GeoSeries.geom_equals_exact
    GeoSeries.intersects
    GeoSeries.overlaps

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -739,15 +739,6 @@ class GeometryArray(ExtensionArray):
     def geom_equals_exact(self, other, tolerance):
         return self._binary_method("equals_exact", self, other, tolerance=tolerance)
 
-    def geom_almost_equals(self, other, decimal):
-        warnings.warn(
-            "The 'geom_almost_equals()' method is deprecated because the name is "
-            "confusing. The 'geom_equals_exact()' method should be used instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.geom_equals_exact(other, 0.5 * 10 ** (-decimal))
-
     #
     # Binary operations that return new geometries
     #

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1,4 +1,3 @@
-import warnings
 from warnings import warn
 
 import numpy as np
@@ -2670,83 +2669,6 @@ GeometryCollection
 
         """
         return _binary_op("geom_equals", self, other, align)
-
-    def geom_almost_equals(self, other, decimal=6, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` if
-        each aligned geometry is approximately equal to `other`.
-
-        Approximate equality is tested at all points to the specified `decimal`
-        place precision.
-
-        The operation works on a 1-to-1 row-wise manner:
-
-        .. image:: ../../../_static/binary_op-01.svg
-           :align: center
-
-        Parameters
-        ----------
-        other : GeoSeries or geometric object
-            The GeoSeries (elementwise) or geometric object to compare to.
-        decimal : int
-            Decimal place precision used when testing for approximate equality.
-        align : bool | None (default None)
-            If True, automatically aligns GeoSeries based on their indices.
-            If False, the order of elements is preserved. None defaults to True.
-
-        Returns
-        -------
-        Series (bool)
-
-        Examples
-        --------
-        >>> from shapely.geometry import Point
-        >>> s = geopandas.GeoSeries(
-        ...     [
-        ...         Point(0, 1.1),
-        ...         Point(0, 1.01),
-        ...         Point(0, 1.001),
-        ...     ],
-        ... )
-        >>> s
-        0      POINT (0 1.1)
-        1     POINT (0 1.01)
-        2    POINT (0 1.001)
-        dtype: geometry
-
-
-        >>> s.geom_almost_equals(Point(0, 1), decimal=2)
-        0    False
-        1    False
-        2     True
-        dtype: bool
-
-        >>> s.geom_almost_equals(Point(0, 1), decimal=1)
-        0    False
-        1     True
-        2     True
-        dtype: bool
-
-        Notes
-        -----
-        This method works in a row-wise manner. It does not check if an element
-        of one GeoSeries is equal to *any* element of the other one.
-
-        See also
-        --------
-        GeoSeries.geom_equals
-        GeoSeries.geom_equals_exact
-
-        """
-        warnings.warn(
-            "The 'geom_almost_equals()' method is deprecated because the name is "
-            "confusing. The 'geom_equals_exact()' method should be used instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        tolerance = 0.5 * 10 ** (-decimal)
-        return _binary_op(
-            "geom_equals_exact", self, other, tolerance=tolerance, align=align
-        )
 
     def geom_equals_exact(self, other, tolerance, align=None):
         """Return True for all geometries that equal aligned *other* to a given

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -288,12 +288,8 @@ def test_as_array():
         ("touches", ()),
         ("within", ()),
         ("geom_equals_exact", (0.1,)),
-        ("geom_almost_equals", (3,)),
     ],
 )
-# filters required for attr=geom_almost_equals only
-@pytest.mark.filterwarnings(r"ignore:The \'geom_almost_equals\(\)\' method is deprecat")
-@pytest.mark.filterwarnings(r"ignore:The \'almost_equals\(\)\' method is deprecated")
 def test_predicates_vector_scalar(attr, args):
     na_value = False
 
@@ -332,12 +328,8 @@ def test_predicates_vector_scalar(attr, args):
         ("touches", ()),
         ("within", ()),
         ("geom_equals_exact", (0.1,)),
-        ("geom_almost_equals", (3,)),
     ],
 )
-# filters required for attr=geom_almost_equals only
-@pytest.mark.filterwarnings(r"ignore:The \'geom_almost_equals\(\)\' method is deprecat")
-@pytest.mark.filterwarnings(r"ignore:The \'almost_equals\(\)\' method is deprecated")
 def test_predicates_vector_vector(attr, args):
     na_value = False
     empty_value = True if attr == "disjoint" else False

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -141,25 +141,6 @@ class TestSeries:
         exp = pd.Series([False, False], index=["A", "B"])
         assert_series_equal(a, exp)
 
-    @pytest.mark.filterwarnings(r"ignore:The 'geom_almost_equals\(\)':FutureWarning")
-    def test_geom_almost_equals(self):
-        # TODO: test decimal parameter
-        assert np.all(self.g1.geom_almost_equals(self.g1))
-        assert_array_equal(self.g1.geom_almost_equals(self.sq), [False, True])
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                "The indices of the left and right GeoSeries' are not equal",
-                UserWarning,
-            )
-            assert_array_equal(
-                self.a1.geom_almost_equals(self.a2, align=True),
-                [False, True, False],
-            )
-        assert_array_equal(
-            self.a1.geom_almost_equals(self.a2, align=False), [False, False]
-        )
-
     def test_geom_equals_exact(self):
         # TODO: test tolerance parameter
         assert np.all(self.g1.geom_equals_exact(self.g1, 0.001))


### PR DESCRIPTION
shapely removed deprecated almost_equals on main, causing failures on our CI. Given our `geom_almost_equals` has also been deprecated for some time, removing it here as well.