### PR TITLE
TST: xfail json serialization tests for geometry dtype

### DIFF
--- a/geopandas/tests/test_extension_array.py
+++ b/geopandas/tests/test_extension_array.py
@@ -609,6 +609,15 @@ class TestMethods(extension_tests.BaseMethodsTests):
     def test_argmax_argmin_no_skipna_notimplemented(self):
         pass
 
+    # https://github.com/geopandas/geopandas/issues/1906
+    @pytest.mark.xfail(reason="JSON serialization not yet working")
+    def test_values_for_json(self, data):
+        super().test_values_for_json(data)
+
+    @pytest.mark.xfail(reason="JSON serialization not yet working")
+    def test_json_roundtrip(self, data):
+        super().test_json_roundtrip(data)
+
 
 class TestCasting(extension_tests.BaseCastingTests):
     pass


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/65127 ensured to more consistently serialize extension dtypes to JSON (controllable through defining `EA._values_for_json`) and also added tests for this we inherit. 
But custom JSON serialization doesn't work yet for our geometry data (outside of `GeoDataFrame.to_json`, where we control this for the active geometry column). That's an existing limitation, somewhat covered by https://github.com/geopandas/geopandas/issues/1906

Thus, for now just xfailing those tests referring to the issue