### PR TITLE
DOC: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,7 @@ Bug fixes:
   `GeoSeries` the name was not used as the active geometry column name (#3237).
 - Fix bug in `GeoSeries` constructor when passing a Series and specifying a `crs` to not change the original input data (#2492).
 - Fix regression preventing reading from file paths containing hashes in `read_file`
-  with the fiona engine (#3280). An analgous fix for pyogrio is included in
+  with the fiona engine (#3280). An analogous fix for pyogrio is included in
   pyogrio 0.8.1.
 - Fix `to_parquet` to write correct metadata in case of 3D geometries (#2824).
 - Fixes for compatibility with psycopg (#3167).
@@ -634,7 +634,7 @@ Small bug-fix release:
   overlay of two geometries in a GeometryCollection with other geometry types
   (#2177).
 - Fix ``overlay()`` to honor the ``keep_geom_type`` keyword for the
-  ``op="differnce"`` case (#2164).
+  ``op="difference"`` case (#2164).
 - Fix regression in ``plot()`` with a mapclassify ``scheme`` in case the
   formatted legend labels have duplicates (#2166).
 - Fix a bug in the ``explore()`` method ignoring the ``vmin`` and ``vmax`` keywords

--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1720,7 +1720,7 @@ class GeometryArray(ExtensionArray):
             # process those. The missing values are handled separately by
             # pandas regardless of the values we return here (to sort
             # first/last depending on 'na_position'), the distances for the
-            # empty geometries are substitued below with an appropriate value
+            # empty geometries are replaced below with an appropriate value
             geoms = self.copy()
             indices = np.nonzero(~mask)[0]
             if indices.size:

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -587,7 +587,7 @@ def _get_filesystem_path(path, filesystem=None, storage_options=None):
 
     if _is_fsspec_url(path) and filesystem is None:
         fsspec = import_optional_dependency(
-            "fsspec", extra="fsspec is requred for 'storage_options'."
+            "fsspec", extra="fsspec is required for 'storage_options'."
         )
         filesystem, path = fsspec.core.url_to_fs(path, **(storage_options or {}))
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1170,7 +1170,7 @@ def test_read_parquet_bbox(tmpdir, naturalearth_lowres, geometry_name):
 
 @pytest.mark.parametrize("geometry_name", ["geometry", "custum_geom_col"])
 def test_read_parquet_bbox_partitioned(tmpdir, naturalearth_lowres, geometry_name):
-    # check bbox is being used to filter results on partioned data.
+    # check bbox is being used to filter results on partitioned data.
     df = read_file(naturalearth_lowres)
     if geometry_name != "geometry":
         df = df.rename_geometry(geometry_name)

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -86,7 +86,7 @@ def test_to_crs_dimension_z():
     assert result.has_z.all()
 
 
-# pyproj + numpy 1.25 trigger warning for single-element array -> recommdation is to
+# pyproj + numpy 1.25 trigger warning for single-element array -> recommendation is to
 # ignore the warning for now (https://github.com/pyproj4/pyproj/issues/1307)
 @pytest.mark.filterwarnings("ignore:Conversion of an array with:DeprecationWarning")
 def test_to_crs_dimension_mixed():
@@ -166,7 +166,7 @@ def test_transform2(epsg4326, epsg26918):
     assert_geodataframe_equal(df, utm, check_less_precise=True, check_crs=False)
 
 
-# pyproj + numpy 1.25 trigger warning for single-element array -> recommdation is to
+# pyproj + numpy 1.25 trigger warning for single-element array -> recommendation is to
 # ignore the warning for now (https://github.com/pyproj4/pyproj/issues/1307)
 @pytest.mark.filterwarnings("ignore:Conversion of an array with:DeprecationWarning")
 def test_crs_axis_order__always_xy():


### PR DESCRIPTION
Some typos detected by [codespell](https://github.com/codespell-project/codespell) are fixed. 