### PR TITLE
DOC: Correct a name accent in citing.md

### DIFF
--- a/doc/source/about/citing.md
+++ b/doc/source/about/citing.md
@@ -37,7 +37,7 @@ _Kelsey Jordahl, Joris Van den Bossche, Martin Fleischmann, Jacob Wasserman, Jam
                   Adam Greenhall and
                   Chris Holdgraf and
                   Filipe and
-                  François Leblanc},
+                  Fran\c{c}ois Leblanc},
   title        = {geopandas/geopandas: v0.8.1},
   month        = jul,
   year         = 2020,


### PR DESCRIPTION
The name "François" should be "Fran\c{c}ois" in LaTeX.