### PR TITLE
CI: speed-up windows CI by caching postgis skip

### DIFF
--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -55,6 +55,31 @@ def check_available_postgis_drivers() -> list[str]:
 
 POSTGIS_DRIVERS = check_available_postgis_drivers()
 
+POSTGIS_AVAILABLE = None
+
+
+def check_postgis_available(driver) -> bool:
+    """
+    Check if a PostGIS database is available for testing.
+
+    Check this once and cache the result, because this can be slow on Windows.
+    """
+    global POSTGIS_AVAILABLE
+    if POSTGIS_AVAILABLE is not None:
+        return POSTGIS_AVAILABLE
+
+    psycopg = pytest.importorskip(driver)
+
+    try:
+        con = psycopg.connect(**prepare_database_credentials())
+    except psycopg.OperationalError:
+        POSTGIS_AVAILABLE = False
+    else:
+        con.close()
+        POSTGIS_AVAILABLE = True
+
+    return POSTGIS_AVAILABLE
+
 
 def prepare_database_credentials() -> dict:
     """Gather postgres connection credentials from environment variables."""
@@ -73,6 +98,9 @@ def connection_postgis(request):
 
     Use this as an indirect fixture, where the request parameter is POSTGIS_DRIVERS."""
     psycopg = pytest.importorskip(request.param)
+
+    if not check_postgis_available(request.param):
+        pytest.skip("Cannot connect with postgresql database")
 
     try:
         con = psycopg.connect(**prepare_database_credentials())

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -70,6 +70,7 @@ def check_postgis_available(driver) -> bool:
 
     psycopg = pytest.importorskip(driver)
 
+    print("testing if PostGIS database is available for testing")
     try:
         con = psycopg.connect(**prepare_database_credentials())
     except psycopg.OperationalError:
@@ -123,6 +124,9 @@ def engine_postgis(request):
     """
     sqlalchemy = pytest.importorskip("sqlalchemy")
     from sqlalchemy.engine.url import URL
+
+    if not check_postgis_available(request.param):
+        pytest.skip("Cannot connect with postgresql database")
 
     credentials = prepare_database_credentials()
     try:

--- a/geopandas/io/tests/test_sql.py
+++ b/geopandas/io/tests/test_sql.py
@@ -70,7 +70,6 @@ def check_postgis_available(driver) -> bool:
 
     psycopg = pytest.importorskip(driver)
 
-    print("testing if PostGIS database is available for testing")
     try:
         con = psycopg.connect(**prepare_database_credentials())
     except psycopg.OperationalError:


### PR DESCRIPTION
I am noticing that the Windows CI is taking forever, like 90min, and it seems to be stalling on skipping the sql tests. I can't reproduce myself, so this is just a test for a first guess.