### PR TITLE
COMPAT: suppress deprecation warnings from pyarrow.feather for now

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -487,7 +487,15 @@ def _to_feather(df, path, index=None, compression=None, schema_version=None, **k
 
     path = _expand_user(path)
     table = _geopandas_to_arrow(df, index=index, schema_version=schema_version)
-    feather.write_feather(table, path, compression=compression, **kwargs)
+    # TODO pyarrow 25 deprecates feather.write_feather in favor of pyarrow.ipc;
+    # suppress until we migrate the implementation
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "pyarrow.feather.write_feather is deprecated",
+            FutureWarning,
+        )
+        feather.write_feather(table, path, compression=compression, **kwargs)
 
 
 def _arrow_to_geopandas(table, geo_metadata=None, to_pandas_kwargs=None, df_attrs=None):
@@ -877,7 +885,15 @@ def _read_feather(path, columns=None, to_pandas_kwargs=None, **kwargs):
 
     path = _expand_user(path)
 
-    table = feather.read_table(path, columns=columns, **kwargs)
+    # TODO pyarrow 25 deprecates feather.read_table in favor of pyarrow.ipc;
+    # suppress until we migrate the implementation
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "pyarrow.feather.read_table is deprecated",
+            FutureWarning,
+        )
+        table = feather.read_table(path, columns=columns, **kwargs)
     return _arrow_to_geopandas(table, to_pandas_kwargs=to_pandas_kwargs)
 
 

--- a/geopandas/io/tests/test_geoarrow.py
+++ b/geopandas/io/tests/test_geoarrow.py
@@ -19,6 +19,11 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from pyarrow import feather
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:pyarrow.feather.read_feather is deprecated"
+)
+
+
 DATA_PATH = pathlib.Path(os.path.dirname(__file__)) / "data"
 
 


### PR DESCRIPTION
PyArrow 25.0 deprecated the `pyarrow.feather` APIs, although the _file format_ (Feather V2 is just the Arrow IPC file format) itself is not deprecated. It is recommended to use `pyarrow.ipc` instead, although that still comes with some usability issues (https://github.com/apache/arrow/issues/49232).

For us, we can migrate to `pyarrow.ipc` under the hood to keep `geopandas.read_feather/to_feather` working, but we still have the question if we follow the naming scheme from Arrow, and eg add an alias `geopandas.read_arrow_file` (and then later on deprecate `read_feather` in favor of that). Although here it would probably also be good to follow whathever pandas decides to do.

But until then, just suppressing the warning here, so users don't yet see this (they also can't do anything about the warning). And this also fixes a bunch of failures in the dev CI.

