### PR TITLE
TST: xfail test_loc_add_row_empty_df for now

### DIFF
--- a/geopandas/tests/test_op_output_types.py
+++ b/geopandas/tests/test_op_output_types.py
@@ -169,7 +169,7 @@ def test_loc_add_row(geom_name, nybb_filename):
         assert nybb.geometry.dtype == "object"
 
 
-@pytest.mark.skipif(not PANDAS_GE_31, reason="fixed in Pandas >= 3.1")
+@pytest.mark.xfail(reason="failing because crs is lost")
 @pytest.mark.parametrize("geom_name", ["geometry", "geom"])
 def test_loc_add_row_empty_df(geom_name):
     # https://github.com/geopandas/geopandas/issues/3109


### PR DESCRIPTION
@m-richards I was briefly looking at this again, but thought that it is maybe not worth spending too much effort on trying to find a fix on the pandas side, since 1) this is the part that didn't yet work before (so we would not be releasing with a regression), and 2) I _think_ this should be fixed by moving the `crs` to the dtype, which is something we should first explore further (if that does not turn out to be feasible for some reason, we can always come back to this issue and try to find another fix)

xref https://github.com/geopandas/geopandas/issues/3761