### PR TITLE
MAINT: Change doctest env

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,7 +95,7 @@ jobs:
           pytest -v -r a --color=yes --cov=geopandas --cov-append --cov-report term-missing --cov-report xml geopandas/io/tests/test_sql.py | tee /dev/stderr | if grep SKIPPED >/dev/null;then echo "TESTS SKIPPED, FAILING" && exit 1;fi
 
       - name: Test docstrings
-        if: contains(matrix.env, '311-pd22.yaml') && contains(matrix.os, 'ubuntu')
+        if: contains(matrix.env, '313-latest.yaml') && contains(matrix.os, 'ubuntu')
         run: |
           pytest -v --color=yes --doctest-only geopandas --ignore=geopandas/datasets
 

--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2996,7 +2996,7 @@ GeometryCollection
            :align: center
 
         >>> polygon = Polygon([(0, 0), (2, 2), (0, 2)])
-        >>> s.geom_equals(polygon)
+        >>> s.geom_equals(polygon, align=True)
         0     True
         1    False
         2    False
@@ -3572,7 +3572,7 @@ GeometryCollection
            :align: center
 
         >>> polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        >>> s.overlaps(polygon)
+        >>> s.overlaps(polygon, align=True)
         0     True
         1     True
         2    False
@@ -3800,7 +3800,7 @@ GeometryCollection
            :align: center
 
         >>> polygon = Polygon([(0, 0), (2, 2), (0, 2)])
-        >>> s.within(polygon)
+        >>> s.within(polygon, align=True)
         0     True
         1     True
         2    False

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -593,13 +593,25 @@ def test_read_file(engine, nybb_filename):
         # url to zip file
         "https://raw.githubusercontent.com/geopandas/geopandas/"
         "main/geopandas/tests/data/nybb_16a.zip",
-        # url to zipfile without extension
-        "https://geonode.goosocean.org/download/480",
         # url to web service
         "https://demo.pygeoapi.io/stable/collections/obs/items",
     ],
 )
 def test_read_file_url(engine, url):
+    gdf = read_file(url, engine=engine)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+
+
+@pytest.mark.web
+@pytest.mark.parametrize(
+    "url",
+    [
+        # url to zipfile without extension
+        "https://geonode.goosocean.org/download/480",
+    ],
+)
+@pytest.mark.xfail(reason="SSL certificate issue")
+def test_read_file_url_flaky(engine, url):
     gdf = read_file(url, engine=engine)
     assert isinstance(gdf, geopandas.GeoDataFrame)
 


### PR DESCRIPTION
This is an enabler for https://github.com/geopandas/geopandas/pull/3623, as geoarrow doesn't support older pythons. 
I think in the past we might have preferred not having doctests tied to one of the "latest" envs because it can lead to flux in the doctest results, but I think we can review that again when it comes up.


I've moved a test into xfailing to get the CI less red. The sole failing tests are those in #3643 and maybe a pandas main groupby agg issue.


