### PR TITLE
DOC: Remove Twitter icon on geopandas website

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -173,9 +173,9 @@ html_theme_options = {
             "icon": "fab fa-github-square fa-xl",
         },
         {
-            "name": "Twitter",
-            "url": "https://twitter.com/geopandas",
-            "icon": "fab fa-twitter-square fa-xl",
+            "name": "X",
+            "url": "https://x.com/geopandas",
+            "icon": "fab fa-x-twitter-square fa-xl",
         },
     ]
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -172,11 +172,6 @@ html_theme_options = {
             "url": "https://github.com/geopandas/geopandas",
             "icon": "fab fa-github-square fa-xl",
         },
-        {
-            "name": "X",
-            "url": "https://x.com/geopandas",
-            "icon": "fab fa-x-twitter-square fa-xl",
-        },
     ]
 }
 


### PR DESCRIPTION
Replace Twitter icon with X on the geopandas website.

I followed the pandas documentation to propose this change.
https://github.com/pandas-dev/pandas/blob/main/doc/source/conf.py
https://pandas.pydata.org/docs/dev/index.html