### PR TITLE
COMPAT: avoid inplace=True in pandas methods for pandas>=3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ GeoPandas also implements alternate constructors that can read any data format r
     >>> import geodatasets
     >>> nybb_path = geodatasets.get_path('nybb')
     >>> boros = geopandas.read_file(nybb_path)
-    >>> boros.set_index('BoroCode', inplace=True)
-    >>> boros.sort_index(inplace=True)
+    >>> boros = boros.set_index('BoroCode').sort_index()
     >>> boros
                    BoroName     Shape_Leng    Shape_Area  \
     BoroCode

--- a/doc/source/docs/user_guide/geometric_manipulations.rst
+++ b/doc/source/docs/user_guide/geometric_manipulations.rst
@@ -168,8 +168,7 @@ GeoPandas also implements alternate constructors that can read any data format r
     >>> import geodatasets
     >>> nybb_path = geodatasets.get_path('nybb')
     >>> boros = geopandas.read_file(nybb_path)
-    >>> boros.set_index('BoroCode', inplace=True)
-    >>> boros.sort_index(inplace=True)
+    >>> boros = boros.set_index('BoroCode').sort_index()
     >>> boros
                    BoroName     Shape_Leng    Shape_Area  \
     BoroCode

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -2027,7 +2027,10 @@ default 'snappy'
                 pass
             else:
                 if self.crs is not None and result.crs is None:
-                    result.set_crs(self.crs, inplace=True)
+                    if PANDAS_GE_30:
+                        result = result.set_crs(self.crs)
+                    else:
+                        result.set_crs(self.crs, inplace=True)
         elif isinstance(result, Series) and result.dtype == "object":
             # Try reconstruct series GeometryDtype if lost by apply
             # If all none and object dtype assert list of nones is more likely
@@ -2415,7 +2418,10 @@ default 'snappy'
         df = df.set_geometry(self._geometry_column_name).__finalize__(self)
 
         if ignore_index:
-            df.reset_index(inplace=True, drop=True)
+            if PANDAS_GE_30:
+                df = df.reset_index(drop=True)
+            else:
+                df.reset_index(inplace=True, drop=True)
         elif index_parts:
             # reset to MultiIndex, otherwise df index is only first level of
             # exploded GeoSeries index.

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -530,7 +530,12 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
                 return self.rename(columns={geometry_col: col}).set_geometry(
                     col, inplace=inplace
                 )
-            self.rename(columns={geometry_col: col}, inplace=inplace)
+            with warnings.catch_warnings():
+                # TODO: pandas >= 3.1 triggers a warning for inplace rename here
+                # suppresing this for now, but we have to replace this with our own
+                # warning specifically for rename_geometry
+                warnings.filterwarnings("ignore", ".*inplace keyword.*")
+                self.rename(columns={geometry_col: col}, inplace=inplace)
             self.set_geometry(col, inplace=inplace)
 
     @property

--- a/geopandas/io/tests/test_file.py
+++ b/geopandas/io/tests/test_file.py
@@ -1419,7 +1419,7 @@ def test_write_index_to_file(tmpdir, df_points, driver, ext, engine):
     # named MultiIndex
     df_p = df_points.copy()
     df_p["value3"] = df_p["value2"] - df_p["value1"]
-    df_p.set_index(["value1", "value2"], inplace=True)
+    df_p = df_p.set_index(["value1", "value2"])
     df = GeoDataFrame(df_p, geometry=df_p.geometry)
     do_checks(df, index_is_used=True)
 

--- a/geopandas/tests/test_geoseries.py
+++ b/geopandas/tests/test_geoseries.py
@@ -495,7 +495,7 @@ class TestSeries:
             self.landmarks, GeoSeries.from_xy(x, y, index=x.index, crs=crs)
         )
         unindexed_landmarks = self.landmarks.copy()
