### PR TITLE
ENH: expose greedy coloring from mapclassify (#2818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 New features and improvements:
 
+- `GeoDataFrame.plot` now supports `scheme="greedy"` for topological coloring
+  where adjacent geometries receive different colors, using mapclassify's
+  greedy function (#2818).
 - `GeoDataFrame.to_parquet` and `read_parquet` will now write and read ``attrs``
   respectively (#3597)
 - Add ``grid_size`` parameter to ``union``, ``difference``, ``symmetric_difference``

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -832,6 +832,11 @@ def plot_dataframe(
             unique_colors = sorted(greedy_colors.unique())
             values = pd.Categorical(greedy_colors.values, categories=unique_colors)
             categories = unique_colors
+            # Create labels for legend (color indices as strings)
+            if legend_kwds is not None and "labels" in legend_kwds:
+                labels = list(legend_kwds.pop("labels"))
+            else:
+                labels = [str(c) for c in unique_colors]
             # set categorical to True for creating the legend
             categorical = True
             if cmap is None:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -765,7 +765,7 @@ def plot_dataframe(
     if isinstance(markersize, str):
         markersize = df[markersize].values
 
-    if column is None:
+    if column is None and not (scheme and scheme.lower() == "greedy"):
         return plot_series(
             df.geometry,
             cmap=cmap,
@@ -779,7 +779,10 @@ def plot_dataframe(
         )
 
     # To accept pd.Series and np.arrays as column
-    if isinstance(column, np.ndarray | pd.Series | pd.Index):
+    if column is None and scheme and scheme.lower() == "greedy":
+        # Greedy coloring doesn't use column values, just geometry
+        values = pd.Series([0] * len(df), index=df.index)
+    elif isinstance(column, np.ndarray | pd.Series | pd.Index):
         if column.shape[0] != df.shape[0]:
             raise ValueError(
                 "The dataframe and given column have different number of rows."

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1980,9 +1980,9 @@ def test_polygon_patch():
         assert len(path.vertices) == len(path.codes) == 198
 
 
-
 try:
     import mapclassify
+
     HAS_GREEDY = hasattr(mapclassify, "greedy")
 except ImportError:
     HAS_GREEDY = False

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1997,8 +1997,14 @@ class TestGreedyColoring:
         self.polys = GeoSeries([t1, t2, t3, t4])
         self.df = GeoDataFrame({"geometry": self.polys, "values": [1, 2, 3, 4]})
 
+try:
+    import mapclassify
+    HAS_GREEDY = hasattr(mapclassify, "greedy")
+except ImportError:
+    HAS_GREEDY = False
+
     @pytest.mark.skipif(
-        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        not HAS_GREEDY,
         reason="mapclassify.greedy not available",
     )
     def test_greedy_scheme(self):
@@ -2007,7 +2013,7 @@ class TestGreedyColoring:
         assert len(ax.collections) > 0
 
     @pytest.mark.skipif(
-        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        not HAS_GREEDY,
         reason="mapclassify.greedy not available",
     )
     def test_greedy_with_legend(self):
@@ -2016,7 +2022,7 @@ class TestGreedyColoring:
         assert ax.get_legend() is not None
 
     @pytest.mark.skipif(
-        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        not HAS_GREEDY,
         reason="mapclassify.greedy not available",
     )
     def test_greedy_with_cmap(self):
@@ -2025,7 +2031,7 @@ class TestGreedyColoring:
         assert len(ax.collections) > 0
 
     @pytest.mark.skipif(
-        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        not HAS_GREEDY,
         reason="mapclassify.greedy not available",
     )
     def test_greedy_adjacent_different_colors(self):

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1980,6 +1980,14 @@ def test_polygon_patch():
         assert len(path.vertices) == len(path.codes) == 198
 
 
+
+try:
+    import mapclassify
+    HAS_GREEDY = hasattr(mapclassify, "greedy")
+except ImportError:
+    HAS_GREEDY = False
+
+
 class TestGreedyColoring:
     """Test greedy topological coloring (scheme='greedy') for issue #2818."""
 
@@ -1996,12 +2004,6 @@ class TestGreedyColoring:
         t4 = Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])  # adjacent to t2, t3
         self.polys = GeoSeries([t1, t2, t3, t4])
         self.df = GeoDataFrame({"geometry": self.polys, "values": [1, 2, 3, 4]})
-
-try:
-    import mapclassify
-    HAS_GREEDY = hasattr(mapclassify, "greedy")
-except ImportError:
-    HAS_GREEDY = False
 
     @pytest.mark.skipif(
         not HAS_GREEDY,

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1980,6 +1980,65 @@ def test_polygon_patch():
         assert len(path.vertices) == len(path.codes) == 198
 
 
+class TestGreedyColoring:
+    """Test greedy topological coloring (scheme='greedy') for issue #2818."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        # Create adjacent polygons for greedy coloring test
+        # Layout: a grid of 4 adjacent squares
+        #   t3 | t4
+        #   ---+---
+        #   t1 | t2
+        t1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+        t2 = Polygon([(1, 0), (2, 0), (2, 1), (1, 1)])  # adjacent to t1
+        t3 = Polygon([(0, 1), (1, 1), (1, 2), (0, 2)])  # adjacent to t1
+        t4 = Polygon([(1, 1), (2, 1), (2, 2), (1, 2)])  # adjacent to t2, t3
+        self.polys = GeoSeries([t1, t2, t3, t4])
+        self.df = GeoDataFrame({"geometry": self.polys, "values": [1, 2, 3, 4]})
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        reason="mapclassify.greedy not available",
+    )
+    def test_greedy_scheme(self):
+        # Test that scheme="greedy" works without error
+        ax = self.df.plot(scheme="greedy")
+        assert len(ax.collections) > 0
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        reason="mapclassify.greedy not available",
+    )
+    def test_greedy_with_legend(self):
+        # Test greedy coloring with legend
+        ax = self.df.plot(scheme="greedy", legend=True)
+        assert ax.get_legend() is not None
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        reason="mapclassify.greedy not available",
+    )
+    def test_greedy_with_cmap(self):
+        # Test greedy coloring with custom colormap
+        ax = self.df.plot(scheme="greedy", cmap="Set1")
+        assert len(ax.collections) > 0
+
+    @pytest.mark.skipif(
+        not hasattr(__import__("mapclassify", fromlist=[""]), "greedy"),
+        reason="mapclassify.greedy not available",
+    )
+    def test_greedy_adjacent_different_colors(self):
+        # Test that adjacent polygons have different colors
+        # This is the core feature of greedy coloring
+        ax = self.df.plot(scheme="greedy")
+        colors = ax.collections[0].get_facecolors()
+        # t1 (index 0) is adjacent to t2 (index 1) - should have different colors
+        assert not np.allclose(colors[0], colors[1])
+        # t1 (index 0) is adjacent to t3 (index 2) - should have different colors
+        assert not np.allclose(colors[0], colors[2])
+
+
 def _check_colors(N, actual_colors, expected_colors, alpha=None):
     """
     Asserts that the members of `collection` match the `expected_colors`


### PR DESCRIPTION
Fixes #2818

This PR adds support for `scheme="greedy"` in `GeoDataFrame.plot()` for topological coloring, where adjacent geometries receive different colors.

Changes:
- Added special handling for `scheme="greedy"` in [plotting.py](cci:7://file:///d:/gis_dev/geopandas/geopandas/plotting.py:0:0-0:0) to use `mapclassify.greedy()` instead of `mapclassify.classify()`
- Updated docstring to document the new option
- Added tests for greedy coloring
- Updated CHANGELOG.md