### PR TITLE
BUG: make `to_json()` serialize datetimes like `to_file(driver="GeoJSON")` does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Bug fixes:
 - Fix `GeoDataFrame.from_features` raising a `ValueError` for an empty list of
   features when a `crs` is provided; it now returns an empty `GeoDataFrame` with
   a `geometry` column (#3777).
+- Fix `GeoDataFrame.to_json` and `GeoSeries.to_json` raising ``TypeError`` on columns
+  holding values with no native JSON type, such as the `datetime64` column produced by
+  reading a GeoPackage date field. Such values are now serialized exactly as
+  ``to_file(driver="GeoJSON")`` already wrote them -- ISO 8601 for temporal types (UTC
+  as a trailing ``Z``), `str` for others such as `Decimal`, `UUID` and `Period`; pass
+  ``default=`` to override.
 
 
 Community:

--- a/geopandas/geodataframe.py
+++ b/geopandas/geodataframe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import json
 import typing
 import warnings
@@ -41,6 +42,22 @@ if typing.TYPE_CHECKING:
         PARQUET_GEOMETRY_ENCODINGS,
         SUPPORTED_VERSIONS_LITERAL,
     )
+
+
+def _json_default(obj: Any) -> str:
+    """Encode values that the stdlib JSON encoder does not handle natively.
+
+    ``iterfeatures`` yields real Python scalars, so a property value can be any
+    object pandas stores -- ``Timestamp``, ``Timedelta``, ``Decimal``, ``UUID``.
+    Temporal values are rendered as ISO 8601, matching what
+    ``to_file(driver="GeoJSON")`` writes; anything else falls back to ``str``.
+    """
+    if isinstance(obj, (datetime.date, datetime.time)):  # datetime subclasses date
+        # GDAL spells a UTC offset "Z" rather than "+00:00"
+        return obj.isoformat().replace("+00:00", "Z")
+    if isinstance(obj, datetime.timedelta):  # including pandas' Timedelta
+        return pd.Timedelta(obj).isoformat()
+    return str(obj)
 
 
 def _ensure_geometry(data, crs: Any | None = None) -> GeoSeries | GeometryArray:
@@ -1021,6 +1038,11 @@ class GeoDataFrame(GeoPandasBase, DataFrame):
         -----
         The remaining *kwargs* are passed to json.dumps().
 
+        Values with no native JSON type are converted rather than raising, matching
+        what ``to_file(driver="GeoJSON")`` writes: temporal types become ISO 8601
+        strings (UTC as a trailing ``Z``), anything else falls back to ``str``. Pass
+        your own ``default=`` callable to override this.
+
         Missing (NaN) values in the GeoDataFrame can be represented as follows:
 
         - ``null``: output the missing entries as JSON null.
@@ -1087,6 +1109,8 @@ es": {"name": "urn:ogc:def:crs:EPSG::3857"}}}'
                 ogc_crs = f"urn:ogc:def:crs:{authority}::{code}"
                 geo["crs"] = {"type": "name", "properties": {"name": ogc_crs}}
 
+        # setdefault so a caller-supplied default= still wins
+        kwargs.setdefault("default", _json_default)
         return json.dumps(geo, **kwargs)
 
     @property

--- a/geopandas/tests/test_geodataframe.py
+++ b/geopandas/tests/test_geodataframe.py
@@ -1,8 +1,11 @@
+import datetime
+import decimal
 import json
 import os
 import re
 import shutil
 import tempfile
+import uuid
 from enum import Enum
 
 import numpy as np
