### PR TITLE
DOC: Fixing Stray Documentation Links for matplotlib_map_utils

### DIFF
--- a/doc/source/gallery/inset_map.ipynb
+++ b/doc/source/gallery/inset_map.ipynb
@@ -237,7 +237,7 @@
     "\n",
     "This library is intended to provide an easier-to-use interface for constructing inset maps (along with scale bars and north arrows) for matplotlib plots than either the `inset_axes()` method or function.\n",
     "\n",
-    "Using this package, an inset map and its relevant indicators can be made with either **functions** or **classes**, which are reusable across plots; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing the map are available within the `docs` directory of the repository (see [here](https://github.com/moss-xyz/matplotlib-map-utils/blob/main/matplotlib_map_utils/docs/howto_inset_map.ipynb))."
+    "Using this package, an inset map and its relevant indicators can be made with either **functions** or **classes**, which are reusable across plots; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing the map are available [at the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/)."
    ]
   },
   {
@@ -321,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed, such as `coords` and `transform` for positioning the map, `to_plot` for plotting additional data, and any `kwarg` accepted as by an Axes object; see the documentation under `docs\\howto_inset_map.ipynb` in [the GitHub repo](https://github.com/moss-xyz/matplotlib-map-utils/blob/main/matplotlib_map_utils/docs/howto_inset_map.ipynb) for details."
+    "Optional additional arguments can be passed, such as `coords` and `transform` for positioning the map, `to_plot` for plotting additional data, and any `kwarg` accepted as by an Axes object; see [the documentation here](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/) for details."
    ]
   },
   {
@@ -336,7 +336,7 @@
     "\n",
     "- *Detail indicators* may be used in the opposite scenario, when the inset map shows a *zoomed-in* version of the parent axes; in this instance, the detail indicator will show the boundary of the extent of the inset map on the parent axes, and connect the two together, just as `mark_inset())` does, above.\n",
     "\n",
-    "To work, both indicators require the CRSs of both the parent and inset axes; however, they do not require the CRSs be the same, and will handle conversion between the two."
+    "To work, both indicators require the CRSs of both the parent and inset axes; however, they do not require the CRSs be the same, and will handle conversion between the two. Details on both of these types of indicators can be found [at the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/#inset-map-indicators)."
    ]
   },
   {

--- a/doc/source/gallery/inset_map.ipynb
+++ b/doc/source/gallery/inset_map.ipynb
@@ -237,7 +237,7 @@
     "\n",
     "This library is intended to provide an easier-to-use interface for constructing inset maps (along with scale bars and north arrows) for matplotlib plots than either the `inset_axes()` method or function.\n",
     "\n",
-    "Using this package, an inset map and its relevant indicators can be made with either **functions** or **classes**, which are reusable across plots; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing the map are available [at the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/)."
+    "Using this package, an inset map and its relevant indicators can be made with either **functions** or **classes**, which are reusable across plots; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing the map are available [in the package documentation](https://moss-xyz.github.io/matplotlib-map-utils/)."
    ]
   },
   {
@@ -321,7 +321,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed, such as `coords` and `transform` for positioning the map, `to_plot` for plotting additional data, and any `kwarg` accepted as by an Axes object; see [the documentation here](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/) for details."
+    "Optional additional arguments can be passed, such as `coords` and `transform` for positioning the map, `to_plot` for plotting additional data, and any `kwarg` accepted as by an Axes object; see [the documentation](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/) for details."
    ]
   },
   {
@@ -336,7 +336,7 @@
     "\n",
     "- *Detail indicators* may be used in the opposite scenario, when the inset map shows a *zoomed-in* version of the parent axes; in this instance, the detail indicator will show the boundary of the extent of the inset map on the parent axes, and connect the two together, just as `mark_inset())` does, above.\n",
     "\n",
-    "To work, both indicators require the CRSs of both the parent and inset axes; however, they do not require the CRSs be the same, and will handle conversion between the two. Details on both of these types of indicators can be found [at the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/#inset-map-indicators)."
+    "To work, both indicators require the CRSs of both the parent and inset axes; however, they do not require the CRSs be the same, and will handle conversion between the two. Details on both of these types of indicators can be found [in the documentation](https://moss-xyz.github.io/matplotlib-map-utils/inset_maps/#inset-map-indicators)."
    ]
   },
   {
@@ -423,7 +423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.14.2"
   }
  },
  "nbformat": 4,

