### PR TITLE
BUG: inserting rows into empty geodataframe should preserve CRS

### DIFF
--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -11,7 +11,7 @@ import shapely
 
 PANDAS_GE_23 = Version(pd.__version__) >= Version("2.3.0")
 PANDAS_GE_30 = Version(pd.__version__) >= Version("3.0.0")
-PANDAS_GE_40 = Version(pd.__version__) >= Version("4.0.0.dev0")
+PANDAS_GE_31 = Version(pd.__version__) >= Version("3.1.0.dev0")
 PANDAS_INFER_STR = PANDAS_GE_23 and pd.options.future.infer_string
 
 

--- a/geopandas/_compat.py
+++ b/geopandas/_compat.py
@@ -10,7 +10,8 @@ import shapely
 # -----------------------------------------------------------------------------
 
 PANDAS_GE_23 = Version(pd.__version__) >= Version("2.3.0")
-PANDAS_GE_30 = Version(pd.__version__) >= Version("3.0.0.dev0")
+PANDAS_GE_30 = Version(pd.__version__) >= Version("3.0.0")
+PANDAS_GE_40 = Version(pd.__version__) >= Version("4.0.0.dev0")
 PANDAS_INFER_STR = PANDAS_GE_23 and pd.options.future.infer_string
 
 

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -163,14 +163,14 @@ def test_loc_add_row(geom_name, nybb_filename):
         expected_crs = nybb.crs
     else:
         ctx = contextlib.nullcontext()
-        if geom_name == "geometry":
-            expected_crs = nybb.crs
-        else:
-            expected_crs = None  # this should be nybb.crs, regressed in #2373
+        expected_crs = None  # this should be nybb.crs, regressed in #2373
     with ctx:
         nybb.loc[5] = [6, nybb.geometry.iloc[0]]
-    assert nybb.geometry.dtype == "geometry"
-    assert nybb.crs is expected_crs
+    if PANDAS_GE_40 or geom_name == "geometry":
+        assert nybb.geometry.dtype == "geometry"
+        assert nybb.crs is expected_crs
+    else:
+        assert nybb.geometry.dtype == "object"
 
 
 def test_iloc(df):

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -6,7 +6,7 @@ from shapely.geometry import Point
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas._compat import PANDAS_GE_31
+from geopandas._compat import PANDAS_GE_30, PANDAS_GE_31
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal
@@ -169,6 +169,7 @@ def test_loc_add_row(geom_name, nybb_filename):
         assert nybb.geometry.dtype == "object"
 
 
+@pytest.mark.skipif(not PANDAS_GE_30, reason="fixed in Pandas >= 3.0")
 @pytest.mark.parametrize("geom_name", ["geometry", "geom"])
 def test_loc_add_row_empty_df(geom_name):
     # https://github.com/geopandas/geopandas/issues/3109

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import numpy as np
 import pandas as pd
 
@@ -5,6 +7,7 @@ from shapely.geometry import Point
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries
+from geopandas._compat import PANDAS_GE_40
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal
@@ -147,30 +150,27 @@ def test_loc(df):
     assert_object(df.loc[:, "value1"], pd.Series)
 
 
