### PR TITLE
shapely 2.1 follow-up (docstrings, positional arguments)

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -384,7 +384,7 @@ GeometryCollection
         """
         return Series(self.geometry.values.is_valid_reason(), index=self.index)
 
-    def is_valid_coverage(self, gap_width=0.0):
+    def is_valid_coverage(self, *, gap_width=0.0):
         """Returns a ``bool`` indicating whether a ``GeoSeries`` forms a valid coverage
 
         A ``GeoSeries`` of valid polygons is considered a coverage if the polygons are:
@@ -402,6 +402,8 @@ GeometryCollection
 
         Geometries that are not Polygon or MultiPolygon are ignored and an empty
         LineString is returned.
+
+        Requires Shapely >= 2.1.
 
         Parameters
         ----------
@@ -452,7 +454,7 @@ GeometryCollection
         """
         return self.geometry.values.is_valid_coverage(gap_width=gap_width)
 
-    def invalid_coverage_edges(self, gap_width=0.0):
+    def invalid_coverage_edges(self, *, gap_width=0.0):
         """Returns a ``GeoSeries`` containing edges causing invalid polygonal coverage
 
         This method returns (Multi)LineStrings showing the location of edges violating
@@ -471,6 +473,8 @@ GeometryCollection
         ``False`` and this method can be used to find the edges of those gaps.
 
         Geometries that are not Polygon or MultiPolygon are ignored.
+
+        Requires Shapely >= 2.1.
 
         Parameters
         ----------
@@ -848,6 +852,7 @@ GeometryCollection
         """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
         features that have a m-component.
 
+        Requires Shapely >= 2.1.
 
         Examples
         --------
@@ -1132,6 +1137,8 @@ GeometryCollection
         polygon(s) to be in the set of resulting triangle edges. An
         unconstrained delaunay triangulation only triangulates based on the
         vertices, hence triangle edges could cross polygon boundaries.
+
+        Requires Shapely >= 2.1.
 
         Examples
         --------
@@ -1864,7 +1871,7 @@ GeometryCollection
         """
         return _delegate_geo_method("minimum_bounding_circle", self)
 
-    def maximum_inscribed_circle(self, tolerance=None):
+    def maximum_inscribed_circle(self, *, tolerance=None):
         """Returns a ``GeoSeries`` of geometries representing the largest circle that
         is fully contained within the input geometry.
 
@@ -1883,6 +1890,8 @@ GeometryCollection
         Returns a GeoSeries with two-point linestrings rows, with the first point at the
         center of the inscribed circle and the second on the boundary of the inscribed
         circle.
+
+        Requires Shapely >= 2.1.
 
         Parameters
         ----------
@@ -2004,6 +2013,8 @@ GeometryCollection
 
         If the geometry has no minimum clearance, an empty LineString will be returned.
 
+        Requires Shapely >= 2.1.
+
         Examples
         --------
 
@@ -2066,7 +2077,7 @@ GeometryCollection
         """
         return _delegate_geo_method("normalize", self)
 
-    def orient_polygons(self, exterior_cw=False):
+    def orient_polygons(self, *, exterior_cw=False):
         """Returns a ``GeoSeries`` of geometries with enforced ring orientation.
 
         Enforce a ring orientation on all polygonal elements in the ``GeoSeries``.
@@ -2077,6 +2088,8 @@ GeometryCollection
 
         Also processes geometries inside a GeometryCollection in the same way. Other
         geometries are returned unchanged.
+
+        Requires Shapely >= 2.1.
 
         Parameters
         ----------
@@ -2531,7 +2544,7 @@ GeometryCollection
             * ``"disjoint_subset:``: use the disjoint subset union algorithm. This
               option is optimized for inputs that can be divided into subsets that do
               not intersect. If there is only one such subset, performance can be
-              expected to be worse than ``"unary"``.
+              expected to be worse than ``"unary"``. Requires Shapely >= 2.1.
 
         grid_size : float, default None
             When grid size is specified, a fixed-precision space is used to perform the
@@ -3140,6 +3153,8 @@ GeometryCollection
 
         .. image:: ../../../_static/binary_op-01.svg
            :align: center
+
+        Requires Shapely >= 2.1.
 
         Parameters
         ----------
@@ -5548,6 +5563,8 @@ GeometryCollection
 
         If the geometry is polygonal but does not form a valid coverage due to overlaps,
         it will be simplified but it may result in invalid coverage topology.
+
+        Requires Shapely >= 2.1.
 
         .. versionadded:: 1.1.0
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2145,7 +2145,7 @@ GeometryCollection
         """
         return _delegate_geo_method("orient_polygons", self, exterior_cw=exterior_cw)
 
