### PR TITLE
CI: tmp avoid pandas nightly in dev test build

### DIFF
--- a/ci/envs/312-dev.yaml
+++ b/ci/envs/312-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - fsspec
+  - pandas
 
   # optional
   #- geopy
@@ -27,7 +28,7 @@ dependencies:
     - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.fury.io/arrow-nightlies/ --extra-index-url https://pypi.org/simple
     - numpy>=2.0.0
     - fiona
-    - pandas
+    # - pandas
     - matplotlib
     - pyarrow
     - git+https://github.com/shapely/shapely.git@main


### PR DESCRIPTION
There are currently many failures (which also will be partially solved upstream), but so testing here with released pandas so we can check the build for the other nightlies (specifically want to test pyogrio)