--- a/doc/source/gallery/matplotlib_scalebar.ipynb
+++ b/doc/source/gallery/matplotlib_scalebar.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using this package, north arrows and scale bars can be made with either **functions** or **classes**; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing each object are available at [the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/)."
+    "Using this package, north arrows and scale bars can be made with either **functions** or **classes**; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing each object are available in [the documentation](https://moss-xyz.github.io/matplotlib-map-utils/)."
    ]
   },
   {
@@ -301,7 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed to `base`, `fancy`, `shadow`, `label`, `pack`, and `aob` to change the styling of the arrow; see [this documentation page](https://moss-xyz.github.io/matplotlib-map-utils/north_arrows/) for details."
+    "Optional additional arguments can be passed to `base`, `fancy`, `shadow`, `label`, `pack`, and `aob` to change the styling of the arrow; see [the documentation](https://moss-xyz.github.io/matplotlib-map-utils/north_arrows/) for details."
    ]
   },
   {
@@ -398,7 +398,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed to `bar`, `labels`, `units`, `text`, and `aob` to change the styling of the bar; see [this documentation page](https://moss-xyz.github.io/matplotlib-map-utils/scale_bars/) for details.\n",
+    "Optional additional arguments can be passed to `bar`, `labels`, `units`, `text`, and `aob` to change the styling of the bar; see [the documentation](https://moss-xyz.github.io/matplotlib-map-utils/scale_bars/) for details.\n",
     "\n",
     "*Note that control of the length of the bar, as well as the number of major and minor divisions, is handled within the `bar` style dictionary.*"
    ]

--- a/doc/source/gallery/matplotlib_scalebar.ipynb
+++ b/doc/source/gallery/matplotlib_scalebar.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using this package, north arrows and scale bars can be made with either **functions** or **classes**; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing each object are available within the [docs](https://github.com/moss-xyz/matplotlib-map-utils/tree/main/matplotlib_map_utils/docs) directory of the repository."
+    "Using this package, north arrows and scale bars can be made with either **functions** or **classes**; for the purposes of this tutorial, only the *functions* will be used, though the *classes* work in much the same way. Tutorials for customizing each object are available at [the documentation site](https://moss-xyz.github.io/matplotlib-map-utils/)."
    ]
   },
   {
@@ -301,7 +301,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed to `base`, `fancy`, `shadow`, `label`, `pack`, and `aob` to change the styling of the arrow; see the documentation under [docs/howto_north_arrow.ipynb](https://github.com/moss-xyz/matplotlib-map-utils/blob/main/matplotlib_map_utils/docs/howto_north_arrow.ipynb) in the GitHub repository for details."
+    "Optional additional arguments can be passed to `base`, `fancy`, `shadow`, `label`, `pack`, and `aob` to change the styling of the arrow; see [this documentation page](https://moss-xyz.github.io/matplotlib-map-utils/north_arrows/) for details."
    ]
   },
   {
@@ -398,7 +398,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Optional additional arguments can be passed to `bar`, `labels`, `units`, `text`, and `aob` to change the styling of the bar; see the documentation under [docs/howto_scale_bar.ipynb](https://github.com/moss-xyz/matplotlib-map-utils/blob/main/matplotlib_map_utils/docs/howto_scale_bar.ipynb) in the GitHub repository for details.\n",
+    "Optional additional arguments can be passed to `bar`, `labels`, `units`, `text`, and `aob` to change the styling of the bar; see [this documentation page](https://moss-xyz.github.io/matplotlib-map-utils/scale_bars/) for details.\n",
     "\n",
     "*Note that control of the length of the bar, as well as the number of major and minor divisions, is handled within the `bar` style dictionary.*"
    ]


### PR DESCRIPTION
Basically the title: updated documentation to reflect [new doc site for matplotlib_map_utils](https://moss-xyz.github.io/matplotlib-map-utils/) that I just finished building!