### PR TITLE
DOC: document fid_as_index for accessing GeoPackage feature IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ New features and improvements:
 - Add ``grid_size`` parameter to ``union``, ``difference``, ``symmetric_difference``
   and ``intersection`` (#3593).
 - `read_parquet` now support direct reading from HTTP/HTTPS protocols (#3699)
+- Document how to access the feature ID (`fid`) as the index when reading files
+  with `read_file` and the pyogrio engine, using `fid_as_index=True` (#TODO)
 
 Deprecations and compatibility notes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features and improvements:
   and ``intersection`` (#3593).
 - `read_parquet` now support direct reading from HTTP/HTTPS protocols (#3699)
 - Document how to access the feature ID (`fid`) as the index when reading files
-  with `read_file` and the pyogrio engine, using `fid_as_index=True` (#TODO)
+  with `read_file` and the pyogrio engine, using `fid_as_index=True` (#3829)
 
 Deprecations and compatibility notes:
 

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -171,6 +171,22 @@ Skip loading geometry from the file:
     )
 
 
+Accessing the feature ID (fid)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some formats (e.g. GeoPackage) store a feature ID (``fid``) per feature that is
+not included in the GeoDataFrame's columns by default. Pass ``fid_as_index=True``
+to use it as the GeoDataFrame's index instead of the default integer index:
+
+.. note:: Requires the pyogrio engine.
+
+.. code-block:: python
+
+    gdf = geopandas.read_file(
+        geodatasets.get_path("nybb"),
+        fid_as_index=True,
+    )
+
 SQL WHERE filter
 ^^^^^^^^^^^^^^^^
 

--- a/doc/source/docs/user_guide/io.rst
+++ b/doc/source/docs/user_guide/io.rst
@@ -183,7 +183,7 @@ to use it as the GeoDataFrame's index instead of the default integer index:
 .. code-block:: python
 
     gdf = geopandas.read_file(
-        geodatasets.get_path("nybb"),
+        geodatasets.get_path("spdata.columbus"),
         fid_as_index=True,
     )
 

--- a/geopandas/io/file.py
+++ b/geopandas/io/file.py
@@ -274,6 +274,11 @@ def _read_file(
     pyarrow is installed, pass ``use_arrow=True`` as an argument. See the User
     Guide page :doc:`../../user_guide/io` for details.
 
+    Some formats (e.g. GeoPackage) store a feature ID (``fid``) that is not
+    included in the columns by default. With the pyogrio engine, pass
+    ``fid_as_index=True`` to use it as the index of the returned GeoDataFrame.
+    See the User Guide page :doc:`../../user_guide/io` for details.
+
 
     When specifying a URL, geopandas will check if the server supports reading
     partial data and in that case pass the URL as is to the underlying engine,


### PR DESCRIPTION
## Summary
- Add a user guide section explaining how to access the feature ID (`fid`) of formats like GeoPackage, via `read_file(..., fid_as_index=True)` with the pyogrio engine
- Add a pointer to this in `read_file`'s docstring
- Add a CHANGELOG entry

Closes #2794

## Test plan
- [x] Verified the option (`fid_as_index`) and its default via pyogrio's docs
- [ ] Docs build cleanly locally (`make html`) — could not verify in this environment (Sphinx not installed); please confirm on CI