### PR TITLE
ENH: add method and keep_collapsed arguments to make_valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ New features and improvements:
 - Avoid change of the plot aspect when plotting missing values (#3438).
 - GeoDataFrame no longer hard-codes the class internally, allowing easier subclassing (#3505).
 - Improve performance of `overlay` with `how=identity` (#3504).
-- Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502)
+- Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502).
+- Add ``method`` and ``keep_collapsed`` parameters to ``make_valid`` (#).
 
 Bug fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ New features and improvements:
 - Added `disjoint_subset` union algorithm for `union_all` and `dissolve` (#3534).
 - Added `to_pandas_kwargs` argument to `from_arrow`, `read_parquet` and `read_feather`
   to allow better control of conversion of non-geometric Arrow data to DataFrames (#3466).
-- Added ``method`` and ``keep_collapsed`` argument to ``make_valid`` (#).
+- Added ``method`` and ``keep_collapsed`` argument to ``make_valid`` (#3548).
 
 Bug fixes:
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,7 +22,7 @@ dependencies:
 
     # styling
     - pre-commit
-    - ruff==0.5.5
+    - ruff==0.8.6
 
     # optional
     - fiona

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,7 +22,7 @@ dependencies:
 
     # styling
     - pre-commit
-    - ruff==0.8.6
+    - ruff==0.11.4
 
     # optional
     - fiona

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -654,12 +654,17 @@ class GeometryArray(ExtensionArray):
         return GeometryArray(shapely.normalize(self._data), crs=self.crs)
 
     def make_valid(self, method="linework", keep_collapsed=True):
-        return GeometryArray(
-            shapely.make_valid(
-                self._data, method=method, keep_collapsed=keep_collapsed
-            ),
-            crs=self.crs,
-        )
+        kwargs = {}
+        if SHAPELY_GE_21:
+            kwargs["method"] = method
+            kwargs["keep_collapsed"] = keep_collapsed
+        else:
+            if method != "linework":
+                raise ValueError(
+                    "The 'structure' method requires GEOS >= 3.10 and shapely >= 2.1."
+                )
+
+        return GeometryArray(shapely.make_valid(self._data, **kwargs), crs=self.crs)
 
     def reverse(self):
         return GeometryArray(shapely.reverse(self._data), crs=self.crs)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -661,7 +661,7 @@ class GeometryArray(ExtensionArray):
         else:
             if method != "linework":
                 raise ValueError(
-                    "The 'structure' method requires GEOS >= 3.10 and shapely >= 2.1."
+                    "Only the 'linework' method is supported for shapely < 2.1."
                 )
 
         return GeometryArray(shapely.make_valid(self._data, **kwargs), crs=self.crs)

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -646,8 +646,13 @@ class GeometryArray(ExtensionArray):
     def normalize(self):
         return GeometryArray(shapely.normalize(self._data), crs=self.crs)
 
-    def make_valid(self):
-        return GeometryArray(shapely.make_valid(self._data), crs=self.crs)
+    def make_valid(self, method="linework", keep_collapsed=True):
+        return GeometryArray(
+            shapely.make_valid(
+                self._data, method=method, keep_collapsed=keep_collapsed
+            ),
+            crs=self.crs,
+        )
 
     def reverse(self):
         return GeometryArray(shapely.reverse(self._data), crs=self.crs)

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1813,9 +1813,10 @@ GeometryCollection
 
             .. versionadded:: 1.1.0
         keep_collapsed : bool, default True
-            For the 'structure' method, True will keep components that have collapsed into a
-            lower dimensionality. For example, a ring collapsing to a line, or a line
-            collapsing to a point. Must be True for the 'linework' method.
+            For the 'structure' method, True will keep components that have
+            collapsed into a lower dimensionality. For example, a ring
+            collapsing to a line, or a line collapsing to a point. Must be True
+            for the 'linework' method.
 
             .. versionadded:: 1.1.0
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1842,16 +1842,9 @@ GeometryCollection
         2                           LINESTRING (0 0, 1 1, 1 0)
         dtype: geometry
         """
-        kwargs = {}
-        if compat.SHAPELY_GE_21:
-            kwargs["method"] = method
-            kwargs["keep_collapsed"] = keep_collapsed
-        else:
-            if method != "linework":
-                raise ValueError(
-                    "The 'structure' method requires GEOS >= 3.10 and shapely >= 2.1."
-                )
-        return _delegate_geo_method("make_valid", self, **kwargs)
+        return _delegate_geo_method(
+            "make_valid", self, method=method, keep_collapsed=keep_collapsed
+        )
 
     def reverse(self):
         """Returns a ``GeoSeries`` with the order of coordinates reversed.

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1842,9 +1842,16 @@ GeometryCollection
         2                           LINESTRING (0 0, 1 1, 1 0)
         dtype: geometry
         """
-        return _delegate_geo_method(
-            "make_valid", self, method=method, keep_collapsed=keep_collapsed
-        )
+        kwargs = {}
+        if compat.SHAPELY_GE_21:
+            kwargs["method"] = method
+            kwargs["keep_collapsed"] = keep_collapsed
+        else:
+            if method != "linework":
+                raise ValueError(
+                    "The 'structure' method requires GEOS >= 3.10 and shapely >= 2.1."
+                )
+        return _delegate_geo_method("make_valid", self, **kwargs)
 
     def reverse(self):
         """Returns a ``GeoSeries`` with the order of coordinates reversed.

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -1776,11 +1776,11 @@ GeometryCollection
         """
         return _delegate_geo_method("normalize", self)
 
-    def make_valid(self):
-        """
-        Repairs invalid geometries.
+    def make_valid(self, method="linework", keep_collapsed=True):
+        """Repairs invalid geometries.
 
         Returns a ``GeoSeries`` with valid geometries.
+
         If the input geometry is already valid, then it will be preserved.
         In many cases, in order to create a valid geometry, the input
         geometry must be split into multiple parts or multiple geometries.
@@ -1789,6 +1789,35 @@ GeometryCollection
         (e.g. a MultiPolygon).
         If the geometry must be split into multiple parts of different types
         to be made valid, then a GeometryCollection will be returned.
+
+        Two ``methods`` are available:
+
+        * the 'linework' algorithm tries to preserve every edge and vertex in
+          the input. It combines all rings into a set of noded lines and then
+          extracts valid polygons from that linework. An alternating even-odd
+          strategy is used to assign areas as interior or exterior. A
+          disadvantage is that for some relatively simple invalid geometries
+          this produces rather complex results.
+        * the 'structure' algorithm tries to reason from the structure of the
+          input to find the 'correct' repair: exterior rings bound area,
+          interior holes exclude area. It first makes all rings valid, then
+          shells are merged and holes are subtracted from the shells to
+          generate valid result. It assumes that holes and shells are correctly
+          categorized in the input geometry.
+
+        Parameters
+        ----------
+        method : {'linework', 'structure'}, default 'linework'
+            Algorithm to use when repairing geometry. 'structure'
+            requires GEOS >= 3.10 and shapely >= 2.1.
+
+            .. versionadded:: 1.1.0
+        keep_collapsed : bool, default True
+            For the 'structure' method, True will keep components that have collapsed into a
+            lower dimensionality. For example, a ring collapsing to a line, or a line
+            collapsing to a point. Must be True for the 'linework' method.
+
+            .. versionadded:: 1.1.0
 
         Examples
         --------
@@ -1812,7 +1841,9 @@ GeometryCollection
         2                           LINESTRING (0 0, 1 1, 1 0)
         dtype: geometry
         """
-        return _delegate_geo_method("make_valid", self)
+        return _delegate_geo_method(
+            "make_valid", self, method=method, keep_collapsed=keep_collapsed
+        )
 
     def reverse(self):
         """Returns a ``GeoSeries`` with the order of coordinates reversed.

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -998,6 +998,32 @@ class TestGeomMethods:
         assert_geoseries_equal(result, expected)
         assert result.is_valid.all()
 
+    @pytest.mark.parametrize(
+        "method, keep_collapsed, expected",
+        [
+            (
+                "linework",
+                True,
+                MultiLineString([[(0, 0), (1, 1)], [(1, 1), (1, 2)]]),
+            ),
+            (
+                "structure",
+                True,
+                LineString([(0, 0), (1, 1), (1, 2), (1, 1), (0, 0)]),
+            ),
+            ("structure", False, Polygon()),
+        ],
+    )
+    @pytest.skipif(not SHAPELY_GE_21, reason="requires Shapely>=2.1")
+    def test_make_valid_method(self, method, keep_collapsed, expected):
+        polygon = Polygon([(0, 0), (1, 1), (1, 2), (1, 1), (0, 0)])
+        series = GeoSeries([polygon])
+        expected = GeoSeries([expected])
+        assert not series.is_valid.all()
+        result = series.make_valid(method=method, keep_collapsed=keep_collapsed)
+        assert_geoseries_equal(result, expected, check_geom_type=True)
+        assert result.is_valid.all()
+
     def test_reverse(self):
         expected = GeoSeries(
             [

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1024,6 +1024,16 @@ class TestGeomMethods:
         assert_geoseries_equal(result, expected, check_geom_type=True)
         assert result.is_valid.all()
 
+    @pytest.mark.skipif(SHAPELY_GE_21, reason="test for Shapely<2.1")
+    def test_make_valid_old_shapely(self):
+        """Only the 'linework' method is supported for shapely < 2.1."""
+        polygon = Polygon([(0, 0), (1, 1), (1, 2), (1, 1), (0, 0)])
+        series = GeoSeries([polygon])
+        with pytest.raises(
+            ValueError, match="Only the 'linework' method is supported for"
+        ):
+            series.make_valid(method="structure")
+
     def test_reverse(self):
         expected = GeoSeries(
             [

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1014,7 +1014,7 @@ class TestGeomMethods:
             ("structure", False, Polygon()),
         ],
     )
-    @pytest.skipif(not SHAPELY_GE_21, reason="requires Shapely>=2.1")
+    @pytest.mark.skipif(not SHAPELY_GE_21, reason="requires Shapely>=2.1")
     def test_make_valid_method(self, method, keep_collapsed, expected):
         polygon = Polygon([(0, 0), (1, 1), (1, 2), (1, 1), (0, 0)])
         series = GeoSeries([polygon])


### PR DESCRIPTION
shapely 2.1 introduced the `method` and `keep_collapsed` argumetns for `make_valid`... Add them in geopandas as well.