### PR TITLE
TST: test _check_invalid_categories explicitly

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pandas.core.dtypes.cast import coerce_indexer_dtype
 import warnings
 from collections.abc import Collection, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
@@ -8,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import pandas as pd
 from pandas import CategoricalDtype
+from pandas.core.dtypes.cast import coerce_indexer_dtype
 from pandas.plotting import PlotAccessor
 
 import shapely

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -432,7 +432,9 @@ class TestPointPlotting:
         values = np.array(["cat1", "cat2"], dtype=object)
         categories = ["cat1"]
 
-        with pytest.raises(ValueError, match="Column contains values not listed in categories"):
+        with pytest.raises(
+            ValueError, match="Column contains values not listed in categories"
+        ):
             _check_invalid_categories(categories, values)
 
     def test_missing(self):


### PR DESCRIPTION
`_check_invalid_categories` could reach its return statement without initializing `cat` when invalid category values are present, causing an `UnboundLocalError` instead of the intended `ValueError`.

This change makes the error path explicit by raising immediately when invalid categories are detected, ensuring `cat` is only returned when it is guaranteed to be defined.

Closes #3718.