-    def make_valid(self, method="linework", keep_collapsed=True):
+    def make_valid(self, *, method="linework", keep_collapsed=True):
         """Repairs invalid geometries.
 
         Returns a ``GeoSeries`` with valid geometries.
@@ -2534,7 +2534,7 @@ GeometryCollection
 
         return self.geometry.values.union_all()
 
-    def union_all(self, method="unary", grid_size=None):
+    def union_all(self, method="unary", *, grid_size=None):
         """Returns a geometry containing the union of all geometries in the
         ``GeoSeries``.
 
@@ -5556,7 +5556,7 @@ GeometryCollection
             "simplify", self, tolerance=tolerance, preserve_topology=preserve_topology
         )
 
-    def simplify_coverage(self, tolerance, simplify_boundary=True):
+    def simplify_coverage(self, tolerance, *, simplify_boundary=True):
         """Returns a ``GeoSeries`` containing a simplified representation of
         polygonal coverage.
 
@@ -6267,7 +6267,7 @@ GeometryCollection
         return _CoordinateIndexer(self)
 
     def get_coordinates(
-        self, include_z=False, ignore_index=False, index_parts=False, include_m=False
+        self, include_z=False, ignore_index=False, index_parts=False, *, include_m=False
     ):
         """Gets coordinates from a :class:`GeoSeries` as a :class:`~pandas.DataFrame` of
         floats.

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -405,6 +405,8 @@ GeometryCollection
 
         Requires Shapely >= 2.1.
 
+        .. versionadded:: 1.1.0
+
         Parameters
         ----------
         gap_width : float, optional
@@ -475,6 +477,8 @@ GeometryCollection
         Geometries that are not Polygon or MultiPolygon are ignored.
 
         Requires Shapely >= 2.1.
+
+        .. versionadded:: 1.1.0
 
         Parameters
         ----------
@@ -854,6 +858,8 @@ GeometryCollection
 
         Requires Shapely >= 2.1.
 
+        .. versionadded:: 1.1.0
+
         Examples
         --------
         >>> from shapely.geometry import Point
@@ -1139,6 +1145,8 @@ GeometryCollection
         vertices, hence triangle edges could cross polygon boundaries.
 
         Requires Shapely >= 2.1.
+
+        .. versionadded:: 1.1.0
 
         Examples
         --------
@@ -1893,6 +1901,8 @@ GeometryCollection
 
         Requires Shapely >= 2.1.
 
+        .. versionadded:: 1.1.0
+
         Parameters
         ----------
         tolerance : float, np.array, pd.Series
@@ -2015,6 +2025,8 @@ GeometryCollection
 
         Requires Shapely >= 2.1.
 
+        .. versionadded:: 1.1.0
+
         Examples
         --------
 
@@ -2090,6 +2102,8 @@ GeometryCollection
         geometries are returned unchanged.
 
         Requires Shapely >= 2.1.
+
+        .. versionadded:: 1.1.0
 
         Parameters
         ----------
@@ -3155,6 +3169,8 @@ GeometryCollection
            :align: center
 
         Requires Shapely >= 2.1.
+
+        .. versionadded:: 1.1.0
 
         Parameters
         ----------

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2198,7 +2198,7 @@ default 'snappy'
             * ``"disjoint_subset:``: use the disjoint subset union algorithm. This
               option is optimized for inputs that can be divided into subsets that do
               not intersect. If there is only one such subset, performance can be
-              expected to be worse than ``"unary"``.
+              expected to be worse than ``"unary"``.  Requires Shapely >= 2.1.
 
 
         grid_size : float, default None

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -341,6 +341,8 @@ class GeoSeries(GeoPandasBase, Series):
 
         Requires Shapely >= 2.1.
 
+        .. versionadded:: 1.1.0
+
         Returns
         -------
         pandas.Series

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -339,6 +339,8 @@ class GeoSeries(GeoPandasBase, Series):
     def m(self) -> Series:
         """Return the m coordinate of point geometries in a GeoSeries
 
+        Requires Shapely >= 2.1.
+
         Returns
         -------
         pandas.Series

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1060,7 +1060,7 @@ class TestGeomMethods:
             holes=[[(2, 2), (2, 4), (4, 4), (4, 2), (2, 2)]],
         )
         expected = GeoSeries([polygon_cw, linestring, point])
-        assert_geoseries_equal(series.orient_polygons(True), expected)
+        assert_geoseries_equal(series.orient_polygons(exterior_cw=True), expected)
 
     def test_make_valid(self):
         polygon1 = Polygon([(0, 0), (0, 2), (1, 1), (2, 2), (2, 0), (1, 1), (0, 0)])


### PR DESCRIPTION
This adds notes to docstrings of all methods that require shapely 2.1 and disables positional arguments in new methods when it makes sense.