### PR TITLE
CI: install before checking versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,15 +68,15 @@ jobs:
         with:
           environment-file: ${{ matrix.env }}
 
+      - name: Install package
+        run: pip install -e .
+
       - name: Check and Log Environment
         run: |
           python -V
           python -c "import geopandas; geopandas.show_versions();"
           micromamba info
           micromamba list
-
-      - name: Install package
-        run: pip install -e .
 
       - name: Test
         env:


### PR DESCRIPTION
Because we are using setuptools-scm, you need to install package to get `__version__`.  Right now, `geopandas.show_versions()` is silently failing on CI.