### PR TITLE
CI: xfail remote url test for now

### DIFF
--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -594,7 +594,11 @@ def test_read_file(engine, nybb_filename):
         "https://raw.githubusercontent.com/geopandas/geopandas/"
         "main/geopandas/tests/data/nybb_16a.zip",
         # url to zipfile without extension
-        "https://geonode.goosocean.org/download/480",
+        # https://github.com/geopandas/geopandas/issues/3583
+        pytest.param(
+            "https://geonode.goosocean.org/download/480",
+            marks=pytest.mark.xfail(reason="link broken"),
+        ),
         # url to web service
         "https://demo.pygeoapi.io/stable/collections/obs/items",
     ],


### PR DESCRIPTION
Given we're trying to do a release I think it makes sense to skip the test failing here https://github.com/geopandas/geopandas/issues/3583 for the moment so the CI is not permanently red. Not familar with the original content at this link so it's a bit hard to say if this will be fixed or if it's permanently broken/ changed.