### PR TITLE
MAINT: enable pydocstyle ruff rules - automatic and easy fixes

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -41,6 +41,7 @@ def import_optional_dependency(name: str, extra: str = ""):
         The module name.
     extra : str
         Additional text to include in the ImportError message.
+
     Returns
     -------
     module

--- a/geopandas/_decorator.py
+++ b/geopandas/_decorator.py
@@ -6,7 +6,8 @@ from textwrap import dedent
 
 
 def doc(*docstrings: str | Callable, **params) -> Callable:
-    """
+    """Append docstrings to a callable.
+
     A decorator take docstring templates, concatenate them and perform string
     substitution on it.
     This decorator will add a variable "_docstring_components" to the wrapped

--- a/geopandas/accessors.py
+++ b/geopandas/accessors.py
@@ -1,6 +1,4 @@
-"""
-Accessors for accessing GeoPandas functionality via pandas extension dtypes
-"""
+"""Accessors for accessing GeoPandas functionality via pandas extension dtypes."""
 
 import pandas.api.extensions
 

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -95,9 +95,7 @@ def _check_crs(left, right, allow_none=False):
 
 
 def _crs_mismatch_warn(left, right, stacklevel=3):
-    """
-    Raise a CRS mismatch warning with the information on the assigned CRS.
-    """
+    """Raise a CRS mismatch warning with the information on the assigned CRS."""
     if left.crs:
         left_srs = left.crs.to_string()
         left_srs = left_srs if len(left_srs) <= 50 else " ".join([left_srs[:50], "..."])
@@ -193,9 +191,7 @@ def from_shapely(data, crs=None):
 
 
 def to_shapely(geoms):
-    """
-    Convert GeometryArray to numpy object array of shapely objects.
-    """
+    """Convert GeometryArray to numpy object array of shapely objects."""
     if not isinstance(geoms, GeometryArray):
         raise ValueError("'geoms' must be a GeometryArray")
     return geoms._data
@@ -227,9 +223,7 @@ def from_wkb(data, crs=None, on_invalid="raise"):
 
 
 def to_wkb(geoms, hex=False, **kwargs):
-    """
-    Convert GeometryArray to a numpy object array of WKB objects.
-    """
+    """Convert GeometryArray to a numpy object array of WKB objects."""
     if not isinstance(geoms, GeometryArray):
         raise ValueError("'geoms' must be a GeometryArray")
     return shapely.to_wkb(geoms, hex=hex, **kwargs)
@@ -261,9 +255,7 @@ def from_wkt(data, crs=None, on_invalid="raise"):
 
 
 def to_wkt(geoms, **kwargs):
-    """
-    Convert GeometryArray to a numpy object array of WKT objects.
-    """
+    """Convert GeometryArray to a numpy object array of WKT objects."""
     if not isinstance(geoms, GeometryArray):
         raise ValueError("'geoms' must be a GeometryArray")
     return shapely.to_wkt(geoms, **kwargs)
@@ -321,9 +313,9 @@ def points_from_xy(x, y, z=None, crs=None):
 
 
 class GeometryArray(ExtensionArray):
-    """
-    Class wrapping a numpy array of Shapely objects and
-    holding the array-based implementations.
+    """Class wrapping a numpy array of Shapely objects.
+
+    It also holds the array-based implementations.
     """
 
     _dtype = GeometryDtype()
@@ -350,6 +342,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def sindex(self):
+        """Spatial index for the geometries in this array."""
         if self._sindex is None:
             self._sindex = SpatialIndex(self._data)
         return self._sindex
@@ -367,7 +360,7 @@ class GeometryArray(ExtensionArray):
         initialized until the first use.
 
         See Also
-        ---------
+        --------
         GeoDataFrame.has_sindex
 
         Returns
@@ -380,9 +373,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def crs(self):
-        """
-        The Coordinate Reference System (CRS) represented as a ``pyproj.CRS``
-        object.
+        """The Coordinate Reference System (CRS) represented as a ``pyproj.CRS`` object.
 
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
@@ -394,7 +385,7 @@ class GeometryArray(ExtensionArray):
 
     @crs.setter
     def crs(self, value):
-        """Sets the value of the crs"""
+        """Set the value of the crs."""
         if HAS_PYPROJ:
             from pyproj import CRS
 
@@ -412,7 +403,7 @@ class GeometryArray(ExtensionArray):
             self._crs = None
 
     def check_geographic_crs(self, stacklevel):
-        """Check CRS and warn if the planar operation is done in a geographic CRS"""
+        """Check CRS and warn if the planar operation is done in a geographic CRS."""
         if self.crs and self.crs.is_geographic:
             warnings.warn(
                 "Geometry is in a geographic CRS. Results from "
@@ -565,6 +556,18 @@ class GeometryArray(ExtensionArray):
 
     @property
     def area(self):
+        """Return the area of the geometries in this array.
+
+        Raises a UserWarning if the CRS is geographic, as the area
+        calculation is not accurate in that case.
+
+        Note that the area is calculated in the units of the CRS.
+
+        Returns
+        -------
+        np.ndarray of float
+            Area of the geometries.
+        """
         self.check_geographic_crs(stacklevel=5)
         return shapely.area(self._data)
 
@@ -614,13 +617,16 @@ class GeometryArray(ExtensionArray):
 
     @property
     def convex_hull(self):
+        """Return the convex hull of the geometries in this array."""
         return GeometryArray(shapely.convex_hull(self._data), crs=self.crs)
 
     @property
     def envelope(self):
+        """Return the envelope of the geometries in this array."""
         return GeometryArray(shapely.envelope(self._data), crs=self.crs)
 
     def minimum_rotated_rectangle(self):
+        """Return the minimum rotated rectangle of the geometries in this array."""
         return GeometryArray(shapely.oriented_envelope(self._data), crs=self.crs)
 
     @property
@@ -1020,8 +1026,7 @@ class GeometryArray(ExtensionArray):
 
     @requires_pyproj
     def to_crs(self, crs=None, epsg=None):
-        """Returns a ``GeometryArray`` with all geometries transformed to a new
-        coordinate reference system.
+        """Transform all geometries to a different coordinate reference system.
 
         Transform all geometries in a GeometryArray to a different coordinate
         reference system.  The ``crs`` attribute on the current GeometryArray must
@@ -1113,7 +1118,7 @@ class GeometryArray(ExtensionArray):
 
     @requires_pyproj
     def estimate_utm_crs(self, datum_name="WGS 84"):
-        """Returns the estimated UTM CRS based on the bounds of the dataset.
+        """Return the estimated UTM CRS based on the bounds of the dataset.
 
         .. versionadded:: 0.9
 
@@ -1200,7 +1205,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def x(self):
-        """Return the x location of point geometries in a GeoSeries"""
+        """Return the x location of point geometries in a GeoSeries."""
         if (self.geom_type[~self.isna()] == "Point").all():
             empty = self.is_empty
             if empty.any():
@@ -1216,7 +1221,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def y(self):
-        """Return the y location of point geometries in a GeoSeries"""
+        """Return the y location of point geometries in a GeoSeries."""
         if (self.geom_type[~self.isna()] == "Point").all():
             empty = self.is_empty
             if empty.any():
@@ -1232,7 +1237,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def z(self):
-        """Return the z location of point geometries in a GeoSeries"""
+        """Return the z location of point geometries in a GeoSeries."""
         if (self.geom_type[~self.isna()] == "Point").all():
             empty = self.is_empty
             if empty.any():
@@ -1248,7 +1253,7 @@ class GeometryArray(ExtensionArray):
 
     @property
     def m(self):
-        """Return the m coordinate of point geometries in a GeoSeries"""
+        """Return the m coordinate of point geometries in a GeoSeries."""
         if not SHAPELY_GE_21:
             raise ImportError("'m' requires shapely>=2.1.")
 
@@ -1439,9 +1444,7 @@ class GeometryArray(ExtensionArray):
                 return np.array(self, dtype=dtype, copy=copy)
 
     def isna(self):
-        """
-        Boolean NumPy array indicating if each value is missing
-        """
+        """Boolean NumPy array indicating if each value is missing."""
         return shapely.is_missing(self._data)
 
     def value_counts(
@@ -1460,7 +1463,6 @@ class GeometryArray(ExtensionArray):
         -------
         pd.Series
         """
-
         # note ExtensionArray usage of value_counts only specifies dropna,
         # so sort, normalize and bins are not arguments
         values = to_wkb(self)
@@ -1683,7 +1685,7 @@ class GeometryArray(ExtensionArray):
         raise TypeError("geometries have no minimum or maximum")
 
     def _formatter(self, boxed=False):
-        """Formatting function for scalar values.
+        """Return a formatting function for scalar values.
 
         This is used in the default '__repr__'. The returned formatting
         function receives instances of your scalar type.
@@ -1739,8 +1741,7 @@ class GeometryArray(ExtensionArray):
 
     @classmethod
     def _concat_same_type(cls, to_concat):
-        """
-        Concatenate multiple array
+        """Concatenate multiple array.
 
         Parameters
         ----------
@@ -1764,8 +1765,9 @@ class GeometryArray(ExtensionArray):
         )
 
     def __array__(self, dtype=None, copy=None):
-        """
-        The numpy array interface.
+        """Return the data as a numpy array.
+
+        This is the numpy array interface.
 
         Returns
         -------
@@ -1809,9 +1811,7 @@ class GeometryArray(ExtensionArray):
         return self._binop(other, operator.ne)
 
     def __contains__(self, item):
