### PR TITLE
TST: update set_geometry test for pandas 3.0 compat (without pyproj)

### DIFF
--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -256,10 +256,12 @@ class TestDataFrame:
     def test_set_geometry(self):
         geom = GeoSeries([Point(x, y) for x, y in zip(range(5), range(5))])
         original_geom = self.df.geometry
+        expected = geom.copy()
+        expected.crs = self.df.crs
 
         df2 = self.df.set_geometry(geom)
-        assert self.df is not df2
-        assert_geoseries_equal(df2.geometry, geom, check_crs=False)
+        assert df2 is not self.df
+        assert_geoseries_equal(df2.geometry, expected)
         assert_geoseries_equal(self.df.geometry, original_geom)
         assert_geoseries_equal(self.df["geometry"], self.df.geometry)
         # unknown column


### PR DESCRIPTION
One more change similar as https://github.com/geopandas/geopandas/pull/3711 (ensuring the compared geometries in `assert_geoseries_equal` are a copy, to avoid the shapely bug that bubbles up with pandas 3.0). 

This one only failed when pyproj is not installed, so therefore not caught yet in https://github.com/geopandas/geopandas/pull/3711 

With this the CI should be back to green