### PR TITLE
TST: clean-up postgis tests related to geometry column name injection

### DIFF
--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -819,7 +819,7 @@ class TestIO:
 
         # Verify data was appended correctly
         sql = text(f'SELECT * FROM "{table}";')
-        df = read_postgis(sql, engine, geom_col="custom_geom")
+        df = read_postgis(sql, engine, geom_col="custom_geom_123")
         assert len(df) == len(gdf) * 2
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -986,7 +986,10 @@ class TestIO:
 
         # Create GeoDataFrame with UNION-based SQL injection attempt
         gdf_malicious = df_nybb.copy()
-        malicious_geom_name = f"geometry')::text UNION SELECT password FROM {test_target_table} WHERE '1'='1'; --"  # noqa
+        malicious_geom_name = (
+            f"geometry')::text UNION SELECT password FROM {test_target_table}"
+            "WHERE '1'='1'; --"
+        )
         gdf_malicious = gdf_malicious.rename_geometry(malicious_geom_name)
 
         # Verify tables exist before injection attempt

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -27,11 +27,12 @@ from geopandas.tests.util import (
 )
 
 try:
-    from sqlalchemy import text
+    from sqlalchemy import inspect, text
 except ImportError:
     # Avoid local imports for text in all sqlalchemy tests
     # all tests using text use engine_postgis, which ensures sqlalchemy is available
     text = str
+    inspect = None
 
 
 @pytest.fixture
@@ -805,6 +806,23 @@ class TestIO:
         write_postgis(df_nybb2, con=engine, name=table, if_exists="append")
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
+    def test_append_with_custom_geom_col(self, engine_postgis, df_nybb):
+        engine = engine_postgis
+        table = "test_custom_geom"
+
+        # Create GeoDataFrame with custom geometry column name
+        gdf = df_nybb.copy()
+        gdf = gdf.rename_geometry("custom_geom_123")
+
+        write_postgis(gdf, con=engine, name=table, if_exists="replace")
+        write_postgis(gdf, con=engine, name=table, if_exists="append")
+
+        # Verify data was appended correctly
+        sql = text(f'SELECT * FROM "{table}";')
+        df = read_postgis(sql, engine, geom_col="custom_geom")
+        assert len(df) == len(gdf) * 2
+
+    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
     def test_duplicate_geometry_column_fails(self, engine_postgis):
         """
         Tests that a ValueError is raised if an SQL query returns two geometry columns.
@@ -883,54 +901,26 @@ class TestIO:
         assert df.crs == "ESRI:54052"
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
-    def test_to_postgis_append_with_custom_geometry_column_name(
-        self, engine_postgis, df_nybb
-    ):
-        """
-        Tests that appending works correctly with custom geometry column names.
-        This ensures the SQL injection fix doesn't break normal functionality.
-        """
-        engine = engine_postgis
-        table = "test_custom_geom"
-
-        # Create GeoDataFrame with custom geometry column name
-        gdf = df_nybb.copy()
-        gdf = gdf.rename_geometry("custom_geom")
-
-        # Write initial data
-        write_postgis(gdf, con=engine, name=table, if_exists="replace")
-
-        # Append more data - this should work without SQL injection vulnerability
-        write_postgis(gdf, con=engine, name=table, if_exists="append")
-
-        # Verify data was appended correctly
-        sql = text(f'SELECT * FROM "{table}";')
-        df = read_postgis(sql, engine, geom_col="custom_geom")
-        assert len(df) == len(gdf) * 2
-
-    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
     def test_to_postgis_sql_injection_prevention_geometry_column(
         self, engine_postgis, df_nybb
     ):
         """
         Tests that SQL injection attempts via geometry column name are prevented.
         This test verifies that malicious geometry column names are treated as
-        literal strings and not executed as SQL code.
+        literal strings and not executed as SQL code in the Find_SRID query
+        when using to_postgis with if_exists='append'.
 
