### PR TITLE
BUG: don't raise when plotting an empty or all-missing GeoDataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Bug fixes:
 - Fix `GeoDataFrame.from_features` raising a `ValueError` for an empty list of
   features when a `crs` is provided; it now returns an empty `GeoDataFrame` with
   a `geometry` column (#3777).
+- Fix `plot()` raising ``ValueError: aspect must be finite and positive`` on a
+  geographic CRS when there is nothing to draw: a `GeoDataFrame` plotted with
+  `column=` but no rows, or geometry that is entirely missing. Such calls now warn
+  and display nothing, as an empty `GeoSeries` already did. This also restores the
+  "empty" warning for `GeoDataFrame.plot(column=...)`, dropped in (#3728).
 
 
 Community:

--- a/geopandas/plotting.py
+++ b/geopandas/plotting.py
@@ -77,6 +77,34 @@ def _set_aspect(
         ax.set_aspect(aspect)
 
 
+def _nothing_to_plot(
+    s: geopandas.GeoSeries, name: Literal["GeoSeries", "GeoDataFrame"]
+) -> str | None:
+    """Return a warning message if `s` holds nothing drawable, else None.
+
+    Missing geometries are not empty geometries (``is_empty`` is False for None), so
+    both have to be accounted for: either would otherwise leave ``total_bounds`` all
+    NaN and make :func:`_set_aspect` raise on a geographic CRS.
+    """
+    if s.empty:
+        return (
+            f"The {name} you are attempting to plot is empty. "
+            "Nothing has been displayed."
+        )
+    missing = s.isna()
+    if missing.all():
+        return (
+            f"The {name} you are attempting to plot is composed of missing "
+            "geometries. Nothing has been displayed."
+        )
+    if (s.is_empty | missing).all():
+        return (
+            f"The {name} you are attempting to plot is composed of empty "
+            "geometries. Nothing has been displayed."
+        )
+    return None
+
+
 def _sanitize_geoms(
     geoms: geopandas.GeoSeries,
 ) -> tuple[geopandas.GeoSeries, np.ndarray]:
@@ -585,22 +613,9 @@ def plot_series(
     if add_labels:
         _set_axis_labels(ax, s.crs)
 
-    if s.empty:
-        warnings.warn(
-            "The GeoSeries you are attempting to plot is "
-            "empty. Nothing has been displayed.",
-            UserWarning,
-            stacklevel=3,
-        )
-        return ax
-
-    if s.is_empty.all():
-        warnings.warn(
-            "The GeoSeries you are attempting to plot is "
-            "composed of empty geometries. Nothing has been displayed.",
-            UserWarning,
-            stacklevel=3,
-        )
+    nothing_to_plot = _nothing_to_plot(s, "GeoSeries")
+    if nothing_to_plot is not None:
+        warnings.warn(nothing_to_plot, UserWarning, stacklevel=3)
         return ax
 
     # set correct aspect to preserve proportions in geographic CRS
@@ -968,6 +983,11 @@ def plot_dataframe(
 
     if add_labels:
         _set_axis_labels(ax, df.crs)
+
+    nothing_to_plot = _nothing_to_plot(df.geometry, "GeoDataFrame")
+    if nothing_to_plot is not None:
+        warnings.warn(nothing_to_plot, UserWarning, stacklevel=3)
+        return ax
 
     # set correct aspect to preserve proportions in geographic CRS
     _set_aspect(aspect, df, ax)

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -1324,6 +1324,62 @@ class TestGeographicAspect:
         assert ax3.get_aspect() == 0.5
 
 
+class TestEmptyOrMissingGeometryPlotting:
+    """Plotting nothing must warn and no-op, never raise.
+
+    With the default ``aspect="auto"`` and a geographic CRS the aspect is derived
+    from ``total_bounds``, which is all NaN when there is nothing to bound; without
+    a guard matplotlib rejects the resulting NaN aspect. Note that these cases only
+    ever raised on a geographic CRS, hence the parametrization over ``crs``.
+    """
+
+    @pytest.mark.parametrize("crs", [None, "EPSG:4326", "EPSG:3857"])
+    @pytest.mark.parametrize("column", [None, "v"])
+    def test_empty_dataframe(self, crs, column):
+        df = GeoDataFrame({"v": []}, geometry=GeoSeries([], crs=crs))
+        with pytest.warns(UserWarning, match="is empty"):
+            ax = df.plot(column=column)
+        assert len(ax.collections) == 0
+
+    @pytest.mark.parametrize("crs", [None, "EPSG:4326", "EPSG:3857"])
+    @pytest.mark.parametrize("column", [None, "v"])
+    def test_all_missing_geometries(self, crs, column):
+        df = GeoDataFrame({"v": [1.0, 2.0]}, geometry=GeoSeries([None, None], crs=crs))
+        with pytest.warns(UserWarning, match="composed of missing geometries"):
+            ax = df.plot(column=column)
+        assert len(ax.collections) == 0
+
+    @pytest.mark.parametrize("crs", [None, "EPSG:4326", "EPSG:3857"])
+    def test_all_missing_geometries_series(self, crs):
+        s = GeoSeries([None, None], crs=crs)
+        with pytest.warns(UserWarning, match="composed of missing geometries"):
+            ax = s.plot()
+        assert len(ax.collections) == 0
+
+    @pytest.mark.parametrize("crs", [None, "EPSG:4326", "EPSG:3857"])
+    @pytest.mark.parametrize("column", [None, "v"])
+    def test_mix_of_missing_and_empty(self, crs, column):
+        # is_empty is False for None, so neither condition catches this on its own
+        df = GeoDataFrame(
+            {"v": [1.0, 2.0]}, geometry=GeoSeries([None, Polygon()], crs=crs)
+        )
+        with pytest.warns(UserWarning, match="composed of empty geometries"):
+            ax = df.plot(column=column)
+        assert len(ax.collections) == 0
+
+    @pytest.mark.parametrize("column", [None, "v"])
+    def test_single_drawable_geometry_still_plots(self, column):
+        # the guard must not swallow a frame that has something to draw
+        df = GeoDataFrame(
+            {"v": [1.0, 2.0, 3.0]},
+            geometry=GeoSeries(
+                [None, Polygon(), Polygon([(0, 0), (1, 0), (1, 1)])], crs="EPSG:4326"
+            ),
+        )
+        ax = df.plot(column=column)
+        assert len(ax.collections) == 1
+
+
 @pytest.mark.filterwarnings(
     "ignore:Numba not installed. Using slow pure python version.:UserWarning"
 )


### PR DESCRIPTION
With `aspect="auto"` and a geographic CRS, `_set_aspect` derives the aspect from `total_bounds` which is all NaN when there's nothing to draw, and matplotlib rejects the resulting NaN. Two holes let that through: `plot_dataframe` had no empty check at all on the `column=` path (it only inherited one by delegating to `plot_series` when `column is None`), and neither guard covered missinggeometry, since `is_empty` is `False` for `None`.

Replaced `plot_series` two partial checks with one helper both call before `_set_aspect`:

```python
def _nothing_to_plot(s, name):
    if s.empty:
        return f"The {name} you are attempting to plot is empty. ..."
    missing = s.isna()
    if missing.all():
        return f"... is composed of missing geometries. ..."
    if (s.is_empty | missing).all():
        return f"... is composed of empty geometries. ..."
    return None
```

That covers all three ways to get an all-NaN `total_bounds`: no rows, all missing, all empty-or-missing. 
Each warns and returns instead of raising.

Also picks up a separate regression: `plot_dataframe`'s `if df.empty:` warn-and-return was dropped in #3728, so on a projected CRS an empty frame had been plotting silently. It warns again.

## Before / after

```python
gdf = gpd.GeoDataFrame(
    {"pop": [1.0, 2.0]},
    geometry=[Point(0, 0), Point(1, 1)],
    crs="EPSG:4326",
)
gdf[gdf["pop"] > 99].plot(column="pop")   # filtered to nothing
```

before:

```
ValueError: aspect must be finite and positive
```

after:

```
UserWarning: The GeoDataFrame you are attempting to plot is empty. Nothing has been displayed.
```

Same for all-`None` geometry, with or without `column=`, and on `GeoSeries.plot()`.

## Tests

New `TestEmptyOrMissingGeometryPlotting`, 23 cases, parametrized over `crs=[None, "EPSG:4326", "EPSG:3857"]`. 
The existing `test_empty_plot` builds its frames with no CRS, which is exactly why this slipped through.