### PR TITLE
DOC: note LinearRing to LineString conversion in WKB methods (#3785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Bug fixes:
   x-axis (#3773).
 - Fix ``GeoDataFrame.explore()`` ignoring custom ``legend_kwds={"labels": ...}``
   for categorical and boolean columns (#3496).
+- Document that WKB serialization (used by ``to_wkb``/``from_wkb`` and internally
+  when pickling a ``GeoSeries``/``GeoDataFrame``) converts ``LinearRing``
+  geometries to ``LineString``, as WKB cannot represent a ``LinearRing`` (#3785).
 
 
 Community:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1286,6 +1286,16 @@ properties': {'col1': 'name1'}, 'geometry': {'type': 'Point', 'coordinates': (1.
         -------
         DataFrame
             geometry columns are encoded to WKB
+
+        Notes
+        -----
+        The WKB specification cannot represent ``LinearRing`` geometries, so a
+        ``LinearRing`` is exported as an equivalent ``LineString`` (see the note in
+        :func:`shapely.to_wkb`). GeoPandas also uses WKB internally when a
+        ``GeoDataFrame`` is pickled, so a ``LinearRing`` that is round-tripped
+        through WKB or through ``pickle`` comes back as a ``LineString``. Use a
+        format that preserves the ring type, such as WKT, if that distinction
+        matters.
         """
         df = DataFrame(self.copy(deep=not PANDAS_GE_30))
 

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -449,6 +449,13 @@ class GeoSeries(GeoPandasBase, Series):
         --------
         GeoSeries.from_wkt
 
+        Notes
+        -----
+        The WKB specification cannot represent ``LinearRing`` geometries, so a
+        ``LinearRing`` encoded to WKB is stored as a ``LineString`` and is read
+        back here as a ``LineString`` (see :func:`shapely.from_wkb`). Use a format
+        that preserves the ring type, such as WKT, if that distinction matters.
+
         Examples
         --------
         >>> wkbs = [
@@ -1376,6 +1383,15 @@ e": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": [3
         See Also
         --------
         GeoSeries.to_wkt
+
+        Notes
+        -----
+        The WKB specification cannot represent ``LinearRing`` geometries, so a
+        ``LinearRing`` is exported as an equivalent ``LineString`` (see the note in
+        :func:`shapely.to_wkb`). GeoPandas also uses WKB internally when a
+        ``GeoSeries`` is pickled, so a ``LinearRing`` that is round-tripped through
+        WKB or through ``pickle`` comes back as a ``LineString``. Use a format that
+        preserves the ring type, such as WKT, if that distinction matters.
 
         Examples
         --------


### PR DESCRIPTION
Closes #3785.

WKB cannot represent `LinearRing` geometries, so shapely serializes a `LinearRing` as a `LineString`. GeoPandas also uses WKB internally when a `GeoSeries`/`GeoDataFrame` is pickled, so a `LinearRing` that is round-tripped through `to_wkb`/`from_wkb`, or through `pickle`, comes back as a `LineString`. That is the behaviour reported in #3785.

Following the suggestion by @martinfleis and @jorisvandenbossche in the issue thread (adding a documentation note like the one in shapely), this PR adds a `Notes` section to:

- `GeoSeries.to_wkb`
- `GeoSeries.from_wkb`
- `GeoDataFrame.to_wkb`

plus a short `CHANGELOG.md` entry.

Documentation only, no behaviour change. Happy to drop the changelog line or adjust the wording if you would prefer.
