### PR TITLE
add opportunistic range request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ New features and improvements:
   to GeoSeries/GeoDataframe (#3541).
 - Added initial support of M coordinates (`m` and `has_m` properties, `include_m` in `get_coordinates`) (#3561).
 - Added `geom_equals_identical` method exposing `equals_identical` from shapely to GeoSeries/GeoDataFrame (#3560).
+- GeoPandas now attempts to use a range request when reading from an URL even if the header
+ does not directly indicate its support (#3572).
 
 Bug fixes:
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -300,11 +300,13 @@ def _read_file(
                     response.headers.get("Accept-Ranges") == "none"
                     or response.status != HTTPStatus.PARTIAL_CONTENT
                 ):
-                    filename = response.read()
                     from_bytes = True
         except ConnectionError:
-            filename = response.read()
             from_bytes = True
+
+        if from_bytes:
+            with urllib.request.urlopen(filename) as response:
+                filename = response.read()
 
     if engine == "pyogrio":
         return _read_file_pyogrio(

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -292,15 +292,19 @@ def _read_file(
         # pyogrio/fiona as is (to support downloading only part of the file)
         # otherwise still download manually because pyogrio/fiona don't support
         # all types of urls (https://github.com/geopandas/geopandas/issues/2908)
-        with urllib.request.urlopen(
-            Request(filename, headers={"Range": "bytes=0-1"})
-        ) as response:
-            if (
-                response.headers.get("Accept-Ranges") == "none"
-                or response.status != HTTPStatus.PARTIAL_CONTENT
-            ):
-                filename = response.read()
-                from_bytes = True
+        try:
+            with urllib.request.urlopen(
+                Request(filename, headers={"Range": "bytes=0-1"})
+            ) as response:
+                if (
+                    response.headers.get("Accept-Ranges") == "none"
+                    or response.status != HTTPStatus.PARTIAL_CONTENT
+                ):
+                    filename = response.read()
+                    from_bytes = True
+        except ConnectionError:
+            filename = response.read()
+            from_bytes = True
 
     if engine == "pyogrio":
         return _read_file_pyogrio(


### PR DESCRIPTION
Closes #3571 

In `read_file(url)`, opportunistically tries a range request and only downloads the whole file if range requests are explicitly not supported (`"Accept-Ranges": "none"` in the header) or if the status is not `206` (PARTIAL_CONTENT).

This makes it possible to avoid downloading large files if they can be read partially with range requests but the server doesn't explicitly advertise it with the header `"Accept-Ranges": "bytes"`.

See the issue for a further description.