### PR TITLE
BUG: overlay with empty input handles keep geom dtype gracefully

### DIFF
--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -846,13 +846,22 @@ def test_zero_len():
         crs=4326,
     )
     # overlay with empty geodataframe shouldn't throw
-    gdf2 = GeoDataFrame({"geometry": []}, crs=4326)
-    res = gdf1.overlay(gdf2, how="union")
+    empty = GeoDataFrame({"geometry": []}, crs=4326)
+    res = gdf1.overlay(empty, how="union")
     assert_geodataframe_equal(res, gdf1)
+    res = gdf1.overlay(empty, how="union")
+    assert_geodataframe_equal(res, gdf1)
+    res = empty.overlay(gdf1, how="union", keep_geom_type=False)
+    assert_geodataframe_equal(res, gdf1)
+    res = empty.overlay(gdf1, how="difference", keep_geom_type=False)
+    assert_geodataframe_equal(res, empty)
 
-    gdf2 = GeoDataFrame(geometry=[], crs=4326)
-    res = gdf1.overlay(gdf2, how="union")
-    assert_geodataframe_equal(res, gdf1)
+    # keep_geom_type should warn gracefully with an empty input
+    # https://github.com/geopandas/geopandas/discussions/3738
+    with pytest.warns(
+        UserWarning, match="`keep_geom_type=True` is invalid when df1 is empty"
+    ):
+        empty.overlay(gdf1, how="union", keep_geom_type=True)
 
 
 class TestOverlayWikiExample:

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -1,5 +1,6 @@
 import warnings
 from functools import reduce
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -169,7 +170,15 @@ def _overlay_union(df1, df2):
     return dfunion.reindex(columns=columns)
 
 
-def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
+def overlay(
+    df1: GeoDataFrame,
+    df2: GeoDataFrame,
+    how: Literal[
+        "intersection", "union", "identity", "symmetric_difference", "difference"
+    ] = "intersection",
+    keep_geom_type: bool | None = None,
+    make_valid: bool = True,
+):
     """Perform spatial overlay between two GeoDataFrames.
 
     Currently only supports data GeoDataFrames with uniform geometry types,
@@ -333,7 +342,15 @@ def overlay(df1, df2, how="intersection", keep_geom_type=None, make_valid=True):
 
     # Determine the geometry type before make_valid, as make_valid may change it
     if keep_geom_type:
-        geom_type = df1.geom_type.iloc[0]
+        if len(df1) == 0:
+            msg = (
+                "`keep_geom_type=True` is invalid when df1 is empty as "
+                "there is no geom type to keep. Setting `keep_geom_type=False`"
+            )
+            warnings.warn(msg, stacklevel=3)
+            keep_geom_type = False
+        else:
+            geom_type = df1.geom_type.iloc[0]
 
     df1 = _make_valid(df1)
     df2 = _make_valid(df2)

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -345,7 +345,7 @@ def overlay(
         if len(df1) == 0:
             msg = (
                 "`keep_geom_type=True` is invalid when df1 is empty as "
-                "there is no geom type to keep. Setting `keep_geom_type=False`"
+                "there is no geometry type to keep. Setting `keep_geom_type=False`"
             )
             warnings.warn(msg, stacklevel=3)
             keep_geom_type = False


### PR DESCRIPTION
From https://github.com/geopandas/geopandas/discussions/3738