### PR TITLE
Ignore int64 vs int_nativesize mismatches

### DIFF
--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -2055,7 +2055,11 @@ class TestGeomMethods:
                 ]
             ),
         )
-        assert_frame_equal(self.g11.get_coordinates(index_parts=True), expected, check_index_type=False)
+        assert_frame_equal(
+            self.g11.get_coordinates(index_parts=True),
+            expected,
+            check_index_type=False,
+        )
 
     def test_minimum_bounding_radius(self):
         mbr_geoms = self.g1.minimum_bounding_radius()


### PR DESCRIPTION
Introduced by pandas 2.x

Closes: #3189