### PR TITLE
BUG: fix ZeroDivisionError in plot() with a single categorical group

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1078,7 +1078,8 @@ def plot_dataframe(
                     return cmap(i)
                 else:
                     # For continuous cmaps, stretch alongside whole range
-                    return cmap(i / (ngroups - 1))
+                    # (a single group has no range to stretch over)
+                    return cmap(i / (ngroups - 1) if ngroups > 1 else 0.0)
             elif isinstance(cmap, dict):
                 return cmap[name]
             else:

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1026,6 +1026,31 @@ class TestPolygonPlotting:
         actual_colors_sub = ax.collections[0].get_facecolors()
         np.testing.assert_array_equal(actual_colors_orig[1], actual_colors_sub[0])
 
+    def test_single_category_continuous_cmap(self):
+        # a categorical plot with a single group must not divide by
+        # (ngroups - 1) == 0 when stretching a continuous cmap
+        df = self.df.copy()
+        df["cat"] = ["a", "a"]
+        ax = df.plot(column="cat", cmap="viridis", legend=True)
+        cmap = plt.get_cmap("viridis")
+        _check_colors(2, ax.collections[0].get_facecolors(), [cmap(0.0)] * 2)
+
+        # a single row is the degenerate case of the same thing
+        ax = df[:1].plot(column="cat", cmap="viridis")
+        _check_colors(1, ax.collections[0].get_facecolors(), [cmap(0.0)])
+
+    def test_single_bin_scheme_default_cmap(self):
+        # a constant column collapses to one bin, and `scheme` defaults to the
+        # continuous "viridis" cmap -> same single-group division by zero
+        pytest.importorskip("mapclassify")
+        df = self.df.copy()
+        df["constant"] = [0, 0]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            ax = df.plot(column="constant", scheme="quantiles", k=5, legend=True)
+        cmap = plt.get_cmap("viridis")
+        _check_colors(2, ax.collections[0].get_facecolors(), [cmap(0.0)] * 2)
+
 
 class TestPolygonZPlotting:
     def setup_method(self):


### PR DESCRIPTION
Fixes #3833

`plot()` blows up with `ZeroDivisionError` when a categorical plot ends up with just one group and a continuous cmap - `i / (ngroups - 1)` becomes `0/0`. Guarded it so a single group maps to `0.0`, same spot the first group lands in the normal multi-group case.

Two ways to hit it:
- `gdf.plot(column="region", cmap="viridis")` where only one region is left after filtering
- `gdf.plot(column="value", scheme="quantiles")` on a constant column - sneakier, since `scheme=` silently switches the default cmap to viridis

Came in with the plotting refactor (#3728), so it's main-only and never shipped - 1.1.4 and earlier are fine. Added tests for both paths.
