### PR TITLE
BUG: GeoSeries.map should preserve the CRS like GeoSeries.apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Bug fixes:
 - Fix `GeoDataFrame.from_features` raising a `ValueError` for an empty list of
   features when a `crs` is provided; it now returns an empty `GeoDataFrame` with
   a `geometry` column (#3777).
+- Fix ``GeoSeries.map()`` dropping the CRS; it is now preserved when the result is
+  a ``GeoSeries``, consistent with ``GeoSeries.apply()`` (#3842).
 
 
 Community:

--- a/geopandas/geoseries.py
+++ b/geopandas/geoseries.py
@@ -814,6 +814,16 @@ class GeoSeries(GeoPandasBase, Series):
                 result.set_crs(self.crs, inplace=True)
         return result
 
+    @doc(pd.Series)
+    def map(self, *args, **kwargs):
+        # signature is passed through, as the name of the first parameter
+        # differs between pandas versions ("arg" vs "func")
+        result = super().map(*args, **kwargs)
+        if isinstance(result, GeoSeries):
+            if self.crs is not None:
+                result.set_crs(self.crs, inplace=True)
+        return result
+
     def isna(self) -> Series:
         """
         Detect missing values.

--- a/geopandas/tests/test_crs.py
+++ b/geopandas/tests/test_crs.py
@@ -693,6 +693,19 @@ class TestGeometryArrayCRS:
         result = s.apply(lambda x: x.centroid)
         assert result.crs == 27700
 
+    def test_map(self):
+        s = GeoSeries(self.arr)
+        assert s.crs == 27700
+
+        # map preserves the CRS if the result is a GeoSeries
+        result = s.map(lambda x: x.centroid)
+        assert result.crs == 27700
+
+        # also for the mapping forms of the argument
+        mapping = dict(zip(s, s.centroid))
+        assert s.map(mapping).crs == 27700
+        assert s.map(pd.Series(mapping)).crs == 27700
+
     def test_apply_geodataframe(self):
         df = GeoDataFrame({"col1": [0, 1]}, geometry=self.geoms, crs=27700)
         assert df.crs == 27700

--- a/geopandas/tests/test_pandas_methods.py
+++ b/geopandas/tests/test_pandas_methods.py
@@ -707,6 +707,26 @@ def test_apply(s):
     assert_series_equal(result, pd.Series([0.0, 1.0, 2.0]))
 
 
+def test_map(s):
+    # function that returns geometry preserves GeoSeries class
+    def geom_func(geom):
+        assert isinstance(geom, Point)
+        return geom
+
+    result = s.map(geom_func)
+    assert isinstance(result, GeoSeries)
+    assert_geoseries_equal(result, s)
+
+    # function that returns non-geometry results in Series
+    def numeric_func(geom):
+        assert isinstance(geom, Point)
+        return geom.x
+
+    result = s.map(numeric_func)
+    assert not isinstance(result, GeoSeries)
+    assert_series_equal(result, pd.Series([0.0, 1.0, 2.0]))
+
+
 def test_apply_loc_len1(df):
     # subset of len 1 with loc -> bug in pandas with inconsistent Block ndim
     # resulting in bug in apply


### PR DESCRIPTION
`GeoSeries.map()` silently drops the CRS. `GeoSeries.apply` has restored `self.crs` since #1478 (2020); `map` never got the equivalent, so it is the only elementwise path that returns naive geometries.

Three of four cells agree — `map` is the odd one out:

```
input crs=EPSG:27700, elementwise op returning geometry
  GeoSeries.apply(f)       -> EPSG:27700
  GeoSeries.map(f)         -> None          <--
  GeoDataFrame.apply(col)  -> EPSG:27700
  GeoDataFrame.map(v)      -> EPSG:27700
```

All three argument forms are affected (callable, dict, Series). Downstream, `s.map(f).to_crs(4326)` raises `ValueError: Cannot transform naive geometries`; otherwise the result is silently treated as unprojected.

The fix mirrors the `apply` override, so it inherits the same accepted trade-off: a function that reprojects now carries the source CRS instead of `None`, exactly as `apply` has since #1478.

`TestGeometryArrayCRS` is the class that catches CRS loss and has `test_apply` and `test_apply_geodataframe`, but there was no `map` test anywhere in the suite. Added one there (fails on all three argument forms without the fix), plus a class/dtype test next to `test_apply` in `test_pandas_methods.py` — that one passes with or without the fix; it pins the existing contract rather than the new behaviour.

Verified on pandas 2.2.3 and 3.0.5. `*args, **kwargs` is deliberate: pandas renamed the first parameter `arg` -> `func` between 2.2 and 3.0, so an explicit signature would break one of them.

`GeoSeries.mode()` drops the CRS the same way. Left out as a separate question (aggregation, not elementwise) — happy to take it in a follow-up.
