### PR TITLE
ENH: expose grid_size parameter in shapely functions

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -827,23 +827,30 @@ class GeometryArray(ExtensionArray):
             shapely.clip_by_rect(self._data, xmin, ymin, xmax, ymax), crs=self.crs
         )
 
-    def difference(self, other):
+    def difference(self, other, grid_size=None):
         return GeometryArray(
-            self._binary_method("difference", self, other), crs=self.crs
+            self._binary_method("difference", self, other, grid_size=grid_size),
+            crs=self.crs,
         )
 
-    def intersection(self, other):
+    def intersection(self, other, grid_size=None):
         return GeometryArray(
-            self._binary_method("intersection", self, other), crs=self.crs
+            self._binary_method("intersection", self, other, grid_size=grid_size),
+            crs=self.crs,
         )
 
-    def symmetric_difference(self, other):
+    def symmetric_difference(self, other, grid_size=None):
         return GeometryArray(
-            self._binary_method("symmetric_difference", self, other), crs=self.crs
+            self._binary_method(
+                "symmetric_difference", self, other, grid_size=grid_size
+            ),
+            crs=self.crs,
         )
 
-    def union(self, other):
-        return GeometryArray(self._binary_method("union", self, other), crs=self.crs)
+    def union(self, other, grid_size=None):
+        return GeometryArray(
+            self._binary_method("union", self, other, grid_size=grid_size), crs=self.crs
+        )
 
     def shortest_line(self, other):
         return GeometryArray(

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -4443,7 +4443,7 @@ GeometryCollection
     # Binary operations that return a GeoSeries
     #
 
-    def difference(self, other, align=None):
+    def difference(self, other, align=None, grid_size=None):
         """Returns a ``GeoSeries`` of the points in each aligned geometry that
         are not in `other`.
 
@@ -4552,9 +4552,9 @@ GeometryCollection
         GeoSeries.union
         GeoSeries.intersection
         """
-        return _binary_geo("difference", self, other, align)
+        return _binary_geo("difference", self, other, align, grid_size)
 
-    def symmetric_difference(self, other, align=None):
+    def symmetric_difference(self, other, align=None, grid_size=None):
         """Returns a ``GeoSeries`` of the symmetric difference of points in
         each aligned geometry with `other`.
 
@@ -4667,9 +4667,11 @@ GeometryCollection
         GeoSeries.union
         GeoSeries.intersection
         """
-        return _binary_geo("symmetric_difference", self, other, align)
+        return _binary_geo(
+            "symmetric_difference", self, other, align, grid_size=grid_size
+        )
 
-    def union(self, other, align=None):
+    def union(self, other, align=None, grid_size=None):
         """Returns a ``GeoSeries`` of the union of points in each aligned geometry with
         `other`.
 
@@ -4781,9 +4783,9 @@ GeometryCollection
         GeoSeries.difference
         GeoSeries.intersection
         """
-        return _binary_geo("union", self, other, align)
+        return _binary_geo("union", self, other, align, grid_size=grid_size)
 
-    def intersection(self, other, align=None):
+    def intersection(self, other, align=None, grid_size=None):
         """Returns a ``GeoSeries`` of the intersection of points in each
         aligned geometry with `other`.
 
@@ -4894,7 +4896,7 @@ GeometryCollection
         GeoSeries.symmetric_difference
         GeoSeries.union
         """
-        return _binary_geo("intersection", self, other, align)
+        return _binary_geo("intersection", self, other, align, grid_size=grid_size)
 
     def clip_by_rect(self, xmin, ymin, xmax, ymax):
         """Returns a ``GeoSeries`` of the portions of geometry within the given

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -920,3 +920,18 @@ class TestOverlayWikiExample:
     def test_b_identity_a(self):
         df_result = overlay(self.layer_b, self.layer_a, how="identity")
         assert_geodataframe_equal(df_result, self.b_identity_a)
+
+
+# def test_grid_size():
+#     polys1 = geopandas.GeoSeries([Polygon([(0,0), (2,0), (2,2), (0,2)]),
+#                               Polygon([(2,2), (4,2), (4,4), (2,4)])])
+#     polys2 = geopandas.GeoSeries([Polygon([(1,1), (3,1), (3,3), (1,3)]),
+#                                 Polygon([(3,3), (5,3), (5,5), (3,5)])])
+#     df1 = geopandas.GeoDataFrame({'geometry': polys1, 'df1_data':[1,2]})
+#     df2 = geopandas.GeoDataFrame({'geometry': polys2, 'df2_data':[1,2]})
+#     df1.plot()
+#     df2.plot()
+#     union_df = geopandas.overlay(df1, df2, how="union")
+#     diff_df = geopandas.overlay(df1, df2, how="difference")
+#     diff2_df = df1.difference(df2)
+#     import pdb; pdb.set_trace()


### PR DESCRIPTION
Looks to expose the `grid_size` parm as described in #3446  for `union`, `difference`, `symmetric_difference`, `intersection`.

`overlay` is a bit more complex as it has its own implementations such as `overlay._overlay_difference()`. Will need more thinking on that one.