### PR TITLE
BUG: sample_points is not accepting list-like size when using pointpatterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Deprecations and compatibility notes:
 - Expired deprecations; option `use_pygeos` which had no functionality,
   `seed` keyword in sample_points (replaced by `rng`) (#3613)
 
+Bug fixes:
+
+- Fix `GeoSeries.sample_points` not accepting list-like `size` when generating points using
+  `pointpaterns` (#3710).
+
 Community:
 
 - GeoPandas now uses the NumFOCUS Code of Conduct.

--- a/geopandas/tests/test_geom_methods.py
+++ b/geopandas/tests/test_geom_methods.py
@@ -2239,6 +2239,16 @@ class TestGeomMethods:
         ):
             gs.sample_points(10, method="nonexistent")
 
+    def test_sample_points_pointpats_array(self):
+        pytest.importorskip("pointpats")
+        output = concat([self.g1, self.g1]).sample_points(
+            [10, 15, 20, 25], method="cluster_poisson"
+        )
+        expected = Series(
+            [10, 15, 20, 25], index=[0, 1, 0, 1], name="sampled_points", dtype="int32"
+        )
+        assert_series_equal(shapely.get_num_geometries(output), expected)
+
     def test_offset_curve(self):
         oc = GeoSeries([self.l1]).offset_curve(1, join_style="mitre")
         expected = GeoSeries([LineString([[-1, 0], [-1, 2], [1, 2]])])


### PR DESCRIPTION
A bug @knaaptime found in https://github.com/pysal/tobler/pull/247#discussion_r2680066691 . We are correctly passing list-like size when generating a uniform distribution but not when generating anything with pointpats.  

E.g. this does not work on main, despite documentation saying otherwise.

```py
variable_size = nybb.sample_points([10, 50, 100, 200, 500], method="cluster_poisson")
```