### PR TITLE
TST: update read_parquet from https test url to stable file

### DIFF
--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1434,6 +1434,6 @@ def test_read_parquet_from_https():
     _ = pytest.importorskip("fsspec")
     _ = pytest.importorskip("requests")
     _ = pytest.importorskip("aiohttp")
-    path = "https://github.com/opengeospatial/geoparquet/raw/refs/heads/main/test_data/data-polygon-encoding_wkb.parquet"
+    path = "https://github.com/opengeospatial/geoparquet/raw/refs/tags/v1.1.0/test_data/data-polygon-encoding_wkb.parquet"
     df = geopandas.read_parquet(path)
     assert df.shape == (4, 2)


### PR DESCRIPTION
On main, the file was updated to use new Parquet types, which isn't supported by older pyarrow versions. And in general, pinning this to a stable url just for checking we can read it seems fine (we should add separate tests to ensure specifically we can read the new Parquet types)

This should fix the [ubuntu-latest, ci/envs/311-minimal.yaml](https://github.com/geopandas/geopandas/actions/runs/27932267985/job/82646376655#logs) CI