### PR TITLE
COMPAT: avoid passing include_z positionally in transform method for shapely 2.1 compat

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -739,7 +739,8 @@ class GeometryArray(ExtensionArray):
 
     def transform(self, transformation, include_z=False):
         return GeometryArray(
-            shapely.transform(self._data, transformation, include_z), crs=self.crs
+            shapely.transform(self._data, transformation, include_z=include_z),
+            crs=self.crs,
         )
 
     def line_merge(self, directed=False):


### PR DESCRIPTION
See deprecations section in https://shapely.readthedocs.io/en/stable/release/2.x.html#api-changes