### PR TITLE
DOC: clarify sindex.query bounding-box-only behaviour when no predicate

### DIFF
--- a/geopandas/sindex.py
+++ b/geopandas/sindex.py
@@ -65,6 +65,14 @@ class SpatialIndex:
         and tree geometries where the bounding box of each input geometry
         intersects the bounding box of a tree geometry.
 
+        .. note::
+            When ``predicate`` is ``None`` (the default), matching is based on
+            **bounding-box intersection only** — the actual geometry shapes are not
+            compared.  When a predicate is provided the spatial index first filters
+            candidates by bounding box and then applies the predicate to the actual
+            geometries, so the result reflects the true spatial relationship. See the
+            ``predicate`` parameter description below for details.
+
         The result can be returned as an array of 'indices' or a boolean 'sparse' or
         'dense' array. This can be controlled using the ``output_format`` keyword.
         Options are as follows.


### PR DESCRIPTION
Closes #2668.

The opening summary of `SpatialIndex.query` describes a bounding-box intersection result, which is accurate when `predicate=None`. However, when a predicate *is* provided the method goes further and filters by actual geometry, so the result reflects the true spatial relationship rather than just bounding boxes.

This distinction was already documented further down (lines 97–100), but was easy to miss. Added a `.. note::` callout near the top of the docstring that makes the `predicate=None` / predicate behaviour explicit at a glance.

Made with [Cursor](https://cursor.com)