### PR TITLE
CI: install geopandas without deps (to test without optional dependencies)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,6 +68,7 @@ jobs:
           environment-file: ${{ matrix.env }}
 
       - name: Install package
+        # install without deps to avoid installing default but optional pyproj/pyogrio
         run: pip install -e . --no-deps
 
       - name: Check and Log Environment


### PR DESCRIPTION
https://github.com/geopandas/geopandas/pull/3589 added a `pip install -e .` to the tests.yaml, but that caused us to always install the default but optional dependencies (i.e. pyproj and pyogrio)

Closes https://github.com/geopandas/geopandas/issues/3694