@@ -600,6 +603,83 @@ class TestDataFrame:
             ValueError, match="GeoDataFrame cannot contain duplicated column names"
         ):
             df.to_json()
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (pd.Timestamp("2024-03-01 12:30:00"), "2024-03-01T12:30:00"),
+            (
+                pd.Timestamp("2024-03-01 12:30:00", tz="UTC"),
+                "2024-03-01T12:30:00Z",  # GDAL spells UTC "Z", not "+00:00"
+            ),
+            (datetime.date(2024, 3, 1), "2024-03-01"),
+            (datetime.time(12, 30), "12:30:00"),
+            (pd.Timedelta("1 days 2:03:04"), "P1DT2H3M4S"),
+            # a plain timedelta must render like its pandas twin, not str()
+            (datetime.timedelta(days=1, hours=2, minutes=3, seconds=4), "P1DT2H3M4S"),
+            (datetime.time(12, 30, tzinfo=datetime.UTC), "12:30:00Z"),
+            (pd.Period("2024-01", freq="M"), "2024-01"),
+            (
+                uuid.UUID("12345678-1234-5678-1234-567812345678"),
+                "12345678-1234-5678-1234-567812345678",
+            ),
+            (decimal.Decimal("1.50"), "1.50"),
+        ],
+    )
+    def test_to_json_non_serializable_values(self, value, expected):
+        # values JSON has no native type for must be converted, not raise
+        df = GeoDataFrame({"v": [value]}, geometry=[Point(1, 1)], crs="EPSG:4326")
+        data = json.loads(df.to_json())
+        assert data["features"][0]["properties"]["v"] == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pd.Timestamp("2024-03-01 12:30:00"),
+            pd.Timestamp("2024-03-01 12:30:00", tz="UTC"),
+            datetime.date(2024, 3, 1),
+        ],
+    )
+    def test_to_json_matches_to_file_geojson(self, value, tmp_path):
+        # to_json and to_file(driver="GeoJSON") both emit GeoJSON, so a value must
+        # serialize identically through either one. Compared dynamically rather than
+        # against a literal so this tracks whatever GDAL writes.
+        pytest.importorskip("pyogrio")
+        df = GeoDataFrame({"v": [value]}, geometry=[Point(1, 1)], crs="EPSG:4326")
+        path = tmp_path / "out.geojson"
+        df.to_file(path, driver="GeoJSON")
+
+        from_file = json.loads(path.read_text())["features"][0]["properties"]["v"]
+        from_json = json.loads(df.to_json())["features"][0]["properties"]["v"]
+        assert from_json == from_file
+
+    @pytest.mark.parametrize("na,expected", [("null", {"v": None}), ("drop", {})])
+    def test_to_json_missing_datetime(self, na, expected):
+        # NaT must still follow the na= rules rather than reach the encoder
+        df = GeoDataFrame(
+            {"v": pd.to_datetime([None])}, geometry=[Point(1, 1)], crs="EPSG:4326"
+        )
+        data = json.loads(df.to_json(na=na))
+        assert data["features"][0]["properties"] == expected
+
+    def test_to_json_default_kwarg_is_overridable(self):
+        df = GeoDataFrame(
+            {"v": [pd.Timestamp("2024-03-01")]},
+            geometry=[Point(1, 1)],
+            crs="EPSG:4326",
+        )
+        data = json.loads(df.to_json(default=lambda obj: "CUSTOM"))
+        assert data["features"][0]["properties"]["v"] == "CUSTOM"
+
+    def test_to_json_serializable_values_unchanged(self):
+        # the fallback must not stringify types JSON already supports
+        df = GeoDataFrame(
+            {"i": [42], "f": [1.5], "b": [True], "s": ["hi"]},
+            geometry=[Point(1, 1)],
+            crs="EPSG:4326",
+        )
+        props = json.loads(df.to_json())["features"][0]["properties"]
+        assert props == {"i": 42, "f": 1.5, "b": True, "s": "hi"}
 
     def test_copy(self):
         df2 = self.df.copy()


### PR DESCRIPTION
Fixes #3840.

`to_json()` handed its dict to the stdlib encoder, which has no handler for the `Timestamp` objects `iterfeatures` produces, so any datetime column blew up, and you hit it just by reading a GeoPackage with a DATE field. Same for `timedelta`, `Period`, `date`, `UUID`, `Decimal` and `bytes`.

Added a `default=` fallback:

```python
def _json_default(obj: Any) -> str:
    if isinstance(obj, (datetime.date, datetime.time)):  # datetime subclasses date
        # GDAL spells a UTC offset "Z" rather than "+00:00"
        return obj.isoformat().replace("+00:00", "Z")
    if isinstance(obj, datetime.timedelta):  # including pandas' Timedelta
        return pd.Timedelta(obj).isoformat()
    return str(obj)
```

installed via `kwargs.setdefault("default", _json_default)`, so your own `default=` still wins. Hooking the encoder rather than coercing columns keeps `to_geo_dict` and `iterfeatures` handing back real Python objects.

The format is whatever `to_file(driver="GeoJSON")` already wrote.
I checked every type both can represent and they now match exactly (`'2024-03-01T12:30:00'`, UTC as `'...Z'`, `Decimal("1.50")` -> `'1.50'`, ints/floats stay native). The one deliberate difference is `timedelta`: GDAL has no duration type and refuses the write, so matching it would mean raising - `to_json` writes the ISO 8601 duration instead.
`NaT` still follows the `na=` rules.

## Before / after with the issue repro
before:

```
TypeError: Object of type Timestamp is not JSON serializable
```

after:

```json
{"type": "FeatureCollection", "features": [{"id": "0", "type": "Feature", "properties":
{"observed": "2024-03-01T00:00:00"}, "geometry": {"type": "Point", "coordinates": [0.0,
0.0]}}, {"id": "1", "type": "Feature", "properties": {"observed": "2024-07-15T00:00:00"},
"geometry": {"type": "Point", "coordinates": [1.0, 1.0]}}]}
```

## Tests

Two regression tests added (13 cases, fail on `main`): exact output per type, and a parity test that compares against `to_file` dynamically so it tracks GDAL instead of freezing today's literals. 