### PR TITLE
ENH: add constrained_delaunay_triangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ New features and improvements:
 - Improve performance of `overlay` with `how=identity` (#3504).
 - Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502).
 - Added `disjoint_subset` union algorithm for `union_all` and `dissolve` (#3534).
-- Added `constrained_delaunay_triangles` property to `GeoSeries` (#3552).
+- Added `constrained_delaunay_triangles` method to GeoSeries/GeoDataframe (#3552).
 - Added `to_pandas_kwargs` argument to `from_arrow`, `read_parquet` and `read_feather`
   to allow better control of conversion of non-geometric Arrow data to DataFrames (#3466).
 - Added ``method`` and ``keep_collapsed`` argument to ``make_valid`` (#3548).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ New features and improvements:
 - Improve performance of `overlay` with `how=identity` (#3504).
 - Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502).
 - Added `disjoint_subset` union algorithm for `union_all` and `dissolve` (#3534).
-- Added `constrained_delaunay_triangles` property to `GeoSeries` (#).
+- Added `constrained_delaunay_triangles` property to `GeoSeries` (#3552).
 - Added `to_pandas_kwargs` argument to `from_arrow`, `read_parquet` and `read_feather`
   to allow better control of conversion of non-geometric Arrow data to DataFrames (#3466).
 - Added ``method`` and ``keep_collapsed`` argument to ``make_valid`` (#3548).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ New features and improvements:
 - Improve performance of `overlay` with `how=identity` (#3504).
 - Fix ambiguous error when GeoDataFrame is initialised with a column called "crs" (#3502).
 - Added `disjoint_subset` union algorithm for `union_all` and `dissolve` (#3534).
+- Added `constrained_delaunay_triangles` property to `GeoSeries` (#).
 - Added `to_pandas_kwargs` argument to `from_arrow`, `read_parquet` and `read_feather`
   to allow better control of conversion of non-geometric Arrow data to DataFrames (#3466).
 - Added ``method`` and ``keep_collapsed`` argument to ``make_valid`` (#3548).

--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -151,6 +151,7 @@ Aggregating and exploding
    :toctree: api/
 
    GeoSeries.build_area
+   GeoSeries.constrained_delaunay_triangles
    GeoSeries.delaunay_triangles
    GeoSeries.explode
    GeoSeries.intersection_all

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -38,6 +38,14 @@ Constructive methods
   number of points in the object is less than three. For two points,
   the convex hull collapses to a `LineString`; for 1, a `Point`.
 
+.. method:: GeoSeries.constrained_delaunay_triangles
+
+  Returns a :class:`~geopandas.GeoSeries` with the constrained Delaunay triangulation
+  of polygons. A constrained Delaunay triangulation requires the edges of the input
+  polygon(s) to be in the set of resulting triangle edges. An unconstrained
+  delaunay triangulation only triangulates based on the vertices, hence triangle
+  edges could cross polygon boundaries.
+
 .. method:: GeoSeries.delaunay_triangles(tolerance, preserve_topology=True)
 
   Returns a :class:`~geopandas.GeoSeries` consisting of polygons (default) or linestrings

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -583,11 +583,12 @@ class GeometryArray(ExtensionArray):
     def concave_hull(self, ratio, allow_holes):
         return shapely.concave_hull(self._data, ratio=ratio, allow_holes=allow_holes)
 
-    @property
     def constrained_delaunay_triangles(self):
+        if not SHAPELY_GE_21:
+            raise ImportError("'constrained_delaunay_triangles' requires shapely>=2.1.")
+
         return GeometryArray(
-            shapely.constrained_delaunay_triangles(self._data),
-            crs=self.crs,
+            shapely.constrained_delaunay_triangles(self._data), crs=self.crs
         )
 
     @property

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -584,6 +584,13 @@ class GeometryArray(ExtensionArray):
         return shapely.concave_hull(self._data, ratio=ratio, allow_holes=allow_holes)
 
     @property
+    def constrained_delaunay_triangles(self):
+        return GeometryArray(
+            shapely.constrained_delaunay_triangles(self._data),
+            crs=self.crs,
+        )
+
+    @property
     def convex_hull(self):
         return GeometryArray(shapely.convex_hull(self._data), crs=self.crs)
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -969,6 +969,36 @@ GeometryCollection
         )
 
     @property
+    def constrained_delaunay_triangles(self):
+        """Returns a :class:`~geopandas.GeoSeries` with the constrained
+        Delaunay triangulation of polygons.
+
+        A constrained Delaunay triangulation requires the edges of the input
+        polygon(s) to be in the set of resulting triangle edges. An
+        unconstrained delaunay triangulation only triangulates based on the
+        vertices, hence triangle edges could cross polygon boundaries.
+
+        Examples
+        --------
+
+        >>> from shapely.geometry import Polygon
+        >>> s = geopandas.GeoSeries([Polygon([(0, 0), (1, 1), (0, 1)])])
+        >>> s
+        0                       POLYGON ((0 0, 1 1, 0 1, 0 0))
+        dtype: geometry
+
+        >>> s.constrained_delaunay_triangles
+        0         GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 0...
+        dtype: geometry
+
+        See also
+        --------
+        GeoSeries.delaunay_triangles : Delaunay triangulation
+
+        """
+        return _delegate_property("constrained_delaunay_triangles", self)
+
+    @property
     def convex_hull(self):
         """Returns a ``GeoSeries`` of geometries representing the convex hull
         of each geometry.
@@ -1103,6 +1133,7 @@ GeometryCollection
         See also
         --------
         GeoSeries.voronoi_polygons : Voronoi diagram around vertices
+        GeoSeries.constrained_delaunay_triangles : constrained Delaunay triangulation
         """
         from .geoseries import GeoSeries
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -968,7 +968,6 @@ GeometryCollection
             "concave_hull", self, ratio=ratio, allow_holes=allow_holes
         )
 
-    @property
     def constrained_delaunay_triangles(self):
         """Returns a :class:`~geopandas.GeoSeries` with the constrained
         Delaunay triangulation of polygons.
@@ -987,7 +986,7 @@ GeometryCollection
         0                       POLYGON ((0 0, 1 1, 0 1, 0 0))
         dtype: geometry
 
-        >>> s.constrained_delaunay_triangles
+        >>> s.constrained_delaunay_triangles()
         0         GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 0...
         dtype: geometry
 
@@ -996,7 +995,7 @@ GeometryCollection
         GeoSeries.delaunay_triangles : Delaunay triangulation
 
         """
-        return _delegate_property("constrained_delaunay_triangles", self)
+        return _delegate_geo_method("constrained_delaunay_triangles", self)
 
     @property
     def convex_hull(self):

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -569,9 +569,6 @@ class TestGeometryArrayCRS:
         cent = arr.centroid
         assert cent.crs == self.osgb
 
-        constrained_delaunay = arr.constrained_delaunay_triangles
-        assert constrained_delaunay.crs == self.osgb
-
         hull = arr.convex_hull
         assert hull.crs == self.osgb
 

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -569,6 +569,9 @@ class TestGeometryArrayCRS:
         cent = arr.centroid
         assert cent.crs == self.osgb
 
+        constrained_delaunay = arr.constrained_delaunay_triangles
+        assert constrained_delaunay.crs == self.osgb
+
         hull = arr.convex_hull
         assert hull.crs == self.osgb
 

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1163,13 +1163,14 @@ class TestGeomMethods:
                 ratio=0.1, allow_holes=Series([True, False], index=[99, 98])
             )
 
+    @pytest.mark.skipif(not SHAPELY_GE_21, reason="requires shapely 2.1")
     def test_constrained_delaunay_triangles(self):
         input = GeoSeries([Polygon([(0, 0), (1, 1), (0, 1)])])
         expected = GeoSeries(
             [GeometryCollection([Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])])]
         )
         assert_geoseries_equal(
-            input.constrained_delaunay_triangles, expected, check_geom_type=True
+            input.constrained_delaunay_triangles(), expected, check_geom_type=True
         )
 
     def test_convex_hull(self):

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1163,6 +1163,15 @@ class TestGeomMethods:
                 ratio=0.1, allow_holes=Series([True, False], index=[99, 98])
             )
 
+    def test_constrained_delaunay_triangles(self):
+        input = GeoSeries([Polygon([(0, 0), (1, 1), (0, 1)])])
+        expected = GeoSeries(
+            [GeometryCollection([Polygon([(0, 0), (0, 1), (1, 1), (0, 0)])])]
+        )
+        assert_geoseries_equal(
+            input.constrained_delaunay_triangles, expected, check_geom_type=True
+        )
+
     def test_convex_hull(self):
         # the convex hull of a square should be the same as the square
         assert_geoseries_equal(self.squares, self.squares.convex_hull)


### PR DESCRIPTION
Add a `constrained_delaunay_triangles` method on GeoSeries/GeoDataFrame as this function became available in shapely 2.1.

xref #2010