### PR TITLE
Improve clarity in GeoDataFrame creation example documentation

### DIFF
--- a/doc/source/gallery/create_geopandas_from_pandas.ipynb
+++ b/doc/source/gallery/create_geopandas_from_pandas.ipynb
@@ -31,6 +31,8 @@
    "metadata": {},
    "source": [
     "From longitudes and latitudes\n",
+    This example demonstrates how to construct a GeoDataFrame from longitude and latitude columns, which is one of the most common workflows when working with geospatial data.
+
     "=============================\n",
     "\n",
     "First, let's consider a ``DataFrame`` containing cities and their respective\n",
@@ -62,6 +64,7 @@
     "``points_from_xy()`` to transform **Longitude** and **Latitude** into a list\n",
     "of ``shapely.Point`` objects and set it as a ``geometry`` while creating the\n",
     "``GeoDataFrame``. (note that ``points_from_xy()`` is an enhanced wrapper for\n",
+    This function simplifies the process of converting coordinate columns into geometric points.
     "``[Point(x, y) for x, y in zip(df.Longitude, df.Latitude)]``). The ``crs``\n",
     "value is also set to explicitly state the geometry data defines latitude/\n",
     "longitude world geodetic degree values. This is important for the correct \n",


### PR DESCRIPTION
Improves clarity in the GeoDataFrame creation example by adding additional explanation for common workflows and the usage of points_from_xy().

This helps new users better understand how coordinate data is converted into geometry.

Closes #529

Assisted by AI for drafting, reviewed manually.