-@pytest.mark.parametrize(
-    "geom_name",
-    [
-        "geometry",
-        pytest.param(
-            "geom",
-            marks=pytest.mark.xfail(
-                reason="pre-regression behaviour only works for geometry col geometry"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("geom_name", ["geometry", "geom"])
 def test_loc_add_row(geom_name, nybb_filename):
     # https://github.com/geopandas/geopandas/issues/3119
 
     nybb = geopandas.read_file(nybb_filename)[["BoroCode", "geometry"]]
     if geom_name != "geometry":
         nybb = nybb.rename_geometry(geom_name)
-    # crs_orig = nybb.crs
-
     # add a new row
-    nybb.loc[5] = [6, nybb.geometry.iloc[0]]
+    if PANDAS_GE_40:
+        ctx = pytest.warns(UserWarning, match="CRS not set for some")
+        expected_crs = nybb.crs
+    else:
+        ctx = contextlib.nullcontext()
+        if geom_name == "geometry":
+            expected_crs = nybb.crs
+        else:
+            expected_crs = None  # this should be nybb.crs, regressed in #2373
+    with ctx:
+        nybb.loc[5] = [6, nybb.geometry.iloc[0]]
     assert nybb.geometry.dtype == "geometry"
-    assert nybb.crs is None  # TODO this should be crs_orig, regressed in #2373
+    assert nybb.crs is expected_crs
 
 
 def test_iloc(df):

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -1,8 +1,7 @@
-import contextlib
-
 import numpy as np
 import pandas as pd
 
+from shapely import Polygon
 from shapely.geometry import Point
 
 import geopandas
@@ -159,18 +158,32 @@ def test_loc_add_row(geom_name, nybb_filename):
         nybb = nybb.rename_geometry(geom_name)
     # add a new row
     if PANDAS_GE_31:
-        ctx = pytest.warns(UserWarning, match="CRS not set for some.*")
         expected_crs = nybb.crs
     else:
-        ctx = contextlib.nullcontext()
         expected_crs = None  # this should be nybb.crs, regressed in #2373
-    with ctx:
-        nybb.loc[5] = [6, nybb.geometry.iloc[0]]
+    nybb.loc[5] = [6, nybb.geometry.iloc[0]]
     if PANDAS_GE_31 or geom_name == "geometry":
         assert nybb.geometry.dtype == "geometry"
         assert nybb.crs is expected_crs
     else:
         assert nybb.geometry.dtype == "object"
+
+
+@pytest.mark.parametrize("geom_name", ["geometry", "geom"])
+def test_loc_add_row_empty_df(geom_name):
+    # https://github.com/geopandas/geopandas/issues/3109
+    gdf = GeoDataFrame(geometry=[], crs="EPSG:4326")
+    if geom_name != "geometry":
+        gdf = gdf.rename_geometry("geom")
+    p = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    gdf.loc[0] = [p]
+    assert gdf.active_geometry_name == geom_name
+    assert gdf.crs == "EPSG:4326"
+
+    # Series case
+    ser = GeoSeries(crs="EPSG:4326")
+    ser[0] = p
+    assert ser.crs == "EPSG:4326"
 
 
 def test_iloc(df):

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -7,7 +7,7 @@ from shapely.geometry import Point
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas._compat import PANDAS_GE_40
+from geopandas._compat import PANDAS_GE_31
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal
@@ -158,15 +158,15 @@ def test_loc_add_row(geom_name, nybb_filename):
     if geom_name != "geometry":
         nybb = nybb.rename_geometry(geom_name)
     # add a new row
-    if PANDAS_GE_40:
-        ctx = pytest.warns(UserWarning, match="CRS not set for some")
+    if PANDAS_GE_31:
+        ctx = pytest.warns(UserWarning, match="CRS not set for some.*")
         expected_crs = nybb.crs
     else:
         ctx = contextlib.nullcontext()
         expected_crs = None  # this should be nybb.crs, regressed in #2373
     with ctx:
         nybb.loc[5] = [6, nybb.geometry.iloc[0]]
-    if PANDAS_GE_40 or geom_name == "geometry":
+    if PANDAS_GE_31 or geom_name == "geometry":
         assert nybb.geometry.dtype == "geometry"
         assert nybb.crs is expected_crs
     else:

--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -6,7 +6,7 @@ from shapely.geometry import Point
 
 import geopandas
 from geopandas import GeoDataFrame, GeoSeries
-from geopandas._compat import PANDAS_GE_30, PANDAS_GE_31
+from geopandas._compat import PANDAS_GE_31
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal
@@ -169,7 +169,7 @@ def test_loc_add_row(geom_name, nybb_filename):
         assert nybb.geometry.dtype == "object"
 
 
-@pytest.mark.skipif(not PANDAS_GE_30, reason="fixed in Pandas >= 3.0")
+@pytest.mark.skipif(not PANDAS_GE_31, reason="fixed in Pandas >= 3.1")
 @pytest.mark.parametrize("geom_name", ["geometry", "geom"])
 def test_loc_add_row_empty_df(geom_name):
     # https://github.com/geopandas/geopandas/issues/3109


### PR DESCRIPTION
Closes #3109, extension of #3741. This actually changes behaviour on our side so best to leave split. Diff will be cleaner once that is merged.

Also fairly sure I'll have to go back and fix old pandas versions.