### PR TITLE
docs: Update force_2d docstring to mention removing M dimension

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -2299,7 +2299,7 @@ GeometryCollection
     def force_2d(self):
         """Force the dimensionality of a geometry to 2D.
 
-        Removes the additional Z coordinate dimension from all geometries.
+        Removes the additional Z and M coordinate dimensions from all geometries.
 
         Returns
         -------


### PR DESCRIPTION
It was kinda ambiguous before whether it's forced to 2d (like in the name) or if it only removed the Z dim.

Noticed during dev of this: https://github.com/apache/sedona/pull/2493