### PR TITLE
TST: avoid deprecated inplace call in sindex tests

### DIFF
--- a/geopandas/tests/test_sindex.py
+++ b/geopandas/tests/test_sindex.py
@@ -179,16 +179,16 @@ class TestFrameSindex:
     def test_rebuild_on_update_inplace(self):
         gdf = self.df.copy()
         old_sindex = gdf.sindex
-        # sorting in place
-        gdf.sort_values("A", ascending=False, inplace=True)
+        # updating geometry columns in place
+        gdf.replace({"geom": {Point(1, 1): Point(10, 10)}}, inplace=True)
         # spatial index should be invalidated
         assert not gdf.has_sindex
         new_sindex = gdf.sindex
         # and should be different
         assert new_sindex is not old_sindex
 
-        # sorting should still have happened though
-        assert gdf.index.tolist() == [4, 3, 2, 1, 0]
+        # update should still have happened though
+        assert gdf.geometry.x.tolist() == [0, 10, 2, 3, 4]
 
     def test_update_inplace_no_rebuild(self):
         gdf = self.df.copy()


### PR DESCRIPTION
One more test case I had forgotten in https://github.com/geopandas/geopandas/pull/3802

`sort_values(.., inplace=True)` is deprecated, but `replace(.., inplace=True) is not, so can keep what it is testing by using a different inplace call