### PR TITLE
COMPAT: pandas 3 refactor breaks __finalize__ (#3611)

### DIFF
--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2095,12 +2095,24 @@ default 'snappy'
 
         # merge operation: using metadata of the left object
         if method == "merge":
+            # pandas-dev/pandas#60357 : merge/concat use input_objs
+            if PANDAS_GE_30:
+                # other is a types.SimpleNameSpace
+                left_obj = other.input_objs[0]
+            else:
+                # other is a _MergeOperation
+                left_obj = other.left
             for name in self._metadata:
-                object.__setattr__(self, name, getattr(other.left, name, None))
+                object.__setattr__(self, name, getattr(left_obj, name, None))
         # concat operation: using metadata of the first object
         elif method == "concat":
+            # pandas-dev/pandas#60357 : merge/concat use input_objs
+            if PANDAS_GE_30:
+                first_obj = other.input_objs[0]
+            else:
+                first_obj = other.objs[0]
             for name in self._metadata:
-                object.__setattr__(self, name, getattr(other.objs[0], name, None))
+                object.__setattr__(self, name, getattr(first_obj, name, None))
 
             if (
                 self.columns.nlevels == 1

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -861,6 +861,36 @@ def test_preserve_attrs(df):
     assert df3.attrs == attrs
 
 
+def test_attrs_concat():
+    # from pandas-dev/pandas#60357
+    # concat propagates attrs if all input attrs are equal
+    geoms = [Point(2, 2), Point(3, 3)]
+    df1 = GeoDataFrame({"A": [2, 3], "geometry": geoms})
+    df1.attrs = {"a": 1, "b": 2}
+    df2 = GeoDataFrame({"A": [4, 5], "geometry": geoms})
+    df2.attrs = df1.attrs.copy()
+    df3 = GeoDataFrame({"A": [6, 7], "geometry": geoms})
+    df3.attrs = df1.attrs.copy()
+    assert pd.concat([df1, df2, df3]).attrs == df1.attrs
+    # concat does not propagate attrs if input attrs are different
+    df2.attrs = {"c": 3}
+    assert pd.concat([df1, df2, df3]).attrs == {}
+
+
+def test_attrs_merge():
+    # from pandas-dev/pandas#60357
+    geoms = [Point(2, 2), Point(3, 3)]
+    # merge propagates attrs if all input attrs are equal
+    df1 = GeoDataFrame({"key": ["a", "b"], "val1": [1, 2], "geometry": geoms})
+    df1.attrs = {"a": 1, "b": 2}
+    df2 = GeoDataFrame({"key": ["a", "b"], "val2": [3, 4], "geometry": geoms})
+    df2.attrs = df1.attrs.copy()
+    assert pd.merge(df1, df2).attrs == df1.attrs
+    # merge does not propagate attrs if input attrs are different
+    df2.attrs = {"c": 3}
+    assert pd.merge(df1, df2).attrs == {}
+
+
 def test_preserve_flags(df):
     # https://github.com/geopandas/geopandas/issues/1654
     df = df.set_flags(allows_duplicate_labels=False)


### PR DESCRIPTION
Setting this up to backport this pandas fix before I forget, I would think it unlikely we have a 1.2 before pandas 3.