### PR TITLE
docs: add complete predicate options to sjoin method docstring

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -42,20 +42,22 @@ def sjoin(
         ``right_df.sindex.valid_query_predicates``
         
         Available predicates include:
+        
         * 'intersects': True if geometries intersect (boundaries and interiors)
         * 'within': True if left geometry is completely within right geometry
         * 'contains': True if left geometry completely contains right geometry
-        * 'contains_properly': True if left geometry contains right geometry 
+        * 'contains_properly': True if left geometry contains right geometry
           and their boundaries do not touch
         * 'overlaps': True if geometries overlap but neither contains the other
-        * 'crosses': True if geometries cross (interiors intersect but neither 
+        * 'crosses': True if geometries cross (interiors intersect but neither
           contains the other, with intersection dimension less than max dimension)
-        * 'touches': True if geometries touch at boundaries but interiors don't intersect
-        * 'covers': True if left geometry covers right geometry (every point of 
-          right is a point of left)
+        * 'touches': True if geometries touch at boundaries but interiors
+          don't intersect
+        * 'covers': True if left geometry covers right geometry (every point
+          of right is a point of left)
         * 'covered_by': True if left geometry is covered by right geometry
-        * 'dwithin': True if geometries are within specified distance (requires 
-          distance parameter)
+        * 'dwithin': True if geometries are within specified distance
+          (requires distance parameter)
         
         Replaces deprecated ``op`` parameter.
     lsuffix : string, default 'left'

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -45,20 +45,18 @@ def sjoin(
         * 'intersects': True if geometries intersect (boundaries and interiors)
         * 'within': True if left geometry is completely within right geometry
         * 'contains': True if left geometry completely contains right geometry
-        * 'contains_properly': True if left geometry contains right geometry
+        * 'contains_properly': True if left geometry contains right geometry 
           and their boundaries do not touch
         * 'overlaps': True if geometries overlap but neither contains the other
-        * 'crosses': True if geometries cross (interiors intersect but neither
+        * 'crosses': True if geometries cross (interiors intersect but neither 
           contains the other, with intersection dimension less than max dimension)
-        * 'touches': True if geometries touch at boundaries but interiors
-          don't intersect
-        * 'covers': True if left geometry covers right geometry (every point
-          of right is a point of left)
+        * 'touches': True if geometries touch at boundaries but interiors don't 
+          intersect
+        * 'covers': True if left geometry covers right geometry (every point of 
+          right is a point of left)
         * 'covered_by': True if left geometry is covered by right geometry
-        * 'dwithin': True if geometries are within specified distance
-          (requires distance parameter)
-        
-        Replaces deprecated ``op`` parameter.
+        * 'dwithin': True if geometries are within specified distance (requires 
+          distance parameter)
     lsuffix : string, default 'left'
         Suffix to apply to overlapping column names (left GeoDataFrame).
     rsuffix : string, default 'right'

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -40,6 +40,23 @@ def sjoin(
         You can check the valid values in left_df or right_df as
         ``left_df.sindex.valid_query_predicates`` or
         ``right_df.sindex.valid_query_predicates``
+        
+        Available predicates include:
+        * 'intersects': True if geometries intersect (boundaries and interiors)
+        * 'within': True if left geometry is completely within right geometry
+        * 'contains': True if left geometry completely contains right geometry
+        * 'contains_properly': True if left geometry contains right geometry 
+          and their boundaries do not touch
+        * 'overlaps': True if geometries overlap but neither contains the other
+        * 'crosses': True if geometries cross (interiors intersect but neither 
+          contains the other, with intersection dimension less than max dimension)
+        * 'touches': True if geometries touch at boundaries but interiors don't intersect
+        * 'covers': True if left geometry covers right geometry (every point of 
+          right is a point of left)
+        * 'covered_by': True if left geometry is covered by right geometry
+        * 'dwithin': True if geometries are within specified distance (requires 
+          distance parameter)
+        
         Replaces deprecated ``op`` parameter.
     lsuffix : string, default 'left'
         Suffix to apply to overlapping column names (left GeoDataFrame).

--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -42,7 +42,6 @@ def sjoin(
         ``right_df.sindex.valid_query_predicates``
         
         Available predicates include:
-        
         * 'intersects': True if geometries intersect (boundaries and interiors)
         * 'within': True if left geometry is completely within right geometry
         * 'contains': True if left geometry completely contains right geometry


### PR DESCRIPTION
## Summary
Added comprehensive documentation for all available spatial predicates in the `sjoin` method docstring.

## Changes
- Documented all 10 available spatial predicates with clear descriptions
- Added explanations of when each predicate returns True
- Noted special requirements (e.g., `dwithin` needs distance parameter)

## Motivation
The original docstring only mentioned the default 'intersects' predicate, leaving users unaware of other available options.