### PR TITLE
DOC: Fix doubled word in sjoin docstring

### DIFF
--- a/geopandas/tools/sjoin.py
+++ b/geopandas/tools/sjoin.py
@@ -438,7 +438,7 @@ def _frame_join(
     left_df : GeoDataFrame
     right_df : GeoDataFrame
     indices : tuple of ndarray
-        Indices returned by the geometric join. Tuple with with integer
+        Indices returned by the geometric join. Tuple with integer
         indices representing the matches from `left_df` and `right_df`
         respectively.
     distances : ndarray, optional


### PR DESCRIPTION
Small doubled-word typo in `geopandas/tools/sjoin.py`: "Tuple with with integer indices" -> "Tuple with integer indices".
