### PR TITLE
BUG: preserve LinearRing when pickling GeometryArray

### DIFF
--- a/geopandas/array.py
+++ b/geopandas/array.py
@@ -518,12 +518,23 @@ class GeometryArray(ExtensionArray):
         #         )
 
     def __getstate__(self):
-        return (shapely.to_wkb(self._data), self._crs)
+        is_linearring = (
+            shapely.get_type_id(self._data) == shapely.GeometryType.LINEARRING
+        )
+        return (shapely.to_wkb(self._data), self._crs, is_linearring)
 
     def __setstate__(self, state):
         if not isinstance(state, dict):
             # pickle file saved with pygeos
             geoms = shapely.from_wkb(state[0])
+
+            if len(state) >= 3:
+                is_linearring = state[2]
+                if is_linearring.any():
+                    geoms = geoms.copy()
+                    for i in np.nonzero(is_linearring)[0]:
+                        geoms[i] = shapely.LinearRing(geoms[i].coords)
+
             self._crs = state[1]
             self._sindex = None  # pygeos.STRtree could not be pickled yet
             self._data = geoms

--- a/geopandas/tests/test_array.py
+++ b/geopandas/tests/test_array.py
@@ -908,6 +908,18 @@ def test_pickle():
     assert T[:-2].geom_equals(T2[:-2]).all()
 
 
+def test_pickle_preserves_linearring():
+    import pickle
+
+    ring = shapely.LinearRing([(0, 0), (1, 0), (1, 1), (0, 0)])
+    arr = from_shapely([ring])
+
+    result = pickle.loads(pickle.dumps(arr))
+
+    assert isinstance(result[0], shapely.LinearRing)
+    assert result[0].geom_type == "LinearRing"
+
+
 def test_raise_on_bad_sizes():
     with pytest.raises(ValueError) as info:
         T.contains(P)


### PR DESCRIPTION
Closes #3785.

This PR preserves LinearRing geometries when pickling and unpickling a GeometryArray / GeoSeries.

Previously, GeometryArray.__getstate__ serialized geometries through WKB. A top-level LinearRing round-tripped through WKB comes back as a LineString, so GeoSeries pickle round-tripping changed the geometry type.

The fix stores a boolean mask identifying which geometries were LinearRing objects and restores those geometries after reading from WKB. The __setstate__ path still supports older two-item pickle states.

Added a regression test for LinearRing pickle round-tripping.