-        This test is based on issue #3679 which reported SQL injection vulnerability
-        in the Find_SRID query when using to_postgis with if_exists='append'.
+        https://github.com/geopandas/geopandas/issues/3679
         """
         engine = engine_postgis
         table = "test_sql_injection"
 
-        # Create a test table first to ensure append mode triggers
-        # the vulnerable code path
+        # Create a test table first to ensure append mode triggers potential issue
         gdf_normal = df_nybb.copy()
         write_postgis(gdf_normal, con=engine, name=table, if_exists="replace")
 
         # Create a test table that would be targeted by SQL injection
         # If SQL injection works, this table would be dropped
-        # Use random name to avoid conflicts with existing tables
         test_target_table = f"test_target_{uuid.uuid4().hex[:12]}"
         with engine.begin() as conn:
             conn.execute(
@@ -939,9 +929,8 @@ class TestIO:
             conn.execute(text(f"INSERT INTO {test_target_table} (id) VALUES (1);"))
 
         # Create GeoDataFrame with malicious geometry column name
-        # This simulates an attacker trying to inject SQL via geometry column name
         gdf_malicious = df_nybb.copy()
-        malicious_geom_name = f"geom'; DROP TABLE {test_target_table}; --"
+        malicious_geom_name = f"geometry'); DROP TABLE {test_target_table}; --"
         gdf_malicious = gdf_malicious.rename_geometry(malicious_geom_name)
 
         # First, verify both tables exist
@@ -949,38 +938,33 @@ class TestIO:
         sql_check_target = text(f"SELECT COUNT(*) FROM {test_target_table};")
         with engine.connect() as conn:
             initial_count = conn.execute(sql_check).fetchone()[0]
-            target_exists = conn.execute(sql_check_target).fetchone()[0] == 1
-
-        assert target_exists, "Target table should exist before SQL injection attempt"
+            assert conn.execute(sql_check_target).fetchone()[0] == 1
 
         # Attempt append - this should fail because the geometry column name
-        # doesn't match, but it should NOT execute the injected SQL
+        # doesn't exist, but it should NOT execute the injected SQL
         try:
             write_postgis(gdf_malicious, con=engine, name=table, if_exists="append")
-            # If it doesn't raise an error, that's also fine - the important
-            # thing is that SQL injection didn't occur
         except (ValueError, Exception):
-            # Expected - the geometry column name doesn't exist in the table
             pass
 
         # Verify both tables still exist and weren't dropped by SQL injection
-        with engine.connect() as conn:
-            final_count = conn.execute(sql_check).fetchone()[0]
-            target_still_exists = conn.execute(sql_check_target).fetchone()[0] == 1
-
-        assert final_count == initial_count, (
+        assert inspect(engine).has_table(table), (
             "Test table should still exist after SQL injection attempt"
         )
-        assert target_still_exists, (
+        assert inspect(engine).has_table(test_target_table), (
             f"Target table '{test_target_table}' should not be dropped by SQL injection"
         )
+
+        with engine.connect() as conn:
+            assert conn.execute(sql_check).fetchone()[0] == initial_count
+            assert conn.execute(sql_check_target).fetchone()[0] == 1
 
     @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
     def test_to_postgis_sql_injection_prevention_geometry_column_union(
         self, engine_postgis, df_nybb
     ):
         """