-        """
-        Return for `item in self`.
-        """
+        """Return for `item in self`."""
         if isna(item):
             if (
                 item is self.dtype.na_value

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -25,28 +25,7 @@ def is_geometry_type(data):
 
 
 def _delegate_binary_method(op, this, other, align, *args, **kwargs):
-    """Binary method on GeoSeries objects that returns a Series/GeoSeries.
-
-    Parameters
-    ----------
-    op : str
-        The operation to perform, e.g. 'intersection', 'union', etc.
-    this : GeoSeries
-        The first GeoSeries operand.
-    other : GeoSeries
-        The second GeoSeries operand.
-    align : bool
-        Whether to align the indices of the two GeoSeries before performing the
-        operation.
-    *args, **kwargs : additional arguments
-        Additional arguments to pass to the method.
-
-    Returns
-    -------
-    Series or GeoSeries
-        A new Series/GeoSeries containing the result of the method.
-
-    """
+    # type: (str, GeoSeries, GeoSeries) -> GeoSeries/Series
     if align is None:
         align = True
         maybe_warn = True
@@ -93,28 +72,8 @@ def _delegate_binary_method(op, this, other, align, *args, **kwargs):
 
 
 def _binary_geo(op, this, other, align, *args, **kwargs):
-    """Binary operation on GeoSeries objects that returns a GeoSeries.
-
-    Parameters
-    ----------
-    op : str
-        The operation to perform, e.g. 'intersection', 'union', etc.
-    this : GeoSeries
-        The first GeoSeries operand.
-    other : GeoSeries
-        The second GeoSeries operand.
-    align : bool
-        Whether to align the indices of the two GeoSeries before performing the
-        operation.
-    *args, **kwargs : additional arguments
-        Additional arguments to pass to the operation.
-
-    Returns
-    -------
-    GeoSeries
-        A new GeoSeries containing the result of the binary operation.
-
-    """
+    # type: (str, GeoSeries, GeoSeries) -> GeoSeries
+    """Binary operation on GeoSeries objects that returns a GeoSeries."""
     from .geoseries import GeoSeries
 
     geoms, index = _delegate_binary_method(op, this, other, align, *args, **kwargs)
@@ -122,48 +81,14 @@ def _binary_geo(op, this, other, align, *args, **kwargs):
 
 
 def _binary_op(op, this, other, align, *args, **kwargs):
-    """Binary operation on GeoSeries objects that returns a Series.
-
-    Parameters
-    ----------
-    op : str
-        The operation to perform, e.g. 'intersection', 'union', etc.
-    this : GeoSeries
-        The first GeoSeries operand.
-    other : GeoSeries
-        The second GeoSeries operand.
-    align : bool
-        Whether to align the indices of the two GeoSeries before performing the
-        operation.
-    *args, **kwargs : additional arguments
-        Additional arguments to pass to the operation.
-
-    Returns
-    -------
-    Series
-        A Series containing the result of the binary operation.
-
-    """
+    # type: (str, GeoSeries, GeoSeries, args/kwargs) -> Series[bool/float]
+    """Binary operation on GeoSeries objects that returns a Series."""
     data, index = _delegate_binary_method(op, this, other, align, *args, **kwargs)
     return Series(data, index=index)
 
 
 def _delegate_property(op, this):
-    """Property on GeoSeries that returns a Series/GeoSeries.
-
-    Parameters
-    ----------
-    op : str
-        The operation to perform, e.g. 'intersection', 'union', etc.
-    this : GeoSeries
-        The first GeoSeries operand.
-
-    Returns
-    -------
-    Series or GeoSeries
-        A new Series/GeoSeries containing the result of the property.
-
-    """
+    # type: (str, GeoSeries) -> GeoSeries/Series
     a_this = GeometryArray(this.geometry.values)
     data = getattr(a_this, op)
     if isinstance(data, GeometryArray):
@@ -175,23 +100,8 @@ def _delegate_property(op, this):
 
 
 def _delegate_geo_method(op, this, **kwargs):
-    """Unary operation that returns a GeoSeries.
-
-    Parameters
-    ----------
-    op : str
-        The operation to perform, e.g. 'buffer', 'simplify', etc.
-    this : GeoSeries
-        The first GeoSeries operand.
-    *args, **kwargs : additional arguments
-        Additional arguments to pass to the method.
-
-    Returns
-    -------
-    GeoSeries
-        A new Series/GeoSeries containing the result of the method.
-
-    """
+    # type: (str, GeoSeries) -> GeoSeries
+    """Unary operation that returns a GeoSeries."""
     from .geodataframe import GeoDataFrame
     from .geoseries import GeoSeries
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -13,8 +13,7 @@ from .array import GeometryArray, GeometryDtype, points_from_xy
 
 
 def is_geometry_type(data):
-    """
-    Check if the data is of geometry dtype.
+    """Check if the data is of geometry dtype.
 
     Does not include object array of shapely scalars.
     """
@@ -26,7 +25,28 @@ def is_geometry_type(data):
 
 
 def _delegate_binary_method(op, this, other, align, *args, **kwargs):
-    # type: (str, GeoSeries, GeoSeries) -> GeoSeries/Series
+    """Binary method on GeoSeries objects that returns a Series/GeoSeries.
+
+    Parameters
+    ----------
+    op : str
+        The operation to perform, e.g. 'intersection', 'union', etc.
+    this : GeoSeries
+        The first GeoSeries operand.
+    other : GeoSeries
+        The second GeoSeries operand.
+    align : bool
+        Whether to align the indices of the two GeoSeries before performing the
+        operation.
+    *args, **kwargs : additional arguments
+        Additional arguments to pass to the method.
+
+    Returns
+    -------
+    Series or GeoSeries
+        A new Series/GeoSeries containing the result of the method.
+
+    """
     if align is None:
         align = True
         maybe_warn = True
@@ -73,8 +93,28 @@ def _delegate_binary_method(op, this, other, align, *args, **kwargs):
 
 
 def _binary_geo(op, this, other, align, *args, **kwargs):
-    # type: (str, GeoSeries, GeoSeries) -> GeoSeries
-    """Binary operation on GeoSeries objects that returns a GeoSeries"""
+    """Binary operation on GeoSeries objects that returns a GeoSeries.
+
+    Parameters
+    ----------
+    op : str
+        The operation to perform, e.g. 'intersection', 'union', etc.
+    this : GeoSeries
+        The first GeoSeries operand.
+    other : GeoSeries
+        The second GeoSeries operand.
+    align : bool
+        Whether to align the indices of the two GeoSeries before performing the
+        operation.
+    *args, **kwargs : additional arguments
+        Additional arguments to pass to the operation.
+
+    Returns
+    -------
+    GeoSeries
+        A new GeoSeries containing the result of the binary operation.
+
+    """
     from .geoseries import GeoSeries
 
     geoms, index = _delegate_binary_method(op, this, other, align, *args, **kwargs)
@@ -82,14 +122,48 @@ def _binary_geo(op, this, other, align, *args, **kwargs):
 
 
 def _binary_op(op, this, other, align, *args, **kwargs):
-    # type: (str, GeoSeries, GeoSeries, args/kwargs) -> Series[bool/float]
-    """Binary operation on GeoSeries objects that returns a Series"""
+    """Binary operation on GeoSeries objects that returns a Series.
+
+    Parameters
+    ----------
+    op : str
+        The operation to perform, e.g. 'intersection', 'union', etc.
+    this : GeoSeries
+        The first GeoSeries operand.
+    other : GeoSeries
+        The second GeoSeries operand.
+    align : bool
+        Whether to align the indices of the two GeoSeries before performing the
+        operation.
+    *args, **kwargs : additional arguments
+        Additional arguments to pass to the operation.
+
+    Returns
+    -------
+    Series
+        A Series containing the result of the binary operation.
+
+    """
     data, index = _delegate_binary_method(op, this, other, align, *args, **kwargs)
     return Series(data, index=index)
 
 
 def _delegate_property(op, this):
-    # type: (str, GeoSeries) -> GeoSeries/Series
+    """Property on GeoSeries that returns a Series/GeoSeries.
+
+    Parameters
+    ----------
+    op : str
+        The operation to perform, e.g. 'intersection', 'union', etc.
+    this : GeoSeries
+        The first GeoSeries operand.
+
+    Returns
+    -------
+    Series or GeoSeries
+        A new Series/GeoSeries containing the result of the property.
+
+    """
     a_this = GeometryArray(this.geometry.values)
     data = getattr(a_this, op)
     if isinstance(data, GeometryArray):
@@ -101,8 +175,23 @@ def _delegate_property(op, this):
 
 
 def _delegate_geo_method(op, this, **kwargs):
-    # type: (str, GeoSeries) -> GeoSeries
-    """Unary operation that returns a GeoSeries"""
+    """Unary operation that returns a GeoSeries.
+
+    Parameters
+    ----------
+    op : str
+        The operation to perform, e.g. 'buffer', 'simplify', etc.
+    this : GeoSeries
+        The first GeoSeries operand.
+    *args, **kwargs : additional arguments
+        Additional arguments to pass to the method.
+
+    Returns
+    -------
+    GeoSeries
+        A new Series/GeoSeries containing the result of the method.
+
+    """
     from .geodataframe import GeoDataFrame
     from .geoseries import GeoSeries
 
@@ -134,12 +223,11 @@ def _delegate_geo_method(op, this, **kwargs):
 class GeoPandasBase:
     @property
     def area(self):
-        """Returns a ``Series`` containing the area of each geometry in the
+        """Return a ``Series`` containing the area of each geometry in the
         ``GeoSeries`` expressed in the units of the CRS.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -166,7 +254,7 @@ class GeoPandasBase:
         4     0.0
         dtype: float64
 
-        See also
+        See Also
         --------
         GeoSeries.length : measure length
 
@@ -183,9 +271,7 @@ class GeoPandasBase:
 
     @property
     def crs(self):
-        """
-        The Coordinate Reference System (CRS) represented as a ``pyproj.CRS``
-        object.
+        """The Coordinate Reference System (CRS) as a ``pyproj.CRS`` object.
 
         Returns None if the CRS is not set, and to set the value it
         :getter: Returns a ``pyproj.CRS`` or None. When setting, the value
@@ -195,7 +281,6 @@ class GeoPandasBase:
 
         Examples
         --------
-
         >>> s.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
@@ -209,7 +294,7 @@ class GeoPandasBase:
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
 
-        See also
+        See Also
         --------
         GeoSeries.set_crs : assign CRS
         GeoSeries.to_crs : re-project to another CRS
@@ -218,7 +303,7 @@ class GeoPandasBase:
 
     @crs.setter
     def crs(self, value):
-        """Sets the value of the crs"""
+        """Set the value of the crs."""
         self.geometry.values.crs = value
 
     @property
@@ -243,12 +328,12 @@ class GeoPandasBase:
 
     @property
     def type(self):
-        """Return the geometry type of each geometry in the GeoSeries"""
+        """Return the geometry type of each geometry in the GeoSeries."""
         return self.geom_type
 
     @property
     def length(self):
-        """Returns a ``Series`` containing the length of each geometry
+        """Return a ``Series`` containing the length of each geometry
         expressed in the units of the CRS.
 
         In the case of a (Multi)Polygon it measures the length
@@ -256,7 +341,6 @@ class GeoPandasBase:
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, MultiLineString, Point, \
 GeometryCollection
         >>> s = geopandas.GeoSeries(
@@ -288,7 +372,7 @@ GeometryCollection
         5    16.180340
         dtype: float64
 
-        See also
+        See Also
         --------
         GeoSeries.area : measure area of a polygon
 
@@ -306,12 +390,11 @@ GeometryCollection
 
     @property
     def is_valid(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         geometries that are valid.
 
         Examples
         --------
-
         An example with one invalid polygon (a bowtie geometry crossing itself)
         and one missing geometry:
 
@@ -338,19 +421,18 @@ GeometryCollection
         3    False
         dtype: bool
 
-        See also
+        See Also
         --------
         GeoSeries.is_valid_reason : reason for invalidity
         """
         return _delegate_property("is_valid", self)
 
     def is_valid_reason(self):
-        """Returns a ``Series`` of strings with the reason for invalidity of
+        """Return a ``Series`` of strings with the reason for invalidity of
         each geometry.
 
         Examples
         --------
-
         An example with one invalid polygon (a bowtie geometry crossing itself)
         and one missing geometry:
 
@@ -377,7 +459,7 @@ GeometryCollection
         3    None
         dtype: object
 
-        See also
+        See Also
         --------
         GeoSeries.is_valid : detect invalid geometries
         GeoSeries.make_valid : fix invalid geometries
@@ -385,7 +467,7 @@ GeometryCollection
         return Series(self.geometry.values.is_valid_reason(), index=self.index)
 
     def is_valid_coverage(self, *, gap_width=0.0):
-        """Returns a ``bool`` indicating whether a ``GeoSeries`` forms a valid coverage
+        """Return a ``bool`` indicating whether a ``GeoSeries`` forms a valid coverage.
 
         A ``GeoSeries`` of valid polygons is considered a coverage if the polygons are:
 
@@ -449,7 +531,7 @@ GeometryCollection
         >>> s2.is_valid_coverage()
         False
 
-        See also
+        See Also
         --------
         GeoSeries.invalid_coverage_edges
         GeoSeries.simplify_coverage
@@ -457,7 +539,7 @@ GeometryCollection
         return self.geometry.values.is_valid_coverage(gap_width=gap_width)
 
     def invalid_coverage_edges(self, *, gap_width=0.0):
-        """Returns a ``GeoSeries`` containing edges causing invalid polygonal coverage
+        """Return a ``GeoSeries`` containing edges causing invalid polygonal coverage.
 
         This method returns (Multi)LineStrings showing the location of edges violating
         polygonal coverage (if any) in each polygon in the input ``GeoSeries``.
@@ -511,7 +593,7 @@ GeometryCollection
         dtype: geometry
 
 
-        See also
+        See Also
         --------
         GeoSeries.is_valid_coverage
         GeoSeries.simplify_coverage
@@ -551,8 +633,7 @@ GeometryCollection
         return _delegate_property("is_empty", self)
 
     def count_coordinates(self):
-        """
-        Returns a ``Series`` containing the count of the number of coordinate pairs
+        """Return a ``Series`` containing the count of the number of coordinate pairs
         in each geometry.
 
         Examples
@@ -586,7 +667,7 @@ GeometryCollection
         4    0
         dtype: int32
 
-        See also
+        See Also
         --------
         GeoSeries.get_coordinates : extract coordinates as a :class:`~pandas.DataFrame`
         GoSeries.count_geometries : count the number of geometries in a collection
@@ -594,8 +675,7 @@ GeometryCollection
         return Series(self.geometry.values.count_coordinates(), index=self.index)
 
     def count_geometries(self):
-        """
-        Returns a ``Series`` containing the count of geometries in each multi-part
+        """Return a ``Series`` containing the count of geometries in each multi-part
         geometry.
 
         For single-part geometry objects, this is always 1. For multi-part geometries,
@@ -630,7 +710,7 @@ GeometryCollection
         3    1
         dtype: int32
 
-        See also
+        See Also
         --------
         GeoSeries.count_coordinates : count the number of coordinates in a geometry
         GeoSeries.count_interior_rings : count the number of interior rings
@@ -638,8 +718,7 @@ GeometryCollection
         return Series(self.geometry.values.count_geometries(), index=self.index)
 
     def count_interior_rings(self):
-        """
-        Returns a ``Series`` containing the count of the number of interior rings
+        """Return a ``Series`` containing the count of the number of interior rings
         in a polygonal geometry.
 
         For non-polygonal geometries, this is always 0.
@@ -675,7 +754,7 @@ GeometryCollection
         2    0
         dtype: int32
 
-        See also
+        See Also
         --------
         GeoSeries.count_coordinates : count the number of coordinates in a geometry
         GeoSeries.count_geometries : count the number of geometries in a collection
@@ -684,7 +763,7 @@ GeometryCollection
 
     @property
     def is_simple(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         geometries that do not cross themselves.
 
         This is meaningful only for `LineStrings` and `LinearRings`.
@@ -712,7 +791,7 @@ GeometryCollection
 
     @property
     def is_ring(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         features that are closed.
 
         When constructing a LinearRing, the sequence of coordinates may be
@@ -747,7 +826,7 @@ GeometryCollection
 
     @property
     def is_ccw(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True``
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True``
         if a LineString or LinearRing is counterclockwise.
 
         Note that there are no checks on whether lines are actually
@@ -788,7 +867,7 @@ GeometryCollection
 
     @property
     def is_closed(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True``
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True``
         if a LineString's or LinearRing's first and last points are equal.
 
         Returns False for any other geometry type.
@@ -822,7 +901,7 @@ GeometryCollection
 
     @property
     def has_z(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         features that have a z-component.
 
         Notes
@@ -853,7 +932,7 @@ GeometryCollection
 
     @property
     def has_m(self):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         features that have a m-component.
 
         Requires Shapely >= 2.1.
@@ -885,7 +964,7 @@ GeometryCollection
         return _delegate_property("has_m", self)
 
     def get_precision(self):
-        """Returns a ``Series`` of the precision of each geometry.
+        """Return a ``Series`` of the precision of each geometry.
 
         If a precision has not been previously set, it will be 0, indicating regular
         double precision coordinates are in use. Otherwise, it will return the precision
@@ -928,14 +1007,14 @@ GeometryCollection
         2    1.0
         dtype: float64
 
-        See also
+        See Also
         --------
         GeoSeries.set_precision : set precision grid size
         """
         return Series(self.geometry.values.get_precision(), index=self.index)
 
     def get_geometry(self, index):
-        """Returns the n-th geometry from a collection of geometries.
+        """Return the n-th geometry from a collection of geometries.
 
         Parameters
         ----------
@@ -996,12 +1075,11 @@ GeometryCollection
 
     @property
     def boundary(self):
-        """Returns a ``GeoSeries`` of lower dimensional objects representing
+        """Return a ``GeoSeries`` of lower dimensional objects representing
         each geometry's set-theoretic `boundary`.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1022,7 +1100,7 @@ GeometryCollection
         2           GEOMETRYCOLLECTION EMPTY
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.exterior : outer boundary (without interior rings)
 
@@ -1031,14 +1109,13 @@ GeometryCollection
 
     @property
     def centroid(self):
-        """Returns a ``GeoSeries`` of points representing the centroid of each
+        """Return a ``GeoSeries`` of points representing the centroid of each
         geometry.
 
         Note that centroid does not have to be on or within original geometry.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1059,14 +1136,14 @@ GeometryCollection
         2                POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.representative_point : point guaranteed to be within each geometry
         """
         return _delegate_property("centroid", self)
 
     def concave_hull(self, ratio=0.0, allow_holes=False):
-        """Returns a ``GeoSeries`` of geometries representing the concave hull
+        """Return a ``GeoSeries`` of geometries representing the concave hull
         of vertices of each geometry.
 
         The concave hull of a geometry is the smallest concave `Polygon`
@@ -1092,7 +1169,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1120,7 +1196,7 @@ GeometryCollection
         4                                         POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.convex_hull : convex hull geometry
 
@@ -1136,7 +1212,7 @@ GeometryCollection
         )
 
     def constrained_delaunay_triangles(self):
-        """Returns a :class:`~geopandas.GeoSeries` with the constrained
+        """Return a :class:`~geopandas.GeoSeries` with the constrained
         Delaunay triangulation of polygons.
 
         A constrained Delaunay triangulation requires the edges of the input
@@ -1150,7 +1226,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon
         >>> s = geopandas.GeoSeries([Polygon([(0, 0), (1, 1), (0, 1)])])
         >>> s
@@ -1161,7 +1236,7 @@ GeometryCollection
         0         GEOMETRYCOLLECTION (POLYGON ((0 0, 0 1, 1 1, 0...
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.delaunay_triangles : Delaunay triangulation
 
@@ -1170,7 +1245,7 @@ GeometryCollection
 
     @property
     def convex_hull(self):
-        """Returns a ``GeoSeries`` of geometries representing the convex hull
+        """Return a ``GeoSeries`` of geometries representing the convex hull
         of each geometry.
 
         The convex hull of a geometry is the smallest convex `Polygon`
@@ -1180,7 +1255,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1207,7 +1281,7 @@ GeometryCollection
         4                            POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.concave_hull : concave hull geometry
         GeoSeries.envelope : bounding rectangle geometry
@@ -1216,7 +1290,7 @@ GeometryCollection
         return _delegate_property("convex_hull", self)
 
     def delaunay_triangles(self, tolerance=0.0, only_edges=False):
-        """Returns a ``GeoSeries`` consisting of objects representing
+        """Return a ``GeoSeries`` consisting of objects representing
         the computed Delaunay triangulation between the vertices of
         an input geometry.
 
@@ -1241,7 +1315,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely import LineString, MultiPoint, Point, Polygon
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1300,7 +1373,7 @@ GeometryCollection
         8    POLYGON ((2 0, 1 1, 1 0, 2 0))
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.voronoi_polygons : Voronoi diagram around vertices
         GeoSeries.constrained_delaunay_triangles : constrained Delaunay triangulation
@@ -1317,7 +1390,7 @@ GeometryCollection
         return GeoSeries(delaunay, crs=self.crs).explode(ignore_index=True)
 
     def voronoi_polygons(self, tolerance=0.0, extend_to=None, only_edges=False):
-        """Returns a ``GeoSeries`` consisting of objects representing
+        """Return a ``GeoSeries`` consisting of objects representing
         the computed Voronoi diagram around the vertices of an input geometry.
 
         All geometries within the GeoSeries are considered together within a single
@@ -1425,7 +1498,7 @@ GeometryCollection
         8       POLYGON ((6 -3, 2.5 0.5, 2.5 2, 6 3.75, 6 -3))
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.delaunay_triangles : Delaunay triangulation around vertices
         """
@@ -1444,7 +1517,7 @@ GeometryCollection
 
     @property
     def envelope(self):
-        """Returns a ``GeoSeries`` of geometries representing the envelope of
+        """Return a ``GeoSeries`` of geometries representing the envelope of
         each geometry.
 
         The envelope of a geometry is the bounding rectangle. That is, the
@@ -1453,7 +1526,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1477,14 +1549,14 @@ GeometryCollection
         3                            POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.convex_hull : convex hull geometry
         """
         return _delegate_property("envelope", self)
 
     def minimum_rotated_rectangle(self):
-        """Returns a ``GeoSeries`` of the general minimum bounding rectangle
+        """Return a ``GeoSeries`` of the general minimum bounding rectangle
         that contains the object.
 
         Unlike envelope this rectangle is not constrained to be parallel
@@ -1493,7 +1565,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point, MultiPoint
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1517,7 +1588,7 @@ GeometryCollection
         3                            POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.envelope : bounding rectangle
         """
@@ -1525,7 +1596,7 @@ GeometryCollection
 
     @property
     def exterior(self):
-        """Returns a ``GeoSeries`` of LinearRings representing the outer
+        """Return a ``GeoSeries`` of LinearRings representing the outer
         boundary of each polygon in the GeoSeries.
 
         Applies to GeoSeries containing only Polygons. Returns ``None``` for
@@ -1533,7 +1604,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1554,7 +1624,7 @@ GeometryCollection
         2                               None
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.boundary : complete set-theoretic boundary
         GeoSeries.interiors : list of inner rings of each polygon
@@ -1563,12 +1633,11 @@ GeometryCollection
         return _delegate_property("exterior", self)
 
     def extract_unique_points(self):
-        """Returns a ``GeoSeries`` of MultiPoints representing all
+        """Return a ``GeoSeries`` of MultiPoints representing all
         distinct vertices of an input geometry.
 
         Examples
         --------
-
         >>> from shapely import LineString, Polygon
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1586,15 +1655,14 @@ GeometryCollection
         1    MULTIPOINT ((0 0), (1 1))
         dtype: geometry
 
-        See also
+        See Also
         --------
-
         GeoSeries.get_coordinates : extract coordinates as a :class:`~pandas.DataFrame`
         """
         return _delegate_geo_method("extract_unique_points", self)
 
     def offset_curve(self, distance, quad_segs=8, join_style="round", mitre_limit=5.0):
-        """Returns a ``LineString`` or ``MultiLineString`` geometry at a
+        """Return a ``LineString`` or ``MultiLineString`` geometry at a
         distance from the object on its right or its left side.
 
         Parameters
@@ -1619,7 +1687,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import LineString
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1646,7 +1713,7 @@ GeometryCollection
 
     @property
     def interiors(self):
-        """Returns a ``Series`` of List representing the
+        """Return a ``Series`` of List representing the
         inner rings of each polygon in the GeoSeries.
 
         Applies to GeoSeries containing only Polygons.
@@ -1658,7 +1725,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1679,14 +1745,14 @@ GeometryCollection
         1                                                   []
         dtype: object
 
-        See also
+        See Also
         --------
         GeoSeries.exterior : outer boundary
         """
         return _delegate_property("interiors", self)
 
     def remove_repeated_points(self, tolerance=0.0):
-        """Returns a ``GeoSeries`` containing a copy of the input geometry
+        """Return a ``GeoSeries`` containing a copy of the input geometry
         with repeated points removed.
 
         From the start of the coordinate sequence, each next point within the
@@ -1703,7 +1769,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely import LineString, Polygon
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1724,7 +1789,7 @@ GeometryCollection
         return _delegate_geo_method("remove_repeated_points", self, tolerance=tolerance)
 
     def set_precision(self, grid_size, mode="valid_output"):
-        """Returns a ``GeoSeries`` with the precision set to a precision grid size.
+        """Return a ``GeoSeries`` with the precision set to a precision grid size.
 
         By default, geometries use double precision coordinates (``grid_size=0``).
 
@@ -1758,7 +1823,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely import LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1813,12 +1877,11 @@ GeometryCollection
         )
 
     def representative_point(self):
-        """Returns a ``GeoSeries`` of (cheaply computed) points that are
+        """Return a ``GeoSeries`` of (cheaply computed) points that are
         guaranteed to be within each geometry.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1839,19 +1902,18 @@ GeometryCollection
         2         POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.centroid : geometric centroid
         """
         return _delegate_geo_method("representative_point", self)
 
     def minimum_bounding_circle(self):
-        """Returns a ``GeoSeries`` of geometries representing the minimum bounding
+        """Return a ``GeoSeries`` of geometries representing the minimum bounding
         circle that encloses each geometry.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1872,7 +1934,7 @@ GeometryCollection
         2                                          POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.convex_hull : convex hull geometry
         GeoSeries.maximum_inscribed_circle : the largest circle within the geometry
@@ -1880,7 +1942,7 @@ GeometryCollection
         return _delegate_geo_method("minimum_bounding_circle", self)
 
     def maximum_inscribed_circle(self, *, tolerance=None):
-        """Returns a ``GeoSeries`` of geometries representing the largest circle that
+        """Return a ``GeoSeries`` of geometries representing the largest circle that
         is fully contained within the input geometry.
 
         Constructs the “maximum inscribed circle” (MIC) for a polygonal geometry, up to
@@ -1913,7 +1975,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -1936,7 +1997,7 @@ GeometryCollection
         1          LINESTRING (2.5 7.5, 2.5 10)
         dtype: geometry
 
-        See also
+        See Also
         --------
         minimum_bounding_circle
         """
@@ -1945,7 +2006,7 @@ GeometryCollection
         )
 
     def minimum_bounding_radius(self):
-        """Returns a `Series` of the radii of the minimum bounding circles
+        """Return a `Series` of the radii of the minimum bounding circles
         that enclose each geometry.
 
         Examples
@@ -1970,7 +2031,7 @@ GeometryCollection
         2    0.000000
         dtype: float64
 
-        See also
+        See Also
         --------
         GeoSeries.minumum_bounding_circle : minimum bounding circle (geometry)
 
@@ -1978,7 +2039,7 @@ GeometryCollection
         return Series(self.geometry.values.minimum_bounding_radius(), index=self.index)
 
     def minimum_clearance(self):
-        """Returns a ``Series`` containing the minimum clearance distance,
+        """Return a ``Series`` containing the minimum clearance distance,
         which is the smallest distance by which a vertex of the geometry
         could be moved to produce an invalid geometry.
 
@@ -1987,7 +2048,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -2008,14 +2068,14 @@ GeometryCollection
         2         inf
         dtype: float64
 
-        See also
+        See Also
         --------
         minimum_clearance_line
         """
         return Series(self.geometry.values.minimum_clearance(), index=self.index)
 
     def minimum_clearance_line(self):
-        """Returns a ``GeoSeries`` of linestrings whose endpoints define the
+        """Return a ``GeoSeries`` of linestrings whose endpoints define the
         minimum clearance.
 
         A geometry's “minimum clearance” is the smallest distance by which a vertex
@@ -2029,7 +2089,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -2050,14 +2109,14 @@ GeometryCollection
         2             LINESTRING EMPTY
         dtype: geometry
 
-        See also
+        See Also
         --------
         minimum_clearance
         """
         return _delegate_geo_method("minimum_clearance_line", self)
 
     def normalize(self):
-        """Returns a ``GeoSeries`` of normalized
+        """Return a ``GeoSeries`` of normalized
         geometries to normal form (or canonical form).
 
         This method orders the coordinates, rings of a polygon and parts of
@@ -2066,7 +2125,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -2090,7 +2148,7 @@ GeometryCollection
         return _delegate_geo_method("normalize", self)
 
     def orient_polygons(self, *, exterior_cw=False):
-        """Returns a ``GeoSeries`` of geometries with enforced ring orientation.
+        """Return a ``GeoSeries`` of geometries with enforced ring orientation.
 
         Enforce a ring orientation on all polygonal elements in the ``GeoSeries``.
 
@@ -2113,7 +2171,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -2216,11 +2273,10 @@ GeometryCollection
         )
 
     def reverse(self):
-        """Returns a ``GeoSeries`` with the order of coordinates reversed.
+        """Return a ``GeoSeries`` with the order of coordinates reversed.
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon, LineString, Point
         >>> s = geopandas.GeoSeries(
         ...     [
@@ -2241,14 +2297,14 @@ GeometryCollection
         2                       POINT (0 0)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.normalize : normalize order of coordinates
         """
         return _delegate_geo_method("reverse", self)
 
     def segmentize(self, max_segment_length):
-        """Returns a ``GeoSeries`` with vertices added to line segments based on
+        """Return a ``GeoSeries`` with vertices added to line segments based on
         maximum segment length.
 
         Additional vertices will be added to every line segment in an input geometry so
@@ -2290,7 +2346,7 @@ GeometryCollection
         )
 
     def transform(self, transformation, include_z=False):
-        """Returns a ``GeoSeries`` with the transformation function
+        """Return a ``GeoSeries`` with the transformation function
         applied to the geometry coordinates.
 
         Parameters
@@ -2332,7 +2388,7 @@ GeometryCollection
         )
 
     def force_2d(self):
-        """Forces the dimensionality of a geometry to 2D.
+        """Force the dimensionality of a geometry to 2D.
 
         Removes the additional Z coordinate dimension from all geometries.
 
@@ -2365,7 +2421,7 @@ GeometryCollection
         return _delegate_geo_method("force_2d", self)
 
     def force_3d(self, z=0):
-        """Forces the dimensionality of a geometry to 3D.
+        """Force the dimensionality of a geometry to 3D.
 
         2D geometries will get the provided Z coordinate; 3D geometries
         are unchanged (unless their Z coordinate is ``np.nan``).
@@ -2428,7 +2484,7 @@ GeometryCollection
         return _delegate_geo_method("force_3d", self, z=z)
 
     def line_merge(self, directed=False):
-        """Returns (Multi)LineStrings formed by combining the lines in a
+        """Return (Multi)LineStrings formed by combining the lines in a
         MultiLineString.
 
         Lines are joined together at their endpoints in case two lines are intersecting.
@@ -2500,7 +2556,7 @@ GeometryCollection
 
     @property
     def unary_union(self):
-        """Returns a geometry containing the union of all geometries in the
+        """Return a geometry containing the union of all geometries in the
         ``GeoSeries``.
 
         The ``unary_union`` attribute is deprecated. Use :meth:`union_all`
@@ -2508,7 +2564,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import box
         >>> s = geopandas.GeoSeries([box(0,0,1,1), box(0,0,2,2)])
         >>> s
@@ -2520,11 +2575,10 @@ GeometryCollection
         >>> print(union)
         POLYGON ((0 1, 0 2, 2 2, 2 0, 1 0, 0 0, 0 1))
 
-        See also
+        See Also
         --------
         GeoSeries.union_all
         """
-
         warn(
             "The 'unary_union' attribute is deprecated, "
             "use the 'union_all()' method instead.",
@@ -2535,7 +2589,7 @@ GeometryCollection
         return self.geometry.values.union_all()
 
     def union_all(self, method="unary", *, grid_size=None):
-        """Returns a geometry containing the union of all geometries in the
+        """Return a geometry containing the union of all geometries in the
         ``GeoSeries``.
 
         By default, the unary union algorithm is used. If the geometries are
@@ -2576,7 +2630,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import box
         >>> s = geopandas.GeoSeries([box(0, 0, 1, 1), box(0, 0, 2, 2)])
         >>> s
@@ -2590,7 +2643,7 @@ GeometryCollection
         return self.geometry.values.union_all(method=method, grid_size=grid_size)
 
     def intersection_all(self):
-        """Returns a geometry containing the intersection of all geometries in
+        """Return a geometry containing the intersection of all geometries in
         the ``GeoSeries``.
 
         This method ignores None values when other geometries are present.
@@ -2599,7 +2652,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import box
         >>> s = geopandas.GeoSeries(
         ...     [box(0, 0, 2, 2), box(1, 1, 3, 3), box(0, 0, 1.5, 1.5)]
@@ -2620,7 +2672,7 @@ GeometryCollection
     #
 
     def contains(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that contains `other`.
 
         An object is said to contain `other` if at least one point of `other` lies in
@@ -2728,7 +2780,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``contains`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.contains_properly
         GeoSeries.within
@@ -2736,7 +2788,7 @@ GeometryCollection
         return _binary_op("contains", self, other, align)
 
     def contains_properly(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is completely inside ``other``, with no common
         boundary points.
 
@@ -2850,14 +2902,14 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``contains_properly`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.contains
         """
         return _binary_op("contains_properly", self, other, align)
 
     def dwithin(self, other, distance, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is within a set distance from ``other``.
 
         The operation works on a 1-to-1 row-wise manner:
@@ -2961,14 +3013,14 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is within the set distance of *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.within
         """
         return _binary_op("dwithin", self, other, distance=distance, align=align)
 
     def geom_equals(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry equal to `other`.
 
         An object is said to be equal to `other` if its set-theoretic
@@ -3070,7 +3122,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is equal to *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.geom_equals_exact
         GeoSeries.geom_equals_identical
@@ -3135,7 +3187,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is equal to *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.geom_equals
         GeoSeries.geom_equals_identical
@@ -3212,7 +3264,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is equal to *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.geom_equals
         GeoSeries.geom_equals_exact
@@ -3220,7 +3272,7 @@ GeometryCollection
         return _binary_op("geom_equals_identical", self, other, align=align)
 
     def crosses(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that cross `other`.
 
         An object is said to cross `other` if its `interior` intersects the
@@ -3323,7 +3375,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``crosses`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.disjoint
         GeoSeries.intersects
@@ -3332,7 +3384,7 @@ GeometryCollection
         return _binary_op("crosses", self, other, align)
 
     def disjoint(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry disjoint to `other`.
 
         An object is said to be disjoint to `other` if its `boundary` and
@@ -3424,7 +3476,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is equal to *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.intersects
         GeoSeries.touches
@@ -3433,7 +3485,7 @@ GeometryCollection
         return _binary_op("disjoint", self, other, align)
 
     def intersects(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that intersects `other`.
 
         An object is said to intersect `other` if its `boundary` and `interior`
@@ -3534,7 +3586,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``crosses`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.disjoint
         GeoSeries.crosses
@@ -3544,7 +3596,7 @@ GeometryCollection
         return _binary_op("intersects", self, other, align)
 
     def overlaps(self, other, align=None):
-        """Returns True for all aligned geometries that overlap *other*, else False.
+        """Return True for all aligned geometries that overlap *other*, else False.
 
         Geometries overlaps if they have more than one but not all
         points in common, have the same dimension, and the intersection of the
@@ -3646,7 +3698,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``overlaps`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.crosses
         GeoSeries.intersects
@@ -3655,7 +3707,7 @@ GeometryCollection
         return _binary_op("overlaps", self, other, align)
 
     def touches(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that touches `other`.
 
         An object is said to touch `other` if it has at least one point in
@@ -3758,7 +3810,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``touches`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.overlaps
         GeoSeries.intersects
@@ -3767,7 +3819,7 @@ GeometryCollection
         return _binary_op("touches", self, other, align)
 
     def within(self, other, align=None):
-        """Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is within `other`.
 
         An object is said to be within `other` if at least one of its points is located
@@ -3874,15 +3926,14 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is ``within`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.contains
         """
         return _binary_op("within", self, other, align)
 
     def covers(self, other, align=None):
-        """
-        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is entirely covering `other`.
 
         An object A is said to cover another object B if no points of B lie
@@ -3987,7 +4038,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries ``covers`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.covered_by
         GeoSeries.overlaps
@@ -3995,8 +4046,7 @@ GeometryCollection
         return _binary_op("covers", self, other, align)
 
     def covered_by(self, other, align=None):
-        """
-        Returns a ``Series`` of ``dtype('bool')`` with value ``True`` for
+        """Return a ``Series`` of ``dtype('bool')`` with value ``True`` for
         each aligned geometry that is entirely covered by `other`.
 
         An object A is said to cover another object B if no points of B lie
@@ -4101,7 +4151,7 @@ GeometryCollection
         This method works in a row-wise manner. It does not check if an element
         of one GeoSeries is ``covered_by`` *any* element of the other one.
 
-        See also
+        See Also
         --------
         GeoSeries.covers
         GeoSeries.overlaps
@@ -4109,7 +4159,7 @@ GeometryCollection
         return _binary_op("covered_by", self, other, align)
 
     def distance(self, other, align=None):
-        """Returns a ``Series`` containing the distance to aligned `other`.
+        """Return a ``Series`` containing the distance to aligned `other`.
 
         The operation works on a 1-to-1 row-wise manner:
 
@@ -4205,7 +4255,7 @@ GeometryCollection
         return _binary_op("distance", self, other, align)
 
     def hausdorff_distance(self, other, align=None, densify=None):
-        """Returns a ``Series`` containing the Hausdorff distance to aligned `other`.
+        """Return a ``Series`` containing the Hausdorff distance to aligned `other`.
 
         The Hausdorff distance is the largest distance consisting of any point in `self`
         with the nearest point in `other`.
@@ -4320,7 +4370,7 @@ GeometryCollection
         return _binary_op("hausdorff_distance", self, other, align, densify=densify)
 
     def frechet_distance(self, other, align=None, densify=None):
-        """Returns a ``Series`` containing the Frechet distance to aligned `other`.
+        """Return a ``Series`` containing the Frechet distance to aligned `other`.
 
         The Fréchet distance is a measure of similarity: it is the greatest distance
         between any point in A and the closest point in B. The discrete distance is an
@@ -4444,7 +4494,7 @@ GeometryCollection
     #
 
     def difference(self, other, align=None):
-        """Returns a ``GeoSeries`` of the points in each aligned geometry that
+        """Return a ``GeoSeries`` of the points in each aligned geometry that
         are not in `other`.
 
         .. image:: ../../../_static/binary_geo-difference.svg
@@ -4555,7 +4605,7 @@ GeometryCollection
         return _binary_geo("difference", self, other, align)
 
     def symmetric_difference(self, other, align=None):
-        """Returns a ``GeoSeries`` of the symmetric difference of points in
+        """Return a ``GeoSeries`` of the symmetric difference of points in
         each aligned geometry with `other`.
 
         For each geometry, the symmetric difference consists of points in the
@@ -4670,7 +4720,7 @@ GeometryCollection
         return _binary_geo("symmetric_difference", self, other, align)
 
     def union(self, other, align=None):
-        """Returns a ``GeoSeries`` of the union of points in each aligned geometry with
+        """Return a ``GeoSeries`` of the union of points in each aligned geometry with
         `other`.
 
         .. image:: ../../../_static/binary_geo-union.svg
@@ -4784,7 +4834,7 @@ GeometryCollection
         return _binary_geo("union", self, other, align)
 
     def intersection(self, other, align=None):
-        """Returns a ``GeoSeries`` of the intersection of points in each
+        """Return a ``GeoSeries`` of the intersection of points in each
         aligned geometry with `other`.
 
         .. image:: ../../../_static/binary_geo-intersection.svg
@@ -4897,7 +4947,7 @@ GeometryCollection
         return _binary_geo("intersection", self, other, align)
 
     def clip_by_rect(self, xmin, ymin, xmax, ymax):
-        """Returns a ``GeoSeries`` of the portions of geometry within the given
+        """Return a ``GeoSeries`` of the portions of geometry within the given
         rectangle.
 
         Note that the results are not exactly equal to
@@ -4955,7 +5005,7 @@ GeometryCollection
         4          GEOMETRYCOLLECTION EMPTY
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoSeries.intersection
         """
@@ -4966,8 +5016,7 @@ GeometryCollection
         return GeoSeries(clipped_geometry, index=self.index, crs=self.crs)
 
     def shortest_line(self, other, align=None):
-        """
-        Returns the shortest two-point line between two geometries.
+        """Return the shortest two-point line between two geometries.
 
         The resulting line consists of two points, representing the nearest points
         between the geometry pair. The line always starts in the first geometry a
@@ -5170,8 +5219,7 @@ GeometryCollection
         return _binary_geo("snap", self, other, align, tolerance=tolerance)
 
     def shared_paths(self, other, align=None):
-        """
-        Returns the shared paths between two geometries.
+        """Return the shared paths between two geometries.
 
         Geometries within the GeoSeries should be only (Multi)LineStrings or
         LinearRings. A GeoSeries of GeometryCollections is returned with two elements
@@ -5265,7 +5313,6 @@ GeometryCollection
         --------
         GeoSeries.get_geometry
         """
-
         return _binary_geo("shared_paths", self, other, align)
 
     #
@@ -5274,7 +5321,7 @@ GeometryCollection
 
     @property
     def bounds(self):
-        """Returns a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
+        """Return a ``DataFrame`` with columns ``minx``, ``miny``, ``maxx``,
         ``maxy`` values containing the bounds for each geometry.
 
         See ``GeoSeries.total_bounds`` for the limits of the entire series.
@@ -5308,7 +5355,7 @@ GeometryCollection
 
     @property
     def total_bounds(self):
-        """Returns a tuple containing ``minx``, ``miny``, ``maxx``, ``maxy``
+        """Return a tuple containing ``minx``, ``miny``, ``maxx``, ``maxy``
         values for the bounds of the series as a whole.
 
         See ``GeoSeries.bounds`` for the bounds of the geometries contained in
@@ -5327,7 +5374,7 @@ GeometryCollection
 
     @property
     def sindex(self):
-        """Generate the spatial index
+        """Generate the spatial index.
 
         Creates R-tree spatial index based on ``shapely.STRtree``.
 
@@ -5391,7 +5438,6 @@ GeometryCollection
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> d = {'geometry': [Point(1, 2), Point(2, 1)]}
         >>> gdf = geopandas.GeoDataFrame(d)
@@ -5419,7 +5465,7 @@ GeometryCollection
         single_sided=False,
         **kwargs,
     ):
-        """Returns a ``GeoSeries`` of geometries representing all points within
+        """Return a ``GeoSeries`` of geometries representing all points within
         a given ``distance`` of each geometric object.
 
         Computes the buffer of a geometry for positive and negative buffer distance.
@@ -5496,7 +5542,7 @@ GeometryCollection
         )
 
     def simplify(self, tolerance, preserve_topology=True):
-        """Returns a ``GeoSeries`` containing a simplified representation of
+        """Return a ``GeoSeries`` containing a simplified representation of
         each geometry.
 
         The algorithm (Douglas-Peucker) recursively splits the original line
@@ -5532,7 +5578,7 @@ GeometryCollection
         coordinates: two geometries differing only in order of coordinates may be
         simplified differently.
 
-        See also
+        See Also
         --------
         simplify_coverage : simplify geometries using coverage simplification
 
@@ -5557,7 +5603,7 @@ GeometryCollection
         )
 
     def simplify_coverage(self, tolerance, *, simplify_boundary=True):
-        """Returns a ``GeoSeries`` containing a simplified representation of
+        """Return a ``GeoSeries`` containing a simplified representation of
         polygonal coverage.
 
         Assumes that the ``GeoSeries`` forms a polygonal coverage. Under this
@@ -5597,7 +5643,7 @@ GeometryCollection
             as its boundary. If set to False, only simplifies internal edges.
 
 
-        See also
+        See Also
         --------
         simplify : simplification of individual geometries
 
@@ -5633,8 +5679,7 @@ GeometryCollection
         )
 
     def relate(self, other, align=None):
-        """
-        Returns the DE-9IM intersection matrices for the geometries
+        """Return the DE-9IM intersection matrices for the geometries.
 
         The operation works on a 1-to-1 row-wise manner:
 
@@ -5738,8 +5783,7 @@ GeometryCollection
         return _binary_op("relate", self, other, align)
 
     def relate_pattern(self, other, pattern, align=None):
-        """
-        Returns True if the DE-9IM string code for the relationship between
+        """Return True if the DE-9IM string code for the relationship between
         the geometries satisfies the pattern, else False.
 
         This function compares the DE-9IM code string for two geometries
@@ -5850,8 +5894,7 @@ GeometryCollection
         return _binary_op("relate_pattern", self, other, pattern=pattern, align=align)
 
     def project(self, other, normalized=False, align=None):
-        """
-        Return the distance along each geometry nearest to *other*
+        """Return the distance along each geometry nearest to *other*.
 
         The operation works on a 1-to-1 row-wise manner:
 
@@ -5942,15 +5985,14 @@ GeometryCollection
         2    0.707107
         dtype: float64
 
-        See also
+        See Also
         --------
         GeoSeries.interpolate
         """
         return _binary_op("project", self, other, normalized=normalized, align=align)
 
     def interpolate(self, distance, normalized=False):
-        """
-        Return a point at the specified distance along each geometry
+        """Return a point at the specified distance along each geometry.
 
         Parameters
         ----------
@@ -6037,7 +6079,7 @@ GeometryCollection
         return _delegate_geo_method("affine_transform", self, matrix=matrix)
 
     def translate(self, xoff=0.0, yoff=0.0, zoff=0.0):
-        """Returns a ``GeoSeries`` with translated geometries.
+        """Return a ``GeoSeries`` with translated geometries.
 
         See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.translate
         for details.
@@ -6075,7 +6117,7 @@ GeometryCollection
         return _delegate_geo_method("translate", self, xoff=xoff, yoff=yoff, zoff=zoff)
 
     def rotate(self, angle, origin="center", use_radians=False):
-        """Returns a ``GeoSeries`` with rotated geometries.
+        """Return a ``GeoSeries`` with rotated geometries.
 
         See http://shapely.readthedocs.io/en/latest/manual.html#shapely.affinity.rotate
         for details.
@@ -6127,7 +6169,7 @@ GeometryCollection
         )
 
     def scale(self, xfact=1.0, yfact=1.0, zfact=1.0, origin="center"):
-        """Returns a ``GeoSeries`` with scaled geometries.
+        """Return a ``GeoSeries`` with scaled geometries.
 
         The geometries can be scaled by different factors along each
         dimension. Negative scale factors will mirror or reflect coordinates.
@@ -6177,7 +6219,7 @@ GeometryCollection
         )
 
     def skew(self, xs=0.0, ys=0.0, origin="center", use_radians=False):
-        """Returns a ``GeoSeries`` with skewed geometries.
+        """Return a ``GeoSeries`` with skewed geometries.
 
         The geometries are sheared by angles along the x and y dimensions.
 
@@ -6269,7 +6311,7 @@ GeometryCollection
     def get_coordinates(
         self, include_z=False, ignore_index=False, index_parts=False, *, include_m=False
     ):
-        """Gets coordinates from a :class:`GeoSeries` as a :class:`~pandas.DataFrame` of
+        """Get coordinates from a :class:`GeoSeries` as a :class:`~pandas.DataFrame` of
         floats.
 
         The shape of the returned :class:`~pandas.DataFrame` is (N, 2), with N being the
@@ -6508,7 +6550,7 @@ GeometryCollection
         return GeoSeries(result, name="sampled_points", crs=self.crs, index=self.index)
 
     def build_area(self, node=True):
-        """Creates an areal geometry formed by the constituent linework.
+        """Create an areal geometry formed by the constituent linework.
 
         Builds areas from the GeoSeries that contain linework which represents the edges
         of a planar graph. Any geometry type may be provided as input; only the
@@ -6569,7 +6611,7 @@ GeometryCollection
         )
 
     def polygonize(self, node=True, full=False):
-        """Creates polygons formed from the linework of a GeoSeries.
+        """Create polygons formed from the linework of a GeoSeries.
 
         Polygonizes the GeoSeries that contain linework which represents the
         edges of a planar graph. Any geometry type may be provided as input; only the
@@ -6657,9 +6699,9 @@ GeometryCollection
 
 
 def _get_index_for_parts(orig_idx, outer_idx, ignore_index, index_parts):
-    """Helper to handle index when geometries get exploded to parts.
+    """Handle index when geometries get exploded to parts.
 
-    Used in get_coordinates and explode.
+    Helper function used in get_coordinates and explode.
 
     Parameters
     ----------
@@ -6675,7 +6717,6 @@ def _get_index_for_parts(orig_idx, outer_idx, ignore_index, index_parts):
     pandas.Index
         index or multiindex
     """
-
     if ignore_index:
         return None
     else:

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -64,7 +64,7 @@ def _explore(
     map_kwds={},
     **kwargs,
 ):
-    """Interactive map based on GeoPandas and folium/leaflet.js
+    """Explore data in interactive map based on GeoPandas and folium/leaflet.js.
 
     Generate an interactive leaflet map based on :class:`~geopandas.GeoDataFrame`
 
@@ -276,7 +276,7 @@ def _explore(
     """
 
     def _colormap_helper(_cmap, n_resample=None, idx=None):
-        """Helper for MPL deprecation - GH#2596"""
+        """Help function for MPL deprecation - GH#2596."""
         if not n_resample:
             return cm.get_cmap(_cmap)
         else:
@@ -758,7 +758,7 @@ def _explore(
 
 
 def _tooltip_popup(type, fields, gdf, **kwds):
-    """get tooltip or popup"""
+    """Get tooltip or popup."""
     import folium
 
     # specify fields to show in the tooltip
@@ -785,8 +785,7 @@ def _tooltip_popup(type, fields, gdf, **kwds):
 
 
 def _categorical_legend(m, title, categories, colors):
-    """
-    Add categorical legend to a map
+    """Add categorical legend to a map.
 
     The implementation is using the code originally written by Michel Metran
     (@michelmetran) and released on GitHub
@@ -805,7 +804,6 @@ def _categorical_legend(m, title, categories, colors):
     colors : list-like
         list of colors (in the same order as categories)
     """
-
     # Header to Add
     head = """
     {% macro header(this, kwargs) %}
@@ -917,7 +915,7 @@ def _explore_geoseries(
     map_kwds={},
     **kwargs,
 ):
-    """Interactive map based on GeoPandas and folium/leaflet.js
+    """Interactive map based on GeoPandas and folium/leaflet.js.
 
     Generate an interactive leaflet map based on :class:`~geopandas.GeoSeries`
 

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -276,7 +276,10 @@ def _explore(
     """
 
     def _colormap_helper(_cmap, n_resample=None, idx=None):
-        """Help function for MPL deprecation - GH#2596."""
+        """Return the color map specified.
+
+        Helper function for MPL deprecation - GH#2596.
+        """
         if not n_resample:
             return cm.get_cmap(_cmap)
         else:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -81,9 +81,10 @@ crs_mismatch_error = (
 
 
 class GeoDataFrame(GeoPandasBase, DataFrame):
-    """
-    A GeoDataFrame object is a pandas.DataFrame that has one or more columns
-    containing geometry. In addition to the standard DataFrame constructor arguments,
+    """A GeoDataFrame object is a pandas.DataFrame that has one or more columns
+    containing geometry.
+
+    In addition to the standard DataFrame constructor arguments,
     GeoDataFrame also accepts the following keyword arguments:
 
     Parameters
@@ -134,7 +135,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     0  name1  POINT (1 2)  POINT (1 2)
     1  name2  POINT (2 1)  POINT (2 1)
 
-    See also
+    See Also
     --------
     GeoSeries : Series object designed to store shapely geometry objects
     """
@@ -383,7 +384,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         -------
         GeoDataFrame
 
-        See also
+        See Also
         --------
         GeoDataFrame.rename_geometry : rename an active geometry column
         """
@@ -487,9 +488,9 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
     ) -> GeoDataFrame: ...
 
     def rename_geometry(self, col: str, inplace: bool = False) -> GeoDataFrame | None:
-        """
-        Renames the GeoDataFrame geometry column to
-        the specified name. By default yields a new object.
+        """Rename the GeoDataFrame geometry column to the specified name.
+
+        By default yields a new object.
 
         The original geometry column is replaced with the input.
 
@@ -512,7 +513,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         'geom1'
 
 
-        See also
+        See Also
         --------
         GeoDataFrame.set_geometry : set the active geometry
         """
@@ -529,7 +530,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     @property
     def active_geometry_name(self) -> Any:
-        """Return the name of the active geometry column
+        """Return the name of the active geometry column.
 
         Returns a name if a GeoDataFrame has an active geometry column set,
         otherwise returns None. The return type is usually a string, but may be
@@ -545,7 +546,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         str or other index label supported by pandas
             name of an active geometry column or None
 
-        See also
+        See Also
         --------
         GeoDataFrame.set_geometry : set the active geometry
         """
@@ -565,7 +566,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Examples
         --------
-
         >>> gdf.crs  # doctest: +SKIP
         <Geographic 2D CRS: EPSG:4326>
         Name: WGS 84
@@ -579,7 +579,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
 
-        See also
+        See Also
         --------
         GeoDataFrame.set_crs : assign CRS
         GeoDataFrame.to_crs : re-project to another CRS
@@ -596,7 +596,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
     @crs.setter
     def crs(self, value) -> None:
-        """Sets the value of the crs"""
+        """Set the value of the crs."""
         if self._geometry_column_name is None:
             raise ValueError(
                 "Assigning CRS to a GeoDataFrame without a geometry column is not "
@@ -660,9 +660,8 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         crs: Any | None = None,
         **kwargs,
     ) -> GeoDataFrame:
-        """
-        Construct GeoDataFrame from dict of array-like or dicts by
-        overriding DataFrame.from_dict method with geometry and crs
+        """Construct GeoDataFrame from dict of array-like or dicts by
+        overriding DataFrame.from_dict method with geometry and crs.
 
         Parameters
         ----------
@@ -727,7 +726,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         >>> gdf = geopandas.read_file(path)
 
-        See also
+        See Also
         --------
         read_file : read file to GeoDataFrame
         GeoDataFrame.to_file : write GeoDataFrame to file
@@ -889,11 +888,10 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         >>> df = geopandas.read_postgis(sql, con)  # doctest: +SKIP
 
-        See also
+        See Also
         --------
         geopandas.read_postgis : read PostGIS database to GeoDataFrame
         """
-
         df = geopandas.io.sql._read_postgis(
             sql,
             con,
@@ -962,8 +960,7 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         to_wgs84: bool = False,
         **kwargs,
     ) -> str:
-        """
-        Returns a GeoJSON representation of the ``GeoDataFrame`` as a string.
+        """Return a GeoJSON representation of the ``GeoDataFrame`` as a string.
 
         Parameters
         ----------
@@ -1001,7 +998,6 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> d = {'col1': ['name1', 'name2'], 'geometry': [Point(1, 2), Point(2, 1)]}
         >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:3857")
@@ -1021,7 +1017,7 @@ es": {"name": "urn:ogc:def:crs:EPSG::3857"}}}'
 
         >>> gdf.to_file(path, driver="GeoJSON")  # doctest: +SKIP
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_file : write GeoDataFrame to file
 
@@ -1072,7 +1068,6 @@ es": {"name": "urn:ogc:def:crs:EPSG::3857"}}}'
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> d = {'col1': ['name1', 'name2'], 'geometry': [Point(1, 2), Point(2, 1)]}
         >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
@@ -1093,9 +1088,8 @@ box': (2.0, 1.0, 2.0, 1.0)}], 'bbox': (1.0, 1.0, 2.0, 2.0)}
     def iterfeatures(
         self, na: str = "null", show_bbox: bool = False, drop_id: bool = False
     ) -> typing.Generator[dict]:
-        """
-        Returns an iterator that yields feature dictionaries that comply with
-        __geo_interface__
+        """Return an iterator that yields feature dictionaries that comply with
+        __geo_interface__.
 
         Parameters
         ----------
@@ -1117,7 +1111,6 @@ individually so that features may have different properties
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> d = {'col1': ['name1', 'name2'], 'geometry': [Point(1, 2), Point(2, 1)]}
         >>> gdf = geopandas.GeoDataFrame(d, crs="EPSG:4326")
@@ -1203,8 +1196,7 @@ individually so that features may have different properties
     def to_geo_dict(
         self, na: str | None = "null", show_bbox: bool = False, drop_id: bool = False
     ) -> dict:
-        """
-        Returns a python feature collection representation of the GeoDataFrame
+        """Return a python feature collection representation of the GeoDataFrame
         as a dictionary with a list of features based on the ``__geo_interface__``
         GeoJSON-like specification.
 
@@ -1228,7 +1220,6 @@ individually so that features may have different properties
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> d = {'col1': ['name1', 'name2'], 'geometry': [Point(1, 2), Point(2, 1)]}
         >>> gdf = geopandas.GeoDataFrame(d)
@@ -1243,7 +1234,7 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
 2.0)}}, {'id': '1', 'type': 'Feature', 'properties': {'col1': 'name2'}, 'geometry':\
  {'type': 'Point', 'coordinates': (2.0, 1.0)}}]}
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_json : return a GeoDataFrame as a GeoJSON string
 
@@ -1278,7 +1269,6 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         DataFrame
             geometry columns are encoded to WKB
         """
-
         df = DataFrame(self.copy())
 
         # Encode all geometry columns to WKB
@@ -1301,7 +1291,6 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         DataFrame
             geometry columns are encoded to WKT
         """
-
         df = DataFrame(self.copy())
 
         # Encode all geometry columns to WKT
@@ -1458,15 +1447,13 @@ default 'snappy'
 
         Examples
         --------
-
         >>> gdf.to_parquet('data.parquet')  # doctest: +SKIP
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_feather : write GeoDataFrame to feather
         GeoDataFrame.to_file : write GeoDataFrame to file
         """
-
         # Accept engine keyword for compatibility with pandas.DataFrame.to_parquet
         # The only engine currently supported by GeoPandas is pyarrow, so no
         # other engine should be specified.
@@ -1527,15 +1514,13 @@ default 'snappy'
 
         Examples
         --------
-
         >>> gdf.to_feather('data.feather')  # doctest: +SKIP
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_parquet : write GeoDataFrame to parquet
         GeoDataFrame.to_file : write GeoDataFrame to file
         """
-
         from geopandas.io.arrow import _to_feather
 
         _to_feather(
@@ -1629,7 +1614,6 @@ default 'snappy'
 
         Examples
         --------
-
         >>> gdf.to_file('dataframe.shp')  # doctest: +SKIP
 
         >>> gdf.to_file('dataframe.gpkg', driver='GPKG', layer='name')  # doctest: +SKIP
@@ -1745,7 +1729,7 @@ default 'snappy'
         Without ``allow_override=True``, ``set_crs`` returns an error if you try to
         override CRS.
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_crs : re-project to another CRS
 
@@ -1852,7 +1836,7 @@ default 'snappy'
         - Ellipsoid: WGS 84
         - Prime Meridian: Greenwich
 
-        See also
+        See Also
         --------
         GeoDataFrame.set_crs : assign CRS without re-projection
         """
@@ -1866,7 +1850,7 @@ default 'snappy'
             return df
 
     def estimate_utm_crs(self, datum_name: str = "WGS 84") -> CRS:
-        """Returns the estimated UTM CRS based on the bounds of the dataset.
+        """Return the estimated UTM CRS based on the bounds of the dataset.
 
         .. versionadded:: 0.9
 
@@ -1935,8 +1919,9 @@ default 'snappy'
         return result
 
     def _persist_old_default_geometry_colname(self) -> None:
-        """Internal util to temporarily persist the default geometry column
-        name of 'geometry' for backwards compatibility."""
+        """Persist the default geometry column name of 'geometry' temporarily for
+        backwards compatibility.
+        """
         # self.columns check required to avoid this warning in __init__
         if self._geometry_column_name is None and "geometry" not in self.columns:
             msg = (
@@ -1953,11 +1938,11 @@ default 'snappy'
             self._geometry_column_name = "geometry"
 
     def __setitem__(self, key, value):
-        """
-        Overwritten to preserve CRS of GeometryArray in cases like
+        """Overridden to preserve CRS of GeometryArray.
+
+        Important for cases like
         df['geometry'] = [geom... for geom in df.geometry]
         """
-
         if not pd.api.types.is_list_like(key) and (
             key == self._geometry_column_name
             or (key == "geometry" and self._geometry_column_name is None)
@@ -2037,11 +2022,10 @@ default 'snappy'
     def _geodataframe_constructor_with_fallback(
         cls, *args, **kwargs
     ) -> pd.DataFrame | GeoDataFrame:
-        """
-        A flexible constructor for GeoDataFrame._constructor, which falls back
+        """A flexible constructor for GeoDataFrame._constructor, which falls back
         to returning a DataFrame (if a certain operation does not preserve the
-        geometry column)
-        """
+        geometry column).
+        """  # noqa: D401
         df = cls(*args, **kwargs)
 
         geometry_cols_mask = df.dtypes == "geometry"
@@ -2072,9 +2056,10 @@ default 'snappy'
     @property
     def _constructor_sliced(self) -> Series | GeoSeries:
         def _geodataframe_constructor_sliced(*args, **kwargs):
-            """
-            A specialized (Geo)Series constructor which can fall back to a
-            Series if a certain operation does not produce geometries:
+            """A specialized (Geo)Series constructor which can fall back to a
+            Series if a certain operation does not produce geometries.
+
+            Note:
 
             - We only return a GeoSeries if the data is actually of geometry
               dtype (and so we don't try to convert geometry objects such as
@@ -2086,7 +2071,7 @@ default 'snappy'
               thus could have a geometry dtype). Therefore, we don't return a
               GeoSeries if we are sure we are in a row selection case (by
               checking the identity of the index)
-            """
+            """  # noqa: D401
             srs = pd.Series(*args, **kwargs)
             is_row_proxy = srs.index.is_(self.columns)
             if is_geometry_type(srs) and not is_row_proxy:
@@ -2105,7 +2090,7 @@ default 'snappy'
     def __finalize__(
         self, other, method: str | None = None, **kwargs
     ) -> GeoDataFrame | GeoSeries:
-        """propagate metadata from other to self"""
+        """Propagate metadata from other to self."""
         self = super().__finalize__(other, method=method, **kwargs)  # noqa: PLW0642
 
         # merge operation: using metadata of the left object
@@ -2229,6 +2214,7 @@ default 'snappy'
             supplied, which will be required in pandas 2.0 for certain aggfuncs.
 
             .. versionadded:: 0.13.0
+
         Returns
         -------
         GeoDataFrame
@@ -2254,12 +2240,11 @@ default 'snappy'
         name1  MULTIPOINT ((0 1), (1 2))
         name2                POINT (2 1)
 
-        See also
+        See Also
         --------
         GeoDataFrame.explode : explode multi-part geometries into single geometries
 
         """
-
         if by is None and level is None:
             by = np.zeros(len(self), dtype="int64")  # type: ignore [assignment]
 
@@ -2335,7 +2320,6 @@ default 'snappy'
 
         Examples
         --------
-
         >>> from shapely.geometry import MultiPoint
         >>> d = {
         ...     "col1": ["name1", "name2"],
@@ -2374,12 +2358,11 @@ default 'snappy'
         2  name2  POINT (2 1)
         3  name2  POINT (0 0)
 
-        See also
+        See Also
         --------
         GeoDataFrame.dissolve : dissolve geometries into a single observation.
 
         """
-
         # If no column is specified then default to the active geometry column
         if column is None:
             column = self.geometry.name
@@ -2461,13 +2444,12 @@ default 'snappy'
 
         Examples
         --------
-
         >>> from sqlalchemy import create_engine
         >>> engine = create_engine("postgresql://myusername:mypassword@myhost:5432\
 /mydatabase")  # doctest: +SKIP
         >>> gdf.to_postgis("my_table", engine)  # doctest: +SKIP
 
-        See also
+        See Also
         --------
         GeoDataFrame.to_file : write GeoDataFrame to file
         read_postgis : read PostGIS database to GeoDataFrame
@@ -2570,7 +2552,7 @@ default 'snappy'
         Every operation in GeoPandas is planar, i.e. the potential third
         dimension is not taken into account.
 
-        See also
+        See Also
         --------
         GeoDataFrame.sjoin_nearest : nearest neighbor join
         sjoin : equivalent top-level function
@@ -2695,7 +2677,7 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
         30          TARGET    UPTOWN
         30       Mariano's    UPTOWN
 
-        See also
+        See Also
         --------
         GeoDataFrame.sjoin : binary predicate joins
         sjoin_nearest : equivalent top-level function
@@ -2755,7 +2737,7 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
             Vector data (points, lines, polygons) from the GeoDataFrame clipped to
             polygon boundary from mask.
 
-        See also
+        See Also
         --------
         clip : equivalent top-level function
 
@@ -2866,7 +2848,7 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
         3         1       NaN      POLYGON ((2 0, 0 0, 0 2, 1 2, 1 1, 2 1, 2 0))
         4         2       NaN  MULTIPOLYGON (((3 4, 3 3, 2 3, 2 4, 3 4)), ((4...
 
-        See also
+        See Also
         --------
         GeoDataFrame.sjoin : spatial join
         overlay : equivalent top-level function

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -39,11 +39,10 @@ if typing.TYPE_CHECKING:
 def _geoseries_constructor_with_fallback(
     data=None, index=None, crs: Any | None = None, **kwargs
 ):
-    """
-    A flexible constructor for GeoSeries._constructor, which needs to be able
+    """A flexible constructor for GeoSeries._constructor, which needs to be able
     to fall back to a Series (if a certain operation does not produce
-    geometries)
-    """
+    geometries).
+    """  # noqa: D401
     try:
         return GeoSeries(data=data, index=index, crs=crs, **kwargs)
     except TypeError:
@@ -97,7 +96,6 @@ class GeoSeries(GeoPandasBase, Series):
 
     Examples
     --------
-
     >>> from shapely.geometry import Point
     >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
     >>> s
@@ -251,7 +249,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def x(self) -> Series:
-        """Return the x location of point geometries in a GeoSeries
+        """Return the x location of point geometries in a GeoSeries.
 
         Returns
         -------
@@ -259,7 +257,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
         >>> s.x
@@ -270,7 +267,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         See Also
         --------
-
         GeoSeries.y
         GeoSeries.z
 
@@ -279,7 +275,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def y(self) -> Series:
-        """Return the y location of point geometries in a GeoSeries
+        """Return the y location of point geometries in a GeoSeries.
 
         Returns
         -------
@@ -287,7 +283,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
         >>> s.y
@@ -298,7 +293,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         See Also
         --------
-
         GeoSeries.x
         GeoSeries.z
         GeoSeries.m
@@ -308,7 +302,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def z(self) -> Series:
-        """Return the z location of point geometries in a GeoSeries
+        """Return the z location of point geometries in a GeoSeries.
 
         Returns
         -------
@@ -316,7 +310,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> s = geopandas.GeoSeries([Point(1, 1, 1), Point(2, 2, 2), Point(3, 3, 3)])
         >>> s.z
@@ -327,7 +320,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         See Also
         --------
-
         GeoSeries.x
         GeoSeries.y
         GeoSeries.m
@@ -337,7 +329,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @property
     def m(self) -> Series:
-        """Return the m coordinate of point geometries in a GeoSeries
+        """Return the m coordinate of point geometries in a GeoSeries.
 
         Requires Shapely >= 2.1.
 
@@ -349,7 +341,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> s = geopandas.GeoSeries.from_wkt(
         ...     [
@@ -369,7 +360,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         See Also
         --------
-
         GeoSeries.x
         GeoSeries.y
         GeoSeries.z
@@ -424,9 +414,8 @@ class GeoSeries(GeoPandasBase, Series):
     def from_wkb(
         cls, data, index=None, crs: Any | None = None, on_invalid="raise", **kwargs
     ) -> GeoSeries:
-        r"""
-        Alternate constructor to create a ``GeoSeries``
-        from a list or array of WKB objects
+        r"""Alternate constructor to create a ``GeoSeries``
+        from a list or array of WKB objects.
 
         Parameters
         ----------
@@ -462,7 +451,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> wkbs = [
         ... (
         ...     b"\x01\x01\x00\x00\x00\x00\x00\x00\x00"
@@ -492,9 +480,8 @@ class GeoSeries(GeoPandasBase, Series):
     def from_wkt(
         cls, data, index=None, crs: Any | None = None, on_invalid="raise", **kwargs
     ) -> GeoSeries:
-        """
-        Alternate constructor to create a ``GeoSeries``
-        from a list or array of WKT objects
+        """Alternate constructor to create a ``GeoSeries``
+        from a list or array of WKT objects.
 
         Parameters
         ----------
@@ -531,7 +518,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> wkts = [
         ... 'POINT (1 1)',
         ... 'POINT (2 2)',
@@ -550,9 +536,8 @@ class GeoSeries(GeoPandasBase, Series):
 
     @classmethod
     def from_xy(cls, x, y, z=None, index=None, crs=None, **kwargs) -> GeoSeries:
-        """
-        Alternate constructor to create a :class:`~geopandas.GeoSeries` of Point
-        geometries from lists or arrays of x, y(, z) coordinates
+        """Alternate constructor to create a :class:`~geopandas.GeoSeries` of Point
+        geometries from lists or arrays of x, y(, z) coordinates.
 
         In case of geographic coordinates, it is assumed that longitude is captured
         by ``x`` coordinates and latitude by ``y``.
@@ -583,7 +568,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> x = [2.5, 5, -3.0]
         >>> y = [0.5, 1, 1.5]
         >>> s = geopandas.GeoSeries.from_xy(x, y, crs="EPSG:4326")
@@ -613,7 +597,7 @@ class GeoSeries(GeoPandasBase, Series):
         on_invalid: str = "raise",
         **kwargs,
     ) -> GeoSeries:
-        """Create a GeoSeries from either WKT or WKB values"""
+        """Create a GeoSeries from either WKT or WKB values."""
         if isinstance(data, Series):
             if index is not None:
                 data = data.reindex(index)
@@ -672,7 +656,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Point
         >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
         >>> s.__geo_interface__
@@ -749,7 +732,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> s.to_file('series.shp')  # doctest: +SKIP
 
         >>> s.to_file('series.gpkg', driver='GPKG', layer='name1')  # doctest: +SKIP
@@ -786,7 +768,7 @@ class GeoSeries(GeoPandasBase, Series):
         return _expanddim_logic(df)
 
     def _wrapped_pandas_method(self, mtd, *args, **kwargs):
-        """Wrap a generic pandas method to ensure it returns a GeoSeries"""
+        """Wrap a generic pandas method to ensure it returns a GeoSeries."""
         val = getattr(super(), mtd)(*args, **kwargs)
         if type(val) is Series:
             val.__class__ = GeoSeries
@@ -838,7 +820,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon
         >>> s = geopandas.GeoSeries(
         ...     [Polygon([(0, 0), (1, 1), (0, 1)]), None, Polygon([])]
@@ -883,7 +864,6 @@ class GeoSeries(GeoPandasBase, Series):
 
         Examples
         --------
-
         >>> from shapely.geometry import Polygon
         >>> s = geopandas.GeoSeries(
         ...     [Polygon([(0, 0), (1, 1), (0, 1)]), None, Polygon([])]
@@ -1003,7 +983,7 @@ class GeoSeries(GeoPandasBase, Series):
         return super().fillna(value=value, limit=limit, inplace=inplace, **kwargs)
 
     def __contains__(self, other) -> bool:
-        """Allow tests of the form "geom in s"
+        """Allow tests of the form "geom in s".
 
         Tests whether a GeoSeries contains a geometry.
 
@@ -1020,7 +1000,7 @@ class GeoSeries(GeoPandasBase, Series):
 
     @doc(_explore_geoseries)
     def explore(self, *args, **kwargs):
-        """Interactive map based on folium/leaflet.js"""
+        """Explore with an interactive map based on folium/leaflet.js."""
         return _explore_geoseries(self, *args, **kwargs)
 
     def explode(self, ignore_index=False, index_parts=False) -> GeoSeries:
@@ -1067,7 +1047,7 @@ class GeoSeries(GeoPandasBase, Series):
            2    POINT (4 4)
         dtype: geometry
 
-        See also
+        See Also
         --------
         GeoDataFrame.explode
 
@@ -1192,7 +1172,7 @@ class GeoSeries(GeoPandasBase, Series):
         return result
 
     def to_crs(self, crs: Any | None = None, epsg: int | None = None) -> GeoSeries:
-        """Returns a ``GeoSeries`` with all geometries transformed to a new
+        """Return a ``GeoSeries`` with all geometries transformed to a new
         coordinate reference system.
 
         Transform all geometries in a GeoSeries to a different coordinate
@@ -1272,7 +1252,7 @@ class GeoSeries(GeoPandasBase, Series):
         )
 
     def estimate_utm_crs(self, datum_name: str = "WGS 84"):
-        """Returns the estimated UTM CRS based on the bounds of the dataset.
+        """Return the estimated UTM CRS based on the bounds of the dataset.
 
         .. versionadded:: 0.9
 
@@ -1316,8 +1296,7 @@ class GeoSeries(GeoPandasBase, Series):
         to_wgs84: bool = False,
         **kwargs,
     ) -> str:
-        """
-        Returns a GeoJSON string representation of the GeoSeries.
+        """Return a GeoJSON string representation of the GeoSeries.
 
         Parameters
         ----------
@@ -1367,8 +1346,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         )
 
     def to_wkb(self, hex: bool = False, **kwargs) -> Series:
-        """
-        Convert GeoSeries geometries to WKB
+        """Convert GeoSeries geometries to WKB.
 
         Parameters
         ----------
@@ -1384,15 +1362,14 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         Series
             WKB representations of the geometries
 
-        See also
+        See Also
         --------
         GeoSeries.to_wkt
         """
         return Series(to_wkb(self.array, hex=hex, **kwargs), index=self.index)
 
     def to_wkt(self, **kwargs) -> Series:
-        """
-        Convert GeoSeries geometries to WKT
+        """Convert GeoSeries geometries to WKT.
 
         Parameters
         ----------
@@ -1420,7 +1397,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         2    POINT (3 3)
         dtype: object
 
-        See also
+        See Also
         --------
         GeoSeries.to_wkb
         """
@@ -1553,7 +1530,7 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
             Vector data (points, lines, polygons) from `gdf` clipped to
             polygon boundary from mask.
 
-        See also
+        See Also
         --------
         clip : top-level function for clip
 

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -335,7 +335,10 @@ def _geopandas_to_arrow(
     schema_version=None,
     write_covering_bbox=None,
 ):
-    """Help function with main, shared logic for to_parquet/to_feather."""
+    """Convert a GeoDataFrame to a pyarrow Table.
+
+    Helper function with main, shared logic for to_parquet/to_feather.
+    """
     from pyarrow import StructArray
 
     from geopandas.io._geoarrow import geopandas_to_arrow
@@ -484,7 +487,10 @@ def _to_feather(df, path, index=None, compression=None, schema_version=None, **k
 
 
 def _arrow_to_geopandas(table, geo_metadata=None, to_pandas_kwargs=None):
-    """Help function with main, shared logic for read_parquet/read_feather."""
+    """Convert a pyarrow Table to a GeoDataFrame.
+
+    Helper function with main, shared logic for read_parquet/read_feather.
+    """
     if geo_metadata is None:
         # Note: this path of not passing metadata is also used by dask-geopandas
         geo_metadata = _validate_and_decode_metadata(table.schema.metadata)

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -98,9 +98,7 @@ _geometry_type_names += [geom_type + " Z" for geom_type in _geometry_type_names]
 
 
 def _get_geometry_types(series):
-    """
-    Get unique geometry types from a GeoSeries.
-    """
+    """Get unique geometry types from a GeoSeries."""
     arr_geometry_types = shapely.get_type_id(series.array._data)
     # ensure to include "... Z" for 3D geometries
     has_z = shapely.has_z(series.array._data)
@@ -205,7 +203,7 @@ def _create_metadata(
 
 
 def _encode_metadata(metadata):
-    """Encode metadata dict to UTF-8 JSON string
+    """Encode metadata dict to UTF-8 JSON string.
 
     Parameters
     ----------
@@ -219,7 +217,7 @@ def _encode_metadata(metadata):
 
 
 def _decode_metadata(metadata_str):
-    """Decode a UTF-8 encoded JSON string to dict
+    """Decode a UTF-8 encoded JSON string to dict.
 
     Parameters
     ----------
@@ -247,7 +245,6 @@ def _validate_dataframe(df):
     ----------
     df : GeoDataFrame
     """
-
     if not isinstance(df, DataFrame):
         raise ValueError("Writing to Parquet/Feather only supports IO with DataFrames")
 
@@ -273,7 +270,6 @@ def _validate_geo_metadata(metadata):
     ----------
     metadata : dict
     """
-
     if not metadata:
         raise ValueError("Missing or malformed geo metadata in Parquet/Feather file")
 
@@ -339,9 +335,7 @@ def _geopandas_to_arrow(
     schema_version=None,
     write_covering_bbox=None,
 ):
-    """
-    Helper function with main, shared logic for to_parquet/to_feather.
-    """
+    """Help function with main, shared logic for to_parquet/to_feather."""
     from pyarrow import StructArray
 
     from geopandas.io._geoarrow import geopandas_to_arrow
@@ -490,9 +484,7 @@ def _to_feather(df, path, index=None, compression=None, schema_version=None, **k
 
 
 def _arrow_to_geopandas(table, geo_metadata=None, to_pandas_kwargs=None):
-    """
-    Helper function with main, shared logic for read_parquet/read_feather.
-    """
+    """Help function with main, shared logic for read_parquet/read_feather."""
     if geo_metadata is None:
         # Note: this path of not passing metadata is also used by dask-geopandas
         geo_metadata = _validate_and_decode_metadata(table.schema.metadata)
@@ -593,7 +585,8 @@ def _get_filesystem_path(path, filesystem=None, storage_options=None):
 
 
 def _ensure_arrow_fs(filesystem):
-    """
+    """Check if ``filesystem`` is a valid filesystem.
+
     Simplified version of pyarrow.fs._ensure_filesystem. This is only needed
     below because `pyarrow.parquet.read_metadata` does not yet accept a
     filesystem keyword (https://issues.apache.org/jira/browse/ARROW-16719)
@@ -633,8 +626,7 @@ def _validate_and_decode_metadata(metadata):
 
 
 def _read_parquet_schema_and_metadata(path, filesystem):
-    """
-    Opening the Parquet file/dataset a first time to get the schema and metadata.
+    """Open the Parquet file/dataset a first time to get the schema and metadata.
 
     TODO: we should look into how we can reuse opened dataset for reading the
     actual data, to avoid discovering the dataset twice (problem right now is
@@ -747,7 +739,6 @@ def _read_parquet(
     ...     columns=["geometry", "pop_est"]
     ... )  # doctest: +SKIP
     """
-
     parquet = import_optional_dependency(
         "pyarrow.parquet", extra="pyarrow is required for Parquet support."
     )
@@ -854,7 +845,6 @@ def _read_feather(path, columns=None, to_pandas_kwargs=None, **kwargs):
     ...     columns=["geometry", "pop_est"]
     ... )  # doctest: +SKIP
     """
-
     feather = import_optional_dependency(
         "pyarrow.feather", extra="pyarrow is required for Feather support."
     )

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -197,8 +197,7 @@ def _is_url(url):
 def _read_file(
     filename, bbox=None, mask=None, columns=None, rows=None, engine=None, **kwargs
 ):
-    """
-    Returns a GeoDataFrame from a file or URL.
+    """Return a GeoDataFrame from a file or URL.
 
     Parameters
     ----------
@@ -597,9 +596,7 @@ def _warn_missing_crs_of_dataframe_and_mask(source_dataset_crs, mask):
 
 
 def _detect_driver(path):
-    """
-    Attempt to auto-detect driver based on the extension
-    """
+    """Attempt to auto-detect driver based on the extension."""
     try:
         # in case the path is a file handle
         path = path.name
@@ -626,8 +623,7 @@ def _to_file(
     metadata=None,
     **kwargs,
 ):
-    """
-    Write this GeoDataFrame to an OGR data source
+    """Write this GeoDataFrame to an OGR data source.
 
     A dictionary of supported OGR providers is available via:
 
@@ -849,9 +845,7 @@ def infer_schema(df):
 
 
 def _geometry_types(df):
-    """
-    Determine the geometry types in the GeoDataFrame for the schema.
-    """
+    """Determine the geometry types in the GeoDataFrame for the schema."""
     geom_types_2D = df[~df.geometry.has_z].geometry.geom_type.unique()
     geom_types_2D = list(geom_types_2D[pd.notna(geom_types_2D)])
     geom_types_3D = df[df.geometry.has_z].geometry.geom_type.unique()

--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -23,6 +23,7 @@ def _get_conn(conn_or_engine):
     ----------
     conn_or_engine : Connection or Engine
         A sqlalchemy Connection or Engine instance
+
     Returns
     -------
     Connection
@@ -43,10 +44,11 @@ def _get_conn(conn_or_engine):
 
 
 def _df_to_geodf(df, geom_col="geom", crs=None, con=None):
-    """
-    Transforms a pandas DataFrame into a GeoDataFrame.
+    """Transform a pandas DataFrame into a GeoDataFrame.
+
     The column 'geom_col' must be a geometry column in WKB representation.
     To be used to convert df based on pd.read_sql to gdf.
+
     Parameters
     ----------
     df : DataFrame
@@ -61,11 +63,11 @@ def _df_to_geodf(df, geom_col="geom", crs=None, con=None):
         first geometry in the database, and assigns that to all geometries.
     con : sqlalchemy.engine.Connection or sqlalchemy.engine.Engine
         Active connection to the database to query.
+
     Returns
     -------
     GeoDataFrame
     """
-
     if geom_col not in df:
         raise ValueError(f"Query missing geometry column '{geom_col}'")
 
@@ -132,8 +134,7 @@ def _read_postgis(
     params=None,
     chunksize=None,
 ):
-    """
-    Returns a GeoDataFrame corresponding to the result of the query
+    """Return a GeoDataFrame corresponding to the result of the query
     string, which must contain a geometry column in WKB representation.
 
     It is also possible to use :meth:`~GeoDataFrame.read_file` to read from a database.
@@ -179,7 +180,6 @@ def _read_postgis(
     >>> sql = "SELECT ST_AsBinary(geom) AS geom, highway FROM roads"
     >>> df = geopandas.read_postgis(sql, con)  # doctest: +SKIP
     """
-
     if chunksize is None:
         # read all in one chunk and return a single GeoDataFrame
         df = pd.read_sql(
@@ -210,8 +210,9 @@ def _read_postgis(
 
 
 def _get_geometry_type(gdf):
-    """
-    Get basic geometry type of a GeoDataFrame. See more info from:
+    """Get basic geometry type of a GeoDataFrame.
+
+    See more info from:
     https://geoalchemy-2.readthedocs.io/en/latest/types.html#geoalchemy2.types._GISType
 
     Following rules apply:
@@ -256,10 +257,7 @@ def _get_geometry_type(gdf):
 
 
 def _get_srid_from_crs(gdf):
-    """
-    Get EPSG code from CRS if available. If not, return 0.
-    """
-
+    """Get EPSG code from CRS if available. If not, return 0."""
     # Use geoalchemy2 default for srid
     # Note: undefined srid in PostGIS is 0
     srid = None
@@ -389,7 +387,6 @@ def _write_postgis(
 
     Examples
     --------
-
     >>> from sqlalchemy import create_engine  # doctest: +SKIP
     >>> engine = create_engine("postgresql://myusername:mypassword@myhost:5432\
 /mydatabase";)  # doctest: +SKIP

--- a/geopandas/io/util.py
+++ b/geopandas/io/util.py
@@ -1,4 +1,4 @@
-"""Vendored, cut down version of pyogrio/util.py for use with fiona"""
+"""Vendored, cut down version of pyogrio/util.py for use with fiona."""
 
 import re
 import sys
@@ -6,11 +6,7 @@ from urllib.parse import urlparse
 
 
 def vsi_path(path: str) -> str:
-    """
-    Ensure path is a local path or a GDAL-compatible vsi path.
-
-    """
-
+    """Ensure path is a local path or a GDAL-compatible vsi path."""
     # path is already in GDAL format
     if path.startswith("/vsi"):
         return path
@@ -56,8 +52,7 @@ CURLSCHEMES = {k for k, v in SCHEMES.items() if v == "curl"}
 
 
 def _parse_uri(path: str):
-    """
-    Parse a URI
+    """Parse a URI.
 
     Returns a tuples of (path, archive, scheme)
 
@@ -92,8 +87,7 @@ def _parse_uri(path: str):
 
 
 def _construct_vsi_path(path, archive, scheme) -> str:
-    """Convert a parsed path to a GDAL VSI path"""
-
+    """Convert a parsed path to a GDAL VSI path."""
     prefix = ""
     suffix = ""
     schemes = scheme.split("+")

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -11,8 +11,7 @@ from ._decorator import doc
 
 
 def _sanitize_geoms(geoms, prefix="Multi"):
-    """
-    Returns Series like geoms and index, except that any Multi geometries
+    """Return Series like geoms and index, except that any Multi geometries
     are split into their components and indices are repeated for all component
     in the same Multi geometry. At the same time, empty or missing geometries are
     filtered out.  Maintains 1:1 matching of geometry to value.
@@ -86,7 +85,7 @@ def _expand_kwargs(kwargs, multiindex):
 
 
 def _PolygonPatch(polygon, **kwargs):
-    """Constructs a matplotlib patch from a Polygon geometry
+    """Construct a matplotlib patch from a Polygon geometry.
 
     The `kwargs` are those supported by the matplotlib.patches.PathPatch class
     constructor. Returns an instance of matplotlib.patches.PathPatch.
@@ -125,8 +124,7 @@ def _plot_polygon_collection(
     autolim=True,
     **kwargs,
 ):
-    """
-    Plots a collection of Polygon and MultiPolygon geometries to `ax`
+    """Plot a collection of Polygon and MultiPolygon geometries to `ax`.
 
     Parameters
     ----------
@@ -196,8 +194,7 @@ def _plot_linestring_collection(
     autolim=True,
     **kwargs,
 ):
-    """
-    Plots a collection of LineString and MultiLineString geometries to `ax`
+    """Plot a collection of LineString and MultiLineString geometries to `ax`.
 
     Parameters
     ----------
@@ -262,8 +259,7 @@ def _plot_point_collection(
     markersize=None,
     **kwargs,
 ):
-    """
-    Plots a collection of Point and MultiPoint geometries to `ax`
+    """Plot a collection of Point and MultiPoint geometries to `ax`.
 
     Parameters
     ----------
@@ -368,7 +364,6 @@ def plot_series(
     -------
     ax : matplotlib axes instance
     """
-
     try:
         import matplotlib.pyplot as plt
     except ImportError:

--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -15,7 +15,6 @@ if compat.GEOS_GE_310:
 class SpatialIndex:
     """A simple wrapper around Shapely's STRTree.
 
-
     Parameters
     ----------
     geometry : np.array of Shapely geometries
@@ -544,7 +543,7 @@ geometries}
 
     @property
     def size(self):
-        """Size of the spatial index
+        """Size of the spatial index.
 
         Number of leaves (input geometries) in the index.
 
@@ -572,7 +571,7 @@ geometries}
 
     @property
     def is_empty(self):
-        """Check if the spatial index is empty
+        """Check if the spatial index is empty.
 
         Examples
         --------

--- a/geopandas/testing.py
+++ b/geopandas/testing.py
@@ -1,6 +1,4 @@
-"""
-Testing functionality for geopandas objects.
-"""
+"""Testing functionality for geopandas objects."""
 
 import warnings
 
@@ -11,7 +9,7 @@ from geopandas.array import GeometryDtype
 
 
 def _isna(this):
-    """isna version that works for both scalars and (Geo)Series"""
+    """Version of isna that works for both scalars and (Geo)Series."""
     with warnings.catch_warnings():
         # GeoSeries.isna will raise a warning about no longer returning True
         # for empty geometries. This helper is used below always in combination
@@ -43,7 +41,6 @@ def _geom_equals_mask(this, that):
     Series
         boolean Series, True if geometries in left equal geometries in right
     """
-
     return (
         this.geom_equals(that)
         | (this.is_empty & that.is_empty)
@@ -66,7 +63,6 @@ def geom_equals(this, that):
     bool
         True if all geometries in left equal geometries in right
     """
-
     return _geom_equals_mask(this, that).all()
 
 
@@ -87,7 +83,6 @@ def _geom_almost_equals_mask(this, that):
     Series
         boolean Series, True if geometries in left almost equal geometries in right
     """
-
     return (
         this.geom_equals_exact(that, tolerance=0.5 * 10 ** (-6))
         | (this.is_empty & that.is_empty)
@@ -200,7 +195,7 @@ def assert_geoseries_equal(
 
 
 def _truncated_string(geom):
-    """Truncated WKT repr of geom"""
+    """Truncate WKT repr of geom."""
     s = str(geom)
     if len(s) > 100:
         return s[:100] + "..."
@@ -251,8 +246,7 @@ def assert_geodataframe_equal(
     check_crs=True,
     normalize=False,
 ):
-    """
-    Check that two GeoDataFrames are equal/
+    """Check that two GeoDataFrames are equal.
 
     Parameters
     ----------

--- a/geopandas/tools/_random.py
+++ b/geopandas/tools/_random.py
@@ -65,18 +65,13 @@ def uniform(geom, size, rng=None):
 
 
 def _uniform_line(geom, size, generator):
-    """
-    Sample points from an input shapely linestring
-    """
-
+    """Sample points from an input shapely linestring."""
     fracs = generator.uniform(size=size)
     return from_shapely(geom.interpolate(fracs, normalized=True)).union_all()
 
 
 def _uniform_polygon(geom, size, generator):
-    """
-    Sample uniformly from within a polygon using batched sampling.
-    """
+    """Sample uniformly from within a polygon using batched sampling."""
     xmin, ymin, xmax, ymax = geom.bounds
     candidates = []
     while len(candidates) < size:

--- a/geopandas/tools/_show_versions.py
+++ b/geopandas/tools/_show_versions.py
@@ -4,7 +4,7 @@ import sys
 
 
 def _get_sys_info():
-    """System information
+    """System information.
 
     Returns
     -------
@@ -23,7 +23,8 @@ def _get_sys_info():
 
 
 def _get_C_info():
-    """Information on system PROJ, GDAL, GEOS
+    """Information on system PROJ, GDAL, GEOS.
+
     Returns
     -------
     c_info: dict
@@ -93,7 +94,7 @@ def _get_C_info():
 
 
 def _get_deps_info():
-    """Overview of the installed version of main dependencies
+    """Overview of the installed version of main dependencies.
 
     Returns
     -------
@@ -144,7 +145,6 @@ def show_versions():
 
     Examples
     --------
-
     ::
 
         $ python -c "import geopandas; geopandas.show_versions()"

--- a/geopandas/tools/clip.py
+++ b/geopandas/tools/clip.py
@@ -1,10 +1,4 @@
-"""
-geopandas.clip
-==============
-
-A module to clip vector data using GeoPandas.
-
-"""
+"""Module to clip vector data using GeoPandas."""
 
 import warnings
 
@@ -152,7 +146,7 @@ def clip(gdf, mask, keep_geom_type=False, sort=False):
          Vector data (points, lines, polygons) from ``gdf`` clipped to
          polygon boundary from mask.
 
-    See also
+    See Also
     --------
     GeoDataFrame.clip : equivalent GeoDataFrame method
     GeoSeries.clip : equivalent GeoSeries method

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -59,7 +59,6 @@ def geocode(strings, provider=None, **kwargs):
     0  POINT (-71.05863 42.35899)                          Boston, MA, United States
     1  POINT (-77.03651 38.89766)  1600 Pennsylvania Ave NW, Washington, DC 20006...
     """
-
     if provider is None:
         provider = "photon"
     throttle_time = _get_throttle_time(provider)
@@ -110,7 +109,6 @@ def reverse_geocode(points, provider=None, **kwargs):
     0  POINT (-71.05941 42.35837)       29 Court Sq, Boston, MA 02108, United States
     1  POINT (-77.03641 38.89766)  1600 Pennsylvania Ave NW, Washington, DC 20006...
     """
-
     if provider is None:
         provider = "photon"
     throttle_time = _get_throttle_time(provider)
@@ -150,8 +148,7 @@ def _query(data, forward, provider, throttle_time, **kwargs):
 
 
 def _prepare_geocode_result(results):
-    """
-    Helper function for the geocode function
+    """Help function for the geocode function.
 
     Takes a dict where keys are index entries, values are tuples containing:
     (address, (lat, lon))

--- a/geopandas/tools/geocoding.py
+++ b/geopandas/tools/geocoding.py
@@ -148,7 +148,7 @@ def _query(data, forward, provider, throttle_time, **kwargs):
 
 
 def _prepare_geocode_result(results):
-    """Help function for the geocode function.
+    """Convert the geocode results to a GeoDataFrame.
 
     Takes a dict where keys are index entries, values are tuples containing:
     (address, (lat, lon))

--- a/geopandas/tools/hilbert_curve.py
+++ b/geopandas/tools/hilbert_curve.py
@@ -40,13 +40,10 @@ def _hilbert_distance(geoms, total_bounds=None, level=16):
 
 
 def _continuous_to_discrete_coords(bounds, level, total_bounds):
-    """
-    Calculates mid points & ranges of geoms and returns
-    as discrete coords
+    """Calculate mid points & ranges of geoms and returns as discrete coords.
 
     Parameters
     ----------
-
     bounds : Bounds of each geometry - array
 
     p : The number of iterations used in constructing the Hilbert curve
@@ -85,9 +82,8 @@ def _continuous_to_discrete_coords(bounds, level, total_bounds):
 
 
 def _continuous_to_discrete(vals, val_range, n):
-    """
-    Convert a continuous one-dimensional array to discrete integer values
-    based their ranges
+    """Convert a continuous one-dimensional array to discrete integer values
+    based their ranges.
 
     Parameters
     ----------

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -16,8 +16,8 @@ from geopandas.array import (
 
 
 def _ensure_geometry_column(df):
-    """
-    Helper function to ensure the geometry column is called 'geometry'.
+    """Help function to ensure the geometry column is called 'geometry'.
+
     If another column with that name exists, it will be dropped.
     """
     if not df._geometry_column_name == "geometry":
@@ -33,9 +33,7 @@ def _ensure_geometry_column(df):
 
 
 def _overlay_intersection(df1, df2):
-    """
-    Overlay Intersection operation used in overlay function
-    """
+    """Overlay Intersection operation used in overlay function."""
     # Spatial Index to create intersections
     idx1, idx2 = df2.sindex.query(df1.geometry, predicate="intersects", sort=True)
     # Create pairs of geometries in both dataframes to be intersected
@@ -83,9 +81,7 @@ def _overlay_intersection(df1, df2):
 
 
 def _overlay_difference(df1, df2):
-    """
-    Overlay Difference operation used in overlay function
-    """
+    """Overlay Difference operation used in overlay function."""
     # spatial index query to find intersections
     idx1, idx2 = df2.sindex.query(df1.geometry, predicate="intersects", sort=True)
     idx1_unique, idx1_unique_indices = np.unique(idx1, return_index=True)
@@ -111,9 +107,7 @@ def _overlay_difference(df1, df2):
 
 
 def _overlay_identity(df1, df2):
-    """
-    Overlay Identity operation used in overlay function.
-    """
+    """Overlay Identity operation used in overlay function."""
     dfintersection = _overlay_intersection(df1, df2)
     dfdifference = _overlay_difference(df1, df2)
     dfdifference = _ensure_geometry_column(dfdifference)
@@ -137,9 +131,7 @@ def _overlay_identity(df1, df2):
 
 
 def _overlay_symmetric_diff(df1, df2):
-    """
-    Overlay Symmetric Difference operation used in overlay function
-    """
+    """Overlay Symmetric Difference operation used in overlay function."""
     dfdiff1 = _overlay_difference(df1, df2)
     dfdiff2 = _overlay_difference(df2, df1)
     dfdiff1["__idx1"] = range(len(dfdiff1))
@@ -166,9 +158,7 @@ def _overlay_symmetric_diff(df1, df2):
 
 
 def _overlay_union(df1, df2):
-    """
-    Overlay Union operation used in overlay function
-    """
+    """Overlay Union operation used in overlay function."""
     dfinter = _overlay_intersection(df1, df2)
     dfsym = _overlay_symmetric_diff(df1, df2)
     dfunion = pd.concat([dfinter, dfsym], ignore_index=True, sort=False)
@@ -257,7 +247,7 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
     3         1       NaN      POLYGON ((2 0, 0 0, 0 2, 1 2, 1 1, 2 1, 2 0))
     4         2       NaN  MULTIPOLYGON (((3 4, 3 3, 2 3, 2 4, 3 4)), ((4...
 
-    See also
+    See Also
     --------
     sjoin : spatial join
     GeoDataFrame.overlay : equivalent method

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -16,7 +16,7 @@ from geopandas.array import (
 
 
 def _ensure_geometry_column(df):
-    """Help function to ensure the geometry column is called 'geometry'.
+    """Ensure that the geometry column is called 'geometry'.
 
     If another column with that name exists, it will be dropped.
     """

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -94,7 +94,7 @@ def sjoin(
     4        27         CHATHAM  MULTIPOINT ((-87.62715 41.73623))
     [5 rows x 95 columns]
 
-    See also
+    See Also
     --------
     overlay : overlay operation resulting in a new geometry
     GeoDataFrame.sjoin : equivalent method
@@ -140,14 +140,14 @@ def _maybe_make_list(obj):
 
 
 def _basic_checks(left_df, right_df, how, lsuffix, rsuffix, on_attribute=None):
-    """Checks the validity of join input parameters.
+    """Check the validity of join input parameters.
 
     `how` must be one of the valid options.
     `'index_'` concatenated with `lsuffix` or `rsuffix` must not already
     exist as columns in the left or right data frames.
 
     Parameters
-    ------------
+    ----------
     left_df : GeoDataFrame
     right_df : GeoData Frame
     how : str, one of 'left', 'right', 'inner'
@@ -212,7 +212,6 @@ def _geom_predicate_query(left_df, right_df, predicate, distance, on_attribute=N
         DataFrame with matching indices in
         columns named `_key_left` and `_key_right`.
     """
-
     original_predicate = predicate
 
     if predicate == "within":
@@ -364,7 +363,8 @@ def _restore_index(joined, index_names, index_names_original):
 
 
 def _adjust_indexers(indices, distances, original_length, how, predicate):
-    """
+    """Adjust the indexers for the join based on the `how` parameter.
+
     The left/right indexers from the query represents an inner join.
     For a left or right join, we need to adjust them to include the rows
     that would not be present in an inner join.
@@ -556,10 +556,10 @@ def _nearest_query(
 
 
 def _filter_shared_attribute(left_df, right_df, l_idx, r_idx, attribute):
-    """
-    Returns the indices for the left and right dataframe that share the same entry
-    in the attribute column. Also returns a Boolean `shared_attribute_rows` for rows
-    with the same entry.
+    """Return the indices for the left and right dataframe that share the same entry
+    in the attribute column.
+
+    Also returns a Boolean `shared_attribute_rows` for rows with the same entry.
     """
     shared_attribute_rows = (
         left_df[attribute].iloc[l_idx].values == right_df[attribute].iloc[r_idx].values
@@ -680,7 +680,7 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
     30          TARGET    UPTOWN
     30       Mariano's    UPTOWN
 
-    See also
+    See Also
     --------
     sjoin : binary predicate joins
     GeoDataFrame.sjoin_nearest : equivalent method
@@ -693,7 +693,6 @@ chicago_w_groceries[chicago_w_groceries["community"] == "UPTOWN"]
     Every operation in GeoPandas is planar, i.e. the potential third
     dimension is not taken into account.
     """
-
     _basic_checks(left_df, right_df, how, lsuffix, rsuffix)
 
     left_df.geometry.values.check_geographic_crs(stacklevel=1)

--- a/geopandas/tools/util.py
+++ b/geopandas/tools/util.py
@@ -11,8 +11,7 @@ _multi_type_map = {
 
 
 def collect(x, multi=False):
-    """
-    Collect single part geometries into their Multi* counterpart
+    """Collect single part geometries into their Multi* counterpart.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ select = [
     "RUF",
     # isort
     "I",
+    # pydocstyle
+    "D",
 ]
 
 ignore = [
@@ -178,6 +180,20 @@ ignore = [
     "PLC1802",
 
     ### Additional checks that don't pass yet
+    # Missing docstring in public module
+    "D100",
+    # Missing docstring in public class
+    "D101",
+    # Missing docstring in public method
+    "D102",
+    # Missing docstring in public function
+    "D103",
+    # Missing docstring in public package
+    "D104",
+    # Missing docstring in magic method
+    "D105",
+    # 1 blank line required between summary line and description
+    "D205",
     # Useless statement
     "B018",
     # Within an except clause, raise exceptions with ...
@@ -191,6 +207,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# ignore pydocstyle errors in tests
+"**/tests/*" = ["D"]
+"geopandas/conftest.py" = ["D"]
+# the order of imports in __init__ is a bit tricky, so keep manual
 "geopandas/__init__.py" = ["F401", "I"]
 
 [tool.ruff.lint.isort]
@@ -209,3 +229,6 @@ section-order = [
 [tool.ruff.lint.isort.sections]
 "geo" = ["shapely", "pyproj"]
 "testing" = ["pytest", "pandas.testing", "numpy.testing", "geopandas.tests", "geopandas.testing"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
Enable the pydocstyle ruff rules, but only the rules that can be fixed automatically or by making trivial changes.

Excluded rules:
- rules that trigger a missing docstring, as the content of the new docstring should be reviewed
- rules regarding having a single line summary at the start of the docstring, as this sometimes needs a serious rewrite of the docstring

In a followup PR the more complex rules can be activated/fixed so reviewing is a bit more manageble.