### PR TITLE
TYP: add overload to GeoSeries.apply for geometry-returning callbacks…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New features and improvements:
 - Add ``grid_size`` parameter to ``union``, ``difference``, ``symmetric_difference``
   and ``intersection`` (#3593).
 - `read_parquet` now support direct reading from HTTP/HTTPS protocols (#3699)
+- Add overload to `GeoSeries.apply` to support callbacks returning `BaseGeometry` (#3698)
 
 Deprecations and compatibility notes:
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 import warnings
-from typing import Any
+from typing import Any, overload
 
 import numpy as np
 import pandas as pd
@@ -802,12 +802,28 @@ class GeoSeries(GeoPandasBase, Series):
     def take(self, *args, **kwargs):
         return self._wrapped_pandas_method("take", *args, **kwargs)
 
+    @overload
+    def apply(
+        self,
+        func: Callable[..., BaseGeometry],
+        convert_dtype: bool | None = ...,
+        args: tuple = ...,
+        **kwargs: Any,
+    ) -> GeoSeries: ...
+
+    @overload
+    def apply(
+        self,
+        func: Callable[..., Any],
+        convert_dtype: bool | None = ...,
+        args: tuple = ...,
+        **kwargs: Any,
+    ) -> Series: ...
+
     @doc(pd.Series)
-    def apply(self, func, convert_dtype: bool | None = None, args=(), **kwargs):
+    def apply(self, func, convert_dtype: bool | None = None, args=(), **kwargs):  # type: ignore[override]
         if convert_dtype is not None:
             kwargs["convert_dtype"] = convert_dtype
-
-        # to avoid warning
         result = super().apply(func, args=args, **kwargs)
         if isinstance(result, GeoSeries):
             if self.crs is not None:

--- a/geopandas/tests/test_types.py
+++ b/geopandas/tests/test_types.py
@@ -43,6 +43,12 @@ class TestSeries:
         for f, s in self.pts.groupby(lambda x: x % 2):
             assert type(s) is GeoSeries
 
+    def test_apply_geometry_returning_callback(self):
+        # GH-3698: GeoSeries.apply should return GeoSeries when the callback
+        # returns a geometry, not a plain Series
+        result = self.pts.apply(lambda geom: geom)
+        assert type(result) is GeoSeries
+
 
 class TestDataFrame:
     def setup_method(self):


### PR DESCRIPTION
Closes #3698

## Problem

Calling `GeoSeries.apply` with a callback that returns a shapely geometry 
triggers mypy errors because the type stubs only allow callbacks returning 
scalar types:

```python
def to_multi(geom: LineString | MultiLineString) -> MultiLineString:
    return geom if isinstance(geom, MultiLineString) else MultiLineString([geom])

gdf = gpd.GeoSeries([LineString([(0, 0), (1, 1)])])
gdf = gdf.apply(to_multi)  # mypy error
```

## Fix

Added two overloads to `GeoSeries.apply`:
- When the callback returns a `BaseGeometry`, the return type is `GeoSeries`
- Otherwise, falls back to `Series`

The concrete method uses `# type: ignore[override]` to suppress the conflict 
with `pandas.Series.apply` overloads. I'm aware this is a compromise and 
happy to explore a cleaner approach if the maintainers have one in mind.

## Testing

Verified with mypy that the original issue is resolved. Added a runtime 
type test in `test_types.py`.