-        Tests another SQL injection pattern: UNION SELECT attack
+        Similar test as above, using another SQL injection pattern: UNION SELECT attack
         via geometry column name.
         """
         engine = engine_postgis
@@ -991,7 +975,6 @@ class TestIO:
         write_postgis(gdf_normal, con=engine, name=table, if_exists="replace")
 
         # Create a test table that would be targeted by UNION SELECT injection
-        # Use random name to avoid conflicts with existing tables
         test_target_table = f"test_target_{uuid.uuid4().hex[:12]}"
         with engine.begin() as conn:
             conn.execute(
@@ -1003,9 +986,7 @@ class TestIO:
 
         # Create GeoDataFrame with UNION-based SQL injection attempt
         gdf_malicious = df_nybb.copy()
-        malicious_geom_name = (
-            f"geom') UNION SELECT password FROM {test_target_table} WHERE '1'='1"
-        )
+        malicious_geom_name = f"geometry')::text UNION SELECT password FROM {test_target_table} WHERE '1'='1'; --"  # noqa
         gdf_malicious = gdf_malicious.rename_geometry(malicious_geom_name)
 
         # Verify tables exist before injection attempt
@@ -1013,126 +994,26 @@ class TestIO:
         sql_check_target = text(f"SELECT COUNT(*) FROM {test_target_table};")
         with engine.connect() as conn:
             initial_count = conn.execute(sql_check).fetchone()[0]
-            target_exists = conn.execute(sql_check_target).fetchone()[0] == 1
+            assert conn.execute(sql_check_target).fetchone()[0] == 1
 
-        assert target_exists, "Target table should exist before SQL injection attempt"
-
-        # Attempt append - should not execute the UNION SELECT
-        try:
+        # Attempt append - should not execute the UNION SELECT (but will still fail
+        # not finding the SRID)
+        with pytest.raises(Exception) as excinfo:
             write_postgis(gdf_malicious, con=engine, name=table, if_exists="append")
-        except (ValueError, Exception):
-            # Expected - geometry column name mismatch
-            pass
+
+        assert "secret" not in str(excinfo.value), (
+            "SQL injection should not have been executed; "
+            "'secret' should not be in the error"
+        )
 
         # Verify table integrity maintained
-        with engine.connect() as conn:
-            final_count = conn.execute(sql_check).fetchone()[0]
-            target_still_exists = conn.execute(sql_check_target).fetchone()[0] == 1
-
-        assert final_count == initial_count, (
+        assert inspect(engine).has_table(table), (
             "Test table should still exist after SQL injection attempt"
         )
-        assert target_still_exists, (
-            f"Target table '{test_target_table}' should not be "
-            "affected by SQL injection"
+        assert inspect(engine).has_table(test_target_table), (
+            f"Target table '{test_target_table}' should not be dropped by SQL injection"
         )
 
-    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
-    def test_to_postgis_sql_injection_prevention_geometry_column_comment(
-        self, engine_postgis, df_nybb
-    ):
-        """
-        Tests SQL injection via comment syntax in geometry column name.
-        """
-        engine = engine_postgis
-        table = "test_sql_injection_comment"
-
-        # Create initial table
-        gdf_normal = df_nybb.copy()
-        write_postgis(gdf_normal, con=engine, name=table, if_exists="replace")
-
-        # Create GeoDataFrame with comment-based SQL injection
-        gdf_malicious = df_nybb.copy()
-        malicious_geom_name = "geom' -- DROP TABLE test_sql_injection_comment;"
-        gdf_malicious = gdf_malicious.rename_geometry(malicious_geom_name)
-
-        # Verify table exists
-        sql_check = text(f"SELECT COUNT(*) FROM {table};")
         with engine.connect() as conn:
-            initial_count = conn.execute(sql_check).fetchone()[0]
-
-        # Attempt append
-        try:
-            write_postgis(gdf_malicious, con=engine, name=table, if_exists="append")
-        except (ValueError, Exception):
-            pass
-
-        # Verify table still exists
-        with engine.connect() as conn:
-            final_count = conn.execute(sql_check).fetchone()[0]
-            assert final_count == initial_count
-
-    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
-    def test_to_postgis_sql_injection_prevention_geometry_column_semicolon(
-        self, engine_postgis, df_nybb
-    ):
-        """
-        Tests SQL injection via semicolon in geometry column name.
-        """
-        engine = engine_postgis
-        table = "test_sql_injection_semicolon"
-
-        # Create initial table
-        gdf_normal = df_nybb.copy()
-        write_postgis(gdf_normal, con=engine, name=table, if_exists="replace")
-
-        # Create GeoDataFrame with semicolon-based SQL injection
-        gdf_malicious = df_nybb.copy()
-        malicious_geom_name = "geom; DELETE FROM test_sql_injection_semicolon;"
-        gdf_malicious = gdf_malicious.rename_geometry(malicious_geom_name)
-
-        # Verify table exists
-        sql_check = text(f"SELECT COUNT(*) FROM {table};")
-        with engine.connect() as conn:
-            initial_count = conn.execute(sql_check).fetchone()[0]
-
-        # Attempt append
-        try:
-            write_postgis(gdf_malicious, con=engine, name=table, if_exists="append")
-        except (ValueError, Exception):
-            pass
-
-        # Verify table still exists and data is intact
-        with engine.connect() as conn:
-            final_count = conn.execute(sql_check).fetchone()[0]
-            assert final_count == initial_count
-
-    @pytest.mark.parametrize("engine_postgis", POSTGIS_DRIVERS, indirect=True)
-    def test_to_postgis_append_with_special_characters_in_geometry_column(
-        self, engine_postgis, df_nybb
-    ):
-        """
-        Tests that legitimate geometry column names with special characters
-        (but not SQL injection) still work correctly.
-        This ensures the fix doesn't break normal functionality with valid
-        but unusual column names.
-        """
-        engine = engine_postgis
-        table = "test_special_chars"
-
-        # Create GeoDataFrame with geometry column name containing special characters
-        # (but not SQL injection patterns)
-        gdf = df_nybb.copy()
-        # Use a valid but unusual geometry column name
-        gdf = gdf.rename_geometry("geom_with_underscores_123")
-
-        # Write initial data
-        write_postgis(gdf, con=engine, name=table, if_exists="replace")
-
-        # Append more data - should work correctly
-        write_postgis(gdf, con=engine, name=table, if_exists="append")
-
-        # Verify data was appended correctly
-        sql = text(f'SELECT * FROM "{table}";')
-        df = read_postgis(sql, engine, geom_col="geom_with_underscores_123")
-        assert len(df) == len(gdf) * 2
+            assert conn.execute(sql_check).fetchone()[0] == initial_count
+            assert conn.execute(sql_check_target).fetchone()[0] == 1


### PR DESCRIPTION
Cleaning up the tests that were added in https://github.com/geopandas/geopandas/pull/3681

- Moved the test about appending with a custom geometry name next to the other append tests
- Fixed the first two injection tests: they were currently not actually failing when reverting the fix, because the injected pattern didn't work (wrong column name, missing bracket
- Removed the two other injection tests: I assume those were currently also not actually working (but didn't test further), but I don't think we have to test all possible patterns, since the fix for all those is the same (avoid treating the column name as executable sql), so removed those
- Reduced a bit the verbosity
- Removed the last test about appending with a custom geometry name with special characters, as that was essentially a duplicate of the first