### PR TITLE
MNT: move "dev" to PEP 735 dependency-groups

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -116,10 +116,9 @@ You may install the latest development version by cloning the
     cd geopandas
     pip install .
 
-Development dependencies can be installed using the dev optional
-dependency group::
+Development dependencies can be installed using the ``dev`` dependency group::
 
-    pip install '.[dev]'
+    pip install -e . --group dev
 
 It is also possible to install the latest development version
 directly from the GitHub repository with::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ all = [
 # fiona>=1.8.21
 # scipy>=1.10.0
 
+[dependency-groups]
 dev = [
     "pytest>=3.1.0",
     "pytest-cov",


### PR DESCRIPTION
This implements [PEP 735](https://peps.python.org/pep-0735/) to use dependency groups for "dev". Other groups like "doc" can be added later.

This group can be installed with `[uv] pip install ... --group dev`, but also note that the "dev" group is [part of `uv`'s default groups](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups) so it doesn't need to be specified.