### PR TITLE
DOC: use the GeoPandas paper as a canonical citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
 - family-names: Fleischmann
   given-names: Martin
   orcid: "https://orcid.org/0000-0003-3319-3366"
-- family-names: Van Den Bossche
+- family-names: Van den Bossche
   given-names: Joris
 - family-names: Jordahl
   given-names: Kelsey

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+cff-version: "1.2.0"
+message: If you use this software, please cite the article below.
+title: GeoPandas
+authors:
+- family-names: Fleischmann
+  given-names: Martin
+  orcid: "https://orcid.org/0000-0003-3319-3366"
+- family-names: Van Den Bossche
+  given-names: Joris
+- family-names: Jordahl
+  given-names: Kelsey
+- family-names: Richards
+  given-names: Matthew John
+- family-names: McBride
+  given-names: James
+- family-names: Wasserman
+  given-names: Jacob
+- family-names: Ward
+  given-names: Brendan
+- family-names: Wolf
+  given-names: Levi John
+preferred-citation:
+  type: article
+  title: "GeoPandas: Fundamental Data Structures for Vector Spatial Data in Python"
+  authors:
+  - family-names: Fleischmann
+    given-names: Martin
+  - family-names: Van Den Bossche
+    given-names: Joris
+  - family-names: Jordahl
+    given-names: Kelsey
+  - family-names: Richards
+    given-names: Matthew John
+  - family-names: McBride
+    given-names: James
+  - family-names: Wasserman
+    given-names: Jacob
+  - family-names: Ward
+    given-names: Brendan
+  - family-names: Wolf
+    given-names: Levi John
+  year: 2026
+  month: 12
+  journal: Computers, Environment and Urban Systems
+  volume: 130
+  start: 102495
+  issn: "0198-9715"
+  doi: 10.1016/j.compenvurbsys.2026.102495
+  languages:
+  - en

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,16 +1,17 @@
 cff-version: "1.2.0"
-message: If you use this software, please cite the article below.
+message: "If you use this software, please cite the article below."
 title: GeoPandas
 authors:
 - family-names: Fleischmann
   given-names: Martin
   orcid: "https://orcid.org/0000-0003-3319-3366"
-- family-names: Van den Bossche
+- family-names: "Van den Bossche"
   given-names: Joris
+  orcid: "https://orcid.org/0000-0003-3284-2977"
 - family-names: Jordahl
   given-names: Kelsey
 - family-names: Richards
-  given-names: Matthew John
+  given-names: "Matthew John"
 - family-names: McBride
   given-names: James
 - family-names: Wasserman
@@ -18,19 +19,19 @@ authors:
 - family-names: Ward
   given-names: Brendan
 - family-names: Wolf
-  given-names: Levi John
+  given-names: "Levi John"
 preferred-citation:
   type: article
   title: "GeoPandas: Fundamental Data Structures for Vector Spatial Data in Python"
   authors:
   - family-names: Fleischmann
     given-names: Martin
-  - family-names: Van Den Bossche
+  - family-names: "Van Den Bossche"
     given-names: Joris
   - family-names: Jordahl
     given-names: Kelsey
   - family-names: Richards
-    given-names: Matthew John
+    given-names: "Matthew John"
   - family-names: McBride
     given-names: James
   - family-names: Wasserman
@@ -38,10 +39,10 @@ preferred-citation:
   - family-names: Ward
     given-names: Brendan
   - family-names: Wolf
-    given-names: Levi John
+    given-names: "Levi John"
   year: 2026
   month: 12
-  journal: Computers, Environment and Urban Systems
+  journal: "Computers, Environment and Urban Systems"
   volume: 130
   start: 102495
   issn: "0198-9715"

