### PR TITLE
Fix to_file() result in offset column

### DIFF
--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -792,6 +792,89 @@ def _to_file_pyogrio(df, filename, driver, schema, crs, mode, metadata, **kwargs
 
     pyogrio.write_dataframe(df, filename, driver=driver, metadata=metadata, **kwargs)
 
+    if driver.upper() == "KML" and mode == "w":
+        _rewrite_kml_extended_data(filename, df)
+
+
+def _rewrite_kml_extended_data(filename, df):
+    """Repair GDAL KML field/value offsets in ExtendedData."""
+    import xml.etree.ElementTree as ET
+
+    try:
+        filename = os.fspath(filename)
+    except TypeError:
+        return
+
+    if filename.startswith("/vsi"):
+        return
+
+    try:
+        tree = ET.parse(filename)
+    except (FileNotFoundError, IsADirectoryError, OSError, ET.ParseError):
+        return
+
+    root = tree.getroot()
+    namespace = ""
+    if root.tag.startswith("{"):
+        namespace = root.tag.partition("}")[0][1:]
+        ET.register_namespace("", namespace)
+    ns = f"{{{namespace}}}" if namespace else ""
+
+    property_columns = [col for col in df.columns if col != df._geometry_column_name]
+    if not property_columns:
+        return
+
+    simple_field_types = {}
+    for field in root.findall(f".//{ns}SimpleField"):
+        field_name = field.get("name")
+        if field_name:
+            simple_field_types[field_name] = field.get("type", "string")
+
+    schema = root.find(f".//{ns}Schema")
+    if schema is not None:
+        for field in list(schema.findall(f"{ns}SimpleField")):
+            schema.remove(field)
+        for column in property_columns:
+            field = ET.SubElement(schema, f"{ns}SimpleField")
+            field.set("name", str(column))
+            field.set("type", simple_field_types.get(column, "string"))
+
+    placemarks = root.findall(f".//{ns}Placemark")
+    for placemark, (_, row) in zip(placemarks, df.iterrows()):
+        extended_data = placemark.find(f"{ns}ExtendedData")
+        if extended_data is None:
+            extended_data = ET.SubElement(placemark, f"{ns}ExtendedData")
+
+        schema_data = extended_data.find(f"{ns}SchemaData")
+        if schema_data is None:
+            schema_data = ET.SubElement(extended_data, f"{ns}SchemaData")
+            if schema is not None and schema.get("id"):
+                schema_data.set("schemaUrl", f"#{schema.get('id')}")
+
+        for simple_data in list(schema_data.findall(f"{ns}SimpleData")):
+            schema_data.remove(simple_data)
+
+        for column in property_columns:
+            value = row[column]
+            try:
+                if pd.isna(value):
+                    continue
+            except (TypeError, ValueError):
+                pass
+            if isinstance(value, pd.Timestamp):
+                value = value.isoformat()
+            elif hasattr(value, "isoformat"):
+                value = value.isoformat()
+            else:
+                value = str(value)
+            if value == "NaT":
+                continue
+            simple_data = ET.SubElement(schema_data, f"{ns}SimpleData")
+            simple_data.set("name", str(column))
+            simple_data.text = value
+
+    tree.write(filename, encoding="utf-8", xml_declaration=True)
+
 
 def infer_schema(df):
     from collections import OrderedDict

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -40,11 +40,13 @@ try:
     PYOGRIO_GE_0121 = Version(Version(pyogrio.__version__).base_version) >= Version(
         "0.12.1"
     )
+    PYOGRIO_HAS_KML = "KML" in pyogrio.list_drivers()
 except ImportError:
     pyogrio = False
     PYOGRIO_GE_090 = False
     PYOGRIO_GE_012 = False
     PYOGRIO_GE_0121 = False
+    PYOGRIO_HAS_KML = False
 
 
 try:
@@ -57,6 +59,9 @@ except ImportError:
 
 
 PYOGRIO_MARK = pytest.mark.skipif(not pyogrio, reason="pyogrio not installed")
+PYOGRIO_KML_MARK = pytest.mark.skipif(
+    not PYOGRIO_HAS_KML, reason="KML driver not available in pyogrio"
+)
 FIONA_MARK = pytest.mark.skipif(not fiona, reason="fiona not installed")
 
 
@@ -514,6 +519,43 @@ def test_to_file_column_len(tmpdir, df_points, engine):
         and "Column names longer than 10 characters will be truncated" in str(w.message)
     ]
     assert len(column_names_warning) == 1
+
+
+@PYOGRIO_KML_MARK
+def test_to_file_kml_pyogrio_keeps_extended_data_aligned(tmp_path):
+    df = GeoDataFrame(
+        {
+            "text_a": ["foo", "bar"],
+            "text_b": ["lorem", "ipsum"],
+            "int_val": [1, 2],
+            "float_val": [0.1, 0.2],
+            "geometry": [Point(-105, 40), Point(-110, 45)],
+        },
+        crs="EPSG:4326",
+    )
+    filename = tmp_path / "test.kml"
+
+    df.to_file(filename, driver="kml", engine="pyogrio")
+
+    import xml.etree.ElementTree as ET
+
+    root = ET.parse(filename).getroot()
+    ns = {"kml": "http://www.opengis.net/kml/2.2"}
+    simple_fields = root.findall(".//kml:SimpleField", ns)
+    simple_data = root.findall(".//kml:Placemark[1]//kml:SimpleData", ns)
+
+    assert [field.get("name") for field in simple_fields] == [
+        "text_a",
+        "text_b",
+        "int_val",
+        "float_val",
+    ]
+    assert [(data.get("name"), data.text) for data in simple_data] == [
+        ("text_a", "foo"),
+        ("text_b", "lorem"),
+        ("int_val", "1"),
+        ("float_val", "0.1"),
+    ]
 
 
 def test_to_file_with_duplicate_columns(tmpdir, engine):


### PR DESCRIPTION
Fixes #3609
When writing a GeoDataFrame to KML via `to_file(filename, driver="kml")` with the
pyogrio engine, GDAL's KML writer maps the first two non-geometry columns to the
`<name>` and `<description>` KML elements but then populates the `<ExtendedData>`
`<SimpleData>` entries starting from the *first* column name while using values from
the *third* column onward, causing a field/value mismatch and data loss for the
last columns.
### Root cause
GDAL's libkml/KML driver silently consumes the first two string-typed fields as
`<name>` and `<description>`, but the `<Schema>` and `<SimpleData>` sections are
not adjusted accordingly — they still reference the original column names while
the values are shifted by two positions.
### Fix
After `pyogrio.write_dataframe()` completes a KML write, a post-processing step
(`_rewrite_kml_extended_data`) re-parses the KML XML and rewrites both the
`<Schema>/<SimpleField>` declarations and each `<Placemark>`'s
`<ExtendedData>/<SimpleData>` entries using the original DataFrame column values,
ensuring names and values stay aligned.
The repair is limited to `mode="w"` (full writes) and skips GDAL virtual
filesystem paths (`/vsi*`).
### Test plan
- Added `test_to_file_kml_pyogrio_keeps_extended_data_aligned` which writes a
  GeoDataFrame with mixed column types (text, int, float) to KML via pyogrio,
  then parses the output XML and asserts that `<SimpleField>` names and
  `<SimpleData>` name/value pairs match the original DataFrame columns exactly.