### PR TITLE
BUG: Fix UnboundLocalError in _check_invalid_categories (#3718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Bug fixes:
 
 - Fix `GeoSeries.sample_points` not accepting list-like `size` when generating points using
   `pointpaterns` (#3710).
+- Fix `_check_invalid_categories` raising `UnboundLocalError` instead of `ValueError` when
+  plotting with invalid category values (#3718).
 
 Community:
 

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1040,16 +1040,13 @@ def _check_invalid_categories(
         wrong = (codes == -1) & ~pd.isna(values)
         if wrong.any():
             missing = list(np.unique(values[wrong]))
-        else:
-            missing = []
-            codes_downcast = pd.core.dtypes.cast.coerce_indexer_dtype(codes, categories)
-            cat = pd.Categorical.from_codes(codes_downcast, categories)
-
-        if missing:
             raise ValueError(
                 "Column contains values not listed in categories. "
                 f"Missing categories: {missing}."
             )
+        codes_downcast = pd.core.dtypes.cast.coerce_indexer_dtype(codes, categories)
+        cat = pd.Categorical.from_codes(codes_downcast, categories)
+
     return cat
 
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -428,6 +428,24 @@ class TestPointPlotting:
         ):
             self.df.plot(column="cats", categories=["cat1"])
 
+    def test_check_invalid_categories_raises_valueerror(self):
+        """Test that _check_invalid_categories raises ValueError, not UnboundLocalError.
+
+        Regression test for https://github.com/geopandas/geopandas/issues/3718
+        """
+        from geopandas.plotting import _check_invalid_categories
+
+        values = pd.Series(["cat1", "cat2", "cat3"])
+
+        # Should raise ValueError with clear message about missing categories
+        with pytest.raises(ValueError, match="Missing categories"):
+            _check_invalid_categories(["cat1", "cat2"], values)
+
+        # Valid case should work without error
+        result = _check_invalid_categories(["cat1", "cat2", "cat3"], values)
+        assert isinstance(result, pd.Categorical)
+        assert list(result.categories) == ["cat1", "cat2", "cat3"]
+
     def test_missing(self):
         self.df.loc[0, "values"] = np.nan
         ax = self.df.plot("values")


### PR DESCRIPTION
Fixes #3718

The `_check_invalid_categories` function had a code path where `cat` was never assigned before return. This happened when invalid category values were detected (`wrong.any()` was True).

**Changes:**
- Restructured to raise `ValueError` immediately when invalid categories detected
- Ensured `cat` is always assigned before return
- Added regression test for error behavior
- Updated CHANGELOG.md