-        unindexed_landmarks.reset_index(inplace=True, drop=True)
+        unindexed_landmarks = unindexed_landmarks.reset_index(drop=True)
         assert_geoseries_equal(
             unindexed_landmarks,
             GeoSeries.from_xy(x, y, crs=crs),

--- a/geopandas/tests/test_overlay.py
+++ b/geopandas/tests/test_overlay.py
@@ -165,11 +165,9 @@ def test_overlay_nybb(how, nybb_filename):
     # 24 is a full original circle overlapping with unioned geometries, and
     # 27 is a completely duplicated row)
     if how == "union":
-        expected = expected.drop([24, 27])
-        expected.reset_index(inplace=True, drop=True)
+        expected = expected.drop([24, 27]).reset_index(drop=True)
     # Eliminate observations without geometries (issue from QGIS)
-    expected = expected[expected.is_valid]
-    expected.reset_index(inplace=True, drop=True)
+    expected = expected[expected.is_valid].reset_index(drop=True)
 
     if how == "identity":
         expected = expected[expected.BoroCode.notnull()].copy()

--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -193,8 +193,8 @@ class TestFrameSindex:
     def test_update_inplace_no_rebuild(self):
         gdf = self.df.copy()
         old_sindex = gdf.sindex
-        gdf.rename(columns={"A": "AA"}, inplace=True)
-        # a rename shouldn't invalidate the index
+        gdf.replace({"A": {1: 2}}, inplace=True)
+        # an inplace replace on another column shouldn't invalidate the index
         assert gdf.has_sindex
         # and the "new" should be the same
         new_sindex = gdf.sindex

--- a/geopandas/tools/overlay.py
+++ b/geopandas/tools/overlay.py
@@ -40,9 +40,13 @@ def _overlay_intersection(df1, df2):
     # Create pairs of geometries in both dataframes to be intersected
     if idx1.size > 0 and idx2.size > 0:
         left = df1.geometry.take(idx1)
-        left.reset_index(drop=True, inplace=True)
         right = df2.geometry.take(idx2)
-        right.reset_index(drop=True, inplace=True)
+        if PANDAS_GE_30:
+            left = left.reset_index(drop=True)
+            right = right.reset_index(drop=True)
+        else:
+            left.reset_index(drop=True, inplace=True)
+            right.reset_index(drop=True, inplace=True)
         intersections = left.intersection(right)
         poly_ix = intersections.geom_type.isin(POLYGON_GEOM_TYPES)
         intersections.loc[poly_ix] = intersections[poly_ix].make_valid()
@@ -152,8 +156,12 @@ def _overlay_symmetric_diff(df1, df2):
     geometry.loc[dfsym.geometry_1.isnull()] = dfsym.loc[
         dfsym.geometry_1.isnull(), "geometry_2"
     ]
-    dfsym.drop(["geometry_1", "geometry_2"], axis=1, inplace=True)
-    dfsym.reset_index(drop=True, inplace=True)
+    if PANDAS_GE_30:
+        dfsym = dfsym.drop(["geometry_1", "geometry_2"], axis=1)
+        dfsym = dfsym.reset_index(drop=True)
+    else:
+        dfsym.drop(["geometry_1", "geometry_2"], axis=1, inplace=True)
+        dfsym.reset_index(drop=True, inplace=True)
     dfsym = GeoDataFrame(dfsym, geometry=geometry, crs=df1.crs)
     return dfsym
 
@@ -369,12 +377,18 @@ def overlay(
             result = _overlay_identity(df1, df2)
 
         if how in ["intersection", "symmetric_difference", "union", "identity"]:
-            result.drop(["__idx1", "__idx2"], axis=1, inplace=True)
+            if PANDAS_GE_30:
+                result = result.drop(["__idx1", "__idx2"], axis=1)
+            else:
+                result.drop(["__idx1", "__idx2"], axis=1, inplace=True)
 
     if keep_geom_type:
         result = _collection_extract(result, geom_type, keep_geom_type_warning)
 
-    result.reset_index(drop=True, inplace=True)
+    if PANDAS_GE_30:
+        result = result.reset_index(drop=True)
+    else:
+        result.reset_index(drop=True, inplace=True)
     return result
 
 


### PR DESCRIPTION
Pandas is starting to deprecate the `inplace` keyword in a subset of cases (https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html).

This PR already updates the cases where we are calling a plain pandas method:

- Remove unnecessary usage in docs and tests
- Usage in actual code is done conditionally on the pandas version (to keep avoiding the copy on pandas 2.x, while on pandas 3.x with CoW this is not needed)

We also have usage of the `inplace` keyword in our own methods (`set_crs`, `set_geometry`, `rename_geometry`). That is left for a separate PR (and might require a bit of discussion how to deal with that, like align with pandas or keep those, also add deprecation, etc)