### PR TITLE
Revert "COMPAT: define _cast_pointwise_result for pandas compat"

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -1715,17 +1715,6 @@ class GeometryArray(ExtensionArray):
             distances[mask_empty] = 0
         return distances
 
-    def _cast_pointwise_result(self, values) -> GeometryArray:
-        result = super()._cast_pointwise_result(values)
-        # only attempt to construct GeometryArray from object dtype result
-        if result.dtype.kind == self.dtype.kind:
-            try:
-                return type(self)._from_sequence(result)
-            except (TypeError, shapely.errors.GeometryTypeError):
-                return result
-        else:  # special case for ea eq/neq methods
-            return result
-
     def argmin(self, skipna: bool = True) -> int:
         raise TypeError("geometries have no minimum or maximum")
 


### PR DESCRIPTION
Reverts geopandas/geopandas#3646

The last pandas 3.0.0rc1 should now have a base implementation of this methods that works as expected for geopandas.