--- a/CITATION.md
+++ b/CITATION.md
@@ -2,7 +2,7 @@ To cite GeoPandas please use the following
 [software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the
 Computers, Environment and Urban Systems.
 
-> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
+> Fleischmann, M., Van den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
 > Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures
 > for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130,
 > 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
@@ -13,7 +13,7 @@ BibTeX:
 @article{fleischmann2026GeoPandas,
   title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
   shorttitle = {{{GeoPandas}}},
-  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  author = {Fleischmann, Martin and Van den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
   year = 2026,
   month = dec,
   journal = {Computers, Environment and Urban Systems},

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,27 @@
+To cite GeoPandas please use the following
+[software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the
+Computers, Environment and Urban Systems.
+
+> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
+> Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures
+> for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130,
+> 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
+
+BibTeX:
+
+```bibtex
+@article{fleischmann2026GeoPandas,
+  title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
+  shorttitle = {{{GeoPandas}}},
+  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  year = 2026,
+  month = dec,
+  journal = {Computers, Environment and Urban Systems},
+  volume = {130},
+  pages = {102495},
+  issn = {01989715},
+  doi = {10.1016/j.compenvurbsys.2026.102495},
+  urldate = {2026-08-01},
+  langid = {english},
+}
+```

--- a/README.md
+++ b/README.md
@@ -150,3 +150,29 @@ GeoPandas also implements alternate constructors that can read any data format r
     dtype: geometry
 
 ![Convex hulls of New York City boroughs](doc/source/gallery/nyc_hull.png)
+
+How to cite
+-----------
+
+To cite GeoPandas please use the following [software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the Computers, Environment and Urban Systems.
+
+> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J., Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130, 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
+
+BibTeX:
+
+```bibtex
+@article{fleischmann2026GeoPandas,
+  title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
+  shorttitle = {{{GeoPandas}}},
+  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  year = 2026,
+  month = dec,
+  journal = {Computers, Environment and Urban Systems},
+  volume = {130},
+  pages = {102495},
+  issn = {01989715},
+  doi = {10.1016/j.compenvurbsys.2026.102495},
+  urldate = {2026-08-01},
+  langid = {english},
+}
+```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ How to cite
 
 To cite GeoPandas please use the following [software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the Computers, Environment and Urban Systems.
 
-> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J., Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130, 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
+> Fleischmann, M., Van den Bossche, J., Jordahl, K., Richards, M. J., McBride, J., Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130, 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
 
 BibTeX:
 
@@ -164,7 +164,7 @@ BibTeX:
 @article{fleischmann2026GeoPandas,
   title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
   shorttitle = {{{GeoPandas}}},
-  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  author = {Fleischmann, Martin and Van den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
   year = 2026,
   month = dec,
   journal = {Computers, Environment and Urban Systems},

--- a/doc/source/about/citing.md
+++ b/doc/source/about/citing.md
@@ -1,50 +1,88 @@
 # Citing
 
-When citing GeoPandas, you can use [Zenodo DOI](https://zenodo.org/record/3946761#.Xy24LC2ZPOQ) for each release. 
-Below is the example of resulting BiBTeX record for GeoPandas 0.8.1 and a reference using APA 6<sup>th</sup> ed.
+## Canonical citation
 
-_Kelsey Jordahl, Joris Van den Bossche, Martin Fleischmann, Jacob Wasserman, James McBride, Jeffrey Gerard, … François Leblanc. (2020, July 15). geopandas/geopandas: v0.8.1 (Version v0.8.1). Zenodo. http://doi.org/10.5281/zenodo.3946761_
+To cite GeoPandas please use the following
+[software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the
+Computers, Environment and Urban Systems.
+
+> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
+> Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures
+> for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130,
+> 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
+
+BibTeX:
+
+```bibtex
+@article{fleischmann2026GeoPandas,
+  title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
+  shorttitle = {{{GeoPandas}}},
+  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  year = 2026,
+  month = dec,
+  journal = {Computers, Environment and Urban Systems},
+  volume = {130},
+  pages = {102495},
+  issn = {01989715},
+  doi = {10.1016/j.compenvurbsys.2026.102495},
+  urldate = {2026-08-01},
+  langid = {english},
+}
+```
+
+## Citing specific version
+
+If you'd like to refer to a specific version, you can use
+[Zenodo DOI](https://doi.org/10.5281/zenodo.2585848) for each release alongside the
+canonical citation above. Below is the example of resulting BiBTeX record for GeoPandas
+1.1.4 and a reference using APA 6<sup>th</sup> ed.
+
+> Joris Van den Bossche, Kelsey Jordahl, Martin Fleischmann, Matt Richards, James
+> McBride, Jacob Wasserman, Adrian Garcia Badaracco, Alan D. Snow, Pieter Roggemans,
+> Brendan Ward, Jeff Tratner, Jeffrey Gerard, Mike Taves, Matthew Perry, carsonfarmer,
+> Geir Arne Hjelle, Nicholas YS Tan, Ray Bell, rraymondgh, … Sergio Rey. (2026).
+> geopandas/geopandas: Version 1.1.4 (Version v1.1.4) [Computer software]. Zenodo.
+> https://doi.org/10.5281/zenodo.20938197
 
 
 ```
-@software{kelsey_jordahl_2020_3946761,
-  author       = {Kelsey Jordahl and
-                  Joris Van den Bossche and
+@software{joris_van_den_bossche_2026_20938197,
+  author       = {Joris Van den Bossche and
+                  Kelsey Jordahl and
                   Martin Fleischmann and
-                  Jacob Wasserman and
+                  Matt Richards and
                   James McBride and
-                  Jeffrey Gerard and
-                  Jeff Tratner and
-                  Matthew Perry and
+                  Jacob Wasserman and
                   Adrian Garcia Badaracco and
-                  Carson Farmer and
-                  Geir Arne Hjelle and
                   Alan D. Snow and
-                  Micah Cochran and
-                  Sean Gillies and
+                  Pieter Roggemans and
+                  Brendan Ward and
+                  Jeff Tratner and
+                  Jeffrey Gerard and
+                  Mike Taves and
+                  Matthew Perry and
+                  carsonfarmer and
+                  Geir Arne Hjelle and
+                  Nicholas YS Tan and
+                  Ray Bell and
+                  rraymondgh and
+                  Micah D. Cochran and
+                  Giacomo Caria and
+                  Ewout ter Hoeven and
+                  Christine P. Chai and
                   Lucas Culbertson and
                   Matt Bartos and
                   Nick Eubank and
-                  maxalbert and
-                  Aleksey Bilogur and
-                  Sergio Rey and
-                  Christopher Ren and
-                  Dani Arribas-Bel and
-                  Leah Wasser and
-                  Levi John Wolf and
-                  Martin Journois and
-                  Joshua Wilson and
-                  Adam Greenhall and
-                  Chris Holdgraf and
-                  Filipe and
-                  Fran\c{c}ois Leblanc},
-  title        = {geopandas/geopandas: v0.8.1},
-  month        = jul,
-  year         = 2020,
+                  sangarshanan and
+                  John Flavin and
+                  Sergio Rey},
+  title        = {geopandas/geopandas: Version 1.1.4},
+  month        = jun,
+  year         = 2026,
   publisher    = {Zenodo},
-  version      = {v0.8.1},
-  doi          = {10.5281/zenodo.3946761},
-  url          = {https://doi.org/10.5281/zenodo.3946761}
+  version      = {v1.1.4},
+  doi          = {10.5281/zenodo.20938197},
+  url          = {https://doi.org/10.5281/zenodo.20938197},
 }
 ```
 

--- a/doc/source/about/citing.md
+++ b/doc/source/about/citing.md
@@ -6,7 +6,7 @@ To cite GeoPandas please use the following
 [software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) published in the
 Computers, Environment and Urban Systems.
 
-> Fleischmann, M., Van Den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
+> Fleischmann, M., Van den Bossche, J., Jordahl, K., Richards, M. J., McBride, J.,
 > Wasserman, J., Ward, B., & Wolf, L. J. (2026). GeoPandas: Fundamental data structures
 > for vector spatial data in Python. _Computers, Environment and Urban Systems_, 130,
 > 102495. https://doi.org/10.1016/j.compenvurbsys.2026.102495
@@ -17,7 +17,7 @@ BibTeX:
 @article{fleischmann2026GeoPandas,
   title = {{{GeoPandas}}: {{Fundamental}} Data Structures for Vector Spatial Data in {{Python}}},
   shorttitle = {{{GeoPandas}}},
-  author = {Fleischmann, Martin and Van Den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
+  author = {Fleischmann, Martin and Van den Bossche, Joris and Jordahl, Kelsey and Richards, Matthew John and McBride, James and Wasserman, Jacob and Ward, Brendan and Wolf, Levi John},
   year = 2026,
   month = dec,
   journal = {Computers, Environment and Urban Systems},


### PR DESCRIPTION
Following the recent publication of the GeoPandas [software paper](https://doi.org/10.1016/j.compenvurbsys.2026.102495) in the CEUS, this PR updates our documentation to point users to the paper as a canonical citation of the project. The paper is Open Access, licensed under CC-BY 4.0, so it will remain open to anyone.