### PR TITLE
BUG: pass autolim through the categorical branch of plot_dataframe

### DIFF
--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -1147,6 +1147,7 @@ def plot_dataframe(
                     cmap=cmap,
                     ax=ax,
                     aspect=None,
+                    autolim=autolim,
                     **group_style_kwds,
                 )
 

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -741,6 +741,18 @@ class TestPolygonPlotting:
         self.df.plot(ax=ax, autolim=True)
         assert ax.get_xlim() != xlim
 
+    def test_autolim_categorical(self):
+        """Test categorical polygon plot respecting autolim."""
+        ax = self.df[:1].plot()
+        xlim = ax.get_xlim()
+        self.df.plot(ax=ax, column="values", categorical=True, autolim=False)
+        assert ax.get_xlim() == xlim
+
+        ax = self.df[:1].plot()
+        xlim = ax.get_xlim()
+        self.df.plot(ax=ax, column="values", categorical=True, autolim=True)
+        assert ax.get_xlim() != xlim
+
     def test_single_color(self):
         ax = self.polys.plot(color="green")
         _check_colors(2, ax.collections[0].get_facecolors(), ["green"] * 2)


### PR DESCRIPTION
`plot_dataframe`'s per-group `plot_series(...)` call on the categorical branch doesn't forward `autolim`, so `autolim=False` is ignored whenever a categorical column or a `scheme` is used. Polygons, on current main:

```
small.plot(); big.plot(ax=ax, autolim=False, column=...)
categorical   before=(-0.05, 1.05)  after=(-8.9, 98.9)   ignored
continuous    before=(-0.05, 1.05)  after=(-0.05, 1.05)  respected
column=None   before=(-0.05, 1.05)  after=(-0.05, 1.05)  respected
```

The continuous branch and the `column=None` delegation both pass it, so the categorical branch is the odd one out of three. Bisected to 05ab6e50a (#3728) — its parent honours `autolim` here, and no tag contains that commit, so this lands before 1.2.0 rather than after. Distinct from #3331, which is Points and upstream.

The existing `test_autolim_false` in both plotting classes calls `.plot(ax=ax, autolim=False)` with no column — the delegation that does forward — so it can't reach this branch.

A question rather than a second fix: the same call also drops `add_labels` (#3779 fixes the `column=None` site, not this one). Either `add_labels=False`, since the `_set_axis_labels` call before the loop already owns labelling, or `add_labels=add_labels` for symmetry with #3779. I ran both and the output is identical in all four cases, because `_set_axis_labels` only writes into an empty label — so it's your call which you'd rather carry. Happy to add either here, or leave it to #3779.

Ran: `test_plotting.py` 139 → 140 passed, full suite 2049 → 2050, no failures either way; ruff 0.15.20 format/check/import-sort clean. Reverting the one-line source change fails the new test. CHANGELOG entry to follow once this has a number.
