### PR TITLE
DOC: improve clarity of spatial joins gallery example

### DIFF
--- a/doc/source/gallery/spatial_joins.ipynb
+++ b/doc/source/gallery/spatial_joins.ipynb
@@ -4,15 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Spatial Joins\n",
+    "# Spatial joins with `GeoDataFrame.sjoin`\n",
     "\n",
-    "A *spatial join* uses [binary predicates](http://shapely.readthedocs.io/en/latest/manual.html#binary-predicates) \n",
-    "such as `intersects` and `crosses` to combine two `GeoDataFrames` based on the spatial relationship \n",
-    "between their geometries.\n",
+    "A *spatial join* combines attributes from two `GeoDataFrame` objects based on\n",
+    "the spatial relationship between their geometries. Typical predicates are\n",
+    "`intersects`, `within`, `contains`, and `touches`.\n",
     "\n",
-    "A common use case might be a spatial join between a point layer and a polygon layer where you want to retain the point geometries and grab the attributes of the intersecting polygons.\n",
+    "In this example, we will:\n",
     "\n",
-    "![illustration](https://web.natur.cuni.cz/~langhamr/lectures/vtfg1/mapinfo_1/about_gis/Image23.gif)"
+    "1. build point and polygon `GeoDataFrame` objects,\n",
+    "2. run `sjoin` with `left`, `right`, and `inner` joins, and\n",
+    "3. show how to use a different predicate and `sjoin_nearest`.\n",
+    "\n",
+    "A common use case is matching point observations (for example, store locations)\n",
+    "to polygon boundaries (for example, neighborhoods) to enrich the points with\n",
+    "polygon attributes.\n"
    ]
   },
   {
@@ -22,7 +28,7 @@
     "\n",
     "## Types of spatial joins\n",
     "\n",
-    "We currently support the following methods of spatial joins. We refer to the *left_df* and *right_df* which are the correspond to the two dataframes passed in as args.\n",
+    "We currently support the following methods of spatial joins. We refer to *left_df* and *right_df* as the two GeoDataFrames passed to `sjoin`.\n",
     "\n",
     "### Left outer join\n",
     "\n",
@@ -91,9 +97,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Spatial Joins between two GeoDataFrames\n",
+    "## Spatial joins between two GeoDataFrames\n",
     "\n",
-    "Let's take a look at how we'd implement these using `GeoPandas`. First, load up the NYC test data into `GeoDataFrames`:"
+    "Let's implement these joins using GeoPandas and the NYC borough test dataset."
    ]
   },
   {
@@ -208,7 +214,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're not limited to using the `intersection` binary predicate. Any of the `Shapely` geometry methods that return a Boolean can be used by specifying the `predicate` kwarg."
+    "We are not limited to the default `intersects` predicate. Any supported spatial\n",
+    "predicate can be used via the `predicate` keyword argument."
    ]
   },
   {


### PR DESCRIPTION
This PR improves the readability of the spatial joins gallery example for beginners.

## What changed

- Updated the notebook title and opening explanation.
- Added a concise outline of what the example covers.
- Clarified wording in the join-types section.
- Improved the explanation of the `predicate` argument and its usage context.

## Why

Issue #529 tracks additional/improved gallery documentation.  
While `sjoin` is already present, this update makes the existing example clearer and more accessible for first-time GeoPandas users.

## Testing

- Verified notebook JSON structure after edits.
- Confirmed the notebook content is consistent with current `sjoin` usage.