### PR TITLE
ENH: allow control of axis labels addition via add_labels in plot

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -475,6 +475,7 @@ def plot_series(
     figsize: tuple[float, float] | None = None,
     aspect: float | Literal["auto", "equal", None] = "auto",
     autolim: bool = True,
+    add_labels: bool = True,
     **style_kwds,
 ) -> Axes:
     """
@@ -513,6 +514,8 @@ def plot_series(
         also be set manually (float) as the ratio of y-unit to x-unit.
     autolim : bool (default True)
         Update axes data limits to contain the new geometries.
+    add_labels : bool (default True)
+        Use CRS metadata to label the axes.
     **style_kwds : dict
         Color options to be passed on to the actual plot function, such
         as ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``,
@@ -537,7 +540,8 @@ def plot_series(
     if ax is None:
         _, ax = plt.subplots(figsize=figsize)
 
-    _set_axis_labels(ax, s.crs)
+    if add_labels:
+        _set_axis_labels(ax, s.crs)
 
     if s.empty:
         warnings.warn(
@@ -675,6 +679,7 @@ def plot_dataframe(
     missing_kwds: dict | None = None,
     aspect: float | Literal["auto", "equal", None] = "auto",
     autolim: bool = True,
+    add_labels: bool = True,
     **style_kwds,
 ) -> Axes:
     """
@@ -793,6 +798,8 @@ def plot_dataframe(
         y-unit to x-unit.
     autolim : ``bool`` (default ``True``)
         Update axes data limits to contain the new geometries.
+    add_labels : bool (default True)
+        Use CRS metadata to label the axes.
     **style_kwds : dict
         Style options to be passed on to the actual plot function, such as
         ``edgecolor``, ``facecolor``, ``linewidth``, ``markersize``, ``alpha``. These
@@ -864,7 +871,8 @@ def plot_dataframe(
             raise ValueError("'ax' can not be None if 'cax' is not.")
         _fig, ax = plt.subplots(figsize=figsize)
 
-    _set_axis_labels(ax, df.crs)
+    if add_labels:
+        _set_axis_labels(ax, df.crs)
 
     # set correct aspect to preserve proportions in geographic CRS
     _set_aspect(aspect, df, ax)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -2744,3 +2744,12 @@ class TestAxisLabels:
         ax = self.nybb.plot(ax=ax)
         assert ax.get_xlabel() == "xlabel"
         assert ax.get_ylabel() == "Northing [US survey foot]"
+
+    def test_no_labels(self):
+        ax = self.nybb.plot("forhis06", add_labels=False)
+        assert ax.get_xlabel() == ""
+        assert ax.get_ylabel() == ""
+
+        ax2 = self.nybb.geometry.plot(add_labels=False)
+        assert ax2.get_xlabel() == ""
+        assert ax2.get_ylabel() == ""


### PR DESCRIPTION
This is a direct follow-up on #3748 which adds a keyword to control the behaviour. It was pointed out to me that there might be cases when you don't want this and don't want to bother with removal of the labels afterwards. For a reference, [xarray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.plot.imshow.html) also has this keyword.

As with other plotting PRs, changelog will come later containing them all.