### PR TITLE
CI: cleanup matrix definition for tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,11 +43,14 @@ jobs:
           # PostGIS envs
           - env: ci/envs/311-pd22.yaml
             postgis: true
+            os: ubuntu-latest
           - env: ci/envs/312-latest.yaml
             postgis: true
+            os: ubuntu-latest
           # doctest env
           - env: ci/envs/313-latest.yaml
             doctest: true
+            os: ubuntu-latest
           # MacOS & Windows envs
           - env: ci/envs/313-latest-no-pyogrio.yaml
             os: macos-latest


### PR DESCRIPTION
Was looking at flags in #3706, realised that we have a postgis flag we don't use but could to try and group all the yamls at the top.

I'm pretty sure at least once I've updated the envs and forgotten to bump the string in the doctest env, this would mean that all the yamls are only listed in one place so that would be less likely to happen