### PR TITLE
fix regression in resolution deprecation

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -5367,7 +5367,7 @@ GeometryCollection
     def buffer(
         self,
         distance,
-        quad_segs=16,
+        quad_segs=None,
         cap_style="round",
         join_style="round",
         mitre_limit=5.0,

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -1464,6 +1464,13 @@ class TestGeomMethods:
         calculated = original.buffer(5, quad_segs=1)
         assert geom_almost_equals(expected, calculated)
 
+        with pytest.warns(
+            DeprecationWarning,
+            match="The `resolution` argument to `buffer` is deprecated",
+        ):
+            calculated = original.buffer(5, resolution=1)
+            assert geom_almost_equals(expected, calculated)
+
     def test_buffer_args(self):
         args = {"cap_style": 3, "join_style": 2, "mitre_limit": 2.5}
         calculated_series = self.g0.buffer(10, **args)


### PR DESCRIPTION
#3600 caused a regression:

```py
gpd.GeoSeries([shapely.Point(0, 0)]).buffer(3, resolution=2)

ValueError: `buffer` received both `quad_segs` and `resolution` but these are aliases for the same parameter. Use `quad_segs` only instead.
```

That is because in base, we set default quad_seqs to 16, not None.