### PR TITLE
fixes #3725 - NA geometries to postgis

### DIFF
--- a/geopandas/io/sql.py
+++ b/geopandas/io/sql.py
@@ -319,9 +319,20 @@ def _psql_insert_copy(tbl, conn, keys, data_iter):
     import csv
     import io
 
+    keys = list(keys)
+
     s_buf = io.StringIO()
     writer = csv.writer(s_buf)
-    writer.writerows(data_iter)
+    if len(keys) != 1:
+        writer.writerows(data_iter)
+    else:
+        for data in data_iter:
+            if pd.notna(data[0]):
+                writer.writerow(data)
+            else:
+                # avoid writing ""\n for NA
+                # which will be interpreted as an empty string
+                s_buf.write(writer.dialect.lineterminator)
     s_buf.seek(0)
 
     columns = ", ".join(f'"{k}"' for k in keys)

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -188,7 +188,6 @@ def df_mixed_none_geometry():
                 None,
                 MultiPolygon([[[[0, 0], [0, 1], [1, 1], [1, 0]]]]),
             ],
-            "id": [0, 1],
         },
         crs="epsg:4326",
     )


### PR DESCRIPTION
Minimal fix for the specific behaviour of the CSV writer when only one column is written and that contains NA.
For this case Python's CSV writer and postgres CSV reader are at odds. The accepted answer is enforced `\n` instead of `""\n`.

Fixing exactly this case avoids other unintended consequences.

Closes #3725.