### PR TITLE
DOC: Update docstring of is_valid_coverage in base.py

### DIFF
--- a/geopandas/base.py
+++ b/geopandas/base.py
@@ -388,7 +388,7 @@ GeometryCollection
         it might be desirable to detect narrow gaps as invalidities in the coverage. The
         ``gap_width`` parameter allows to specify the maximum width of gaps to detect.
         When gaps are detected, this method will return ``False`` and the
-        :meth:`coverage_invalid_edges` method can be used to find the edges of those
+        :meth:`invalid_coverage_edges` method can be used to find the edges of those
         gaps.
 
         Geometries that are not Polygon or MultiPolygon are ignored and an empty


### PR DESCRIPTION
The doc-string of `is_valid_coverage()` references `coverage_invalid_edges()`. The correct name is instead [invalid_coverage_edges()](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoSeries.invalid_coverage_edges.html)