### PR TITLE
TST: update test parametrization for non-collection iterables (pytest 9.1 compat)

### DIFF
--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -913,7 +913,7 @@ def test_write_iso_wkb_old_geos(tmpdir):
 
 @pytest.mark.parametrize(
     "format,schema_version",
-    product(["feather", "parquet"], [None] + SUPPORTED_VERSIONS),
+    list(product(["feather", "parquet"], [None] + SUPPORTED_VERSIONS)),
 )
 def test_write_spec_version(tmpdir, format, schema_version):
     if format == "feather":


### PR DESCRIPTION
See https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize