### PR TITLE
DOC: clarify measurement units and set_crs vs to_crs workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ New features and improvements:
 - `read_parquet` now support direct reading from HTTP/HTTPS protocols (#3699)
 - Document how to access the feature ID (`fid`) as the index when reading files
   with `read_file` and the pyogrio engine, using `fid_as_index=True` (#3829)
+- DOC: add example clarifying measurement units (area, length, distance,
+  buffer) depend on the active CRS, and demonstrate the `set_crs()` →
+  `to_crs()` workflow before metric calculations (#XXXX)
 
 Deprecations and compatibility notes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ New features and improvements:
   with `read_file` and the pyogrio engine, using `fid_as_index=True` (#3829)
 - DOC: add example clarifying measurement units (area, length, distance,
   buffer) depend on the active CRS, and demonstrate the `set_crs()` →
-  `to_crs()` workflow before metric calculations (#XXXX)
+  `to_crs()` workflow before metric calculations (#3846)
 
 Deprecations and compatibility notes:
 

--- a/doc/source/docs/user_guide/projections.rst
+++ b/doc/source/docs/user_guide/projections.rst
@@ -72,6 +72,49 @@ the :attr:`GeoSeries.crs` attribute):
     my_geoseries = my_geoseries.set_crs("EPSG:4326")
     my_geoseries = my_geoseries.set_crs(epsg=4326)
 
+It is important to know that the coordinate values in a ``GeoSeries`` or
+``GeoDataFrame`` are only ever expressed in the units of its active CRS.
+This has a direct effect on measurement operations such as ``area``,
+``length``, ``distance``, and ``buffer``. For example, geometries assigned a
+geographic CRS such as ``EPSG:4326`` have coordinates in degrees, so any
+direct area calculation is expressed in square degrees rather than a ground
+area in square metres.
+
+.. code-block:: python
+
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
+    gdf = gpd.GeoDataFrame(
+        {"name": ["example area"]},
+        geometry=[
+            Polygon(
+                [
+                    (80.20, 13.00),
+                    (80.21, 13.00),
+                    (80.21, 13.01),
+                    (80.20, 13.01),
+                ]
+            )
+        ],
+    )
+
+    # The source coordinates are known to be longitude and latitude.
+    # Setting a CRS defines their interpretation; it does not modify them.
+    gdf = gdf.set_crs("EPSG:4326")
+
+    # With a geographic CRS, this result uses square-degree coordinate units
+    # and should not be interpreted as ground area in square metres.
+    area_in_coordinate_units = gdf.area
+
+    # Transform coordinates before calculating metric measurements.
+    gdf_projected = gdf.to_crs(gdf.estimate_utm_crs())
+    gdf_projected["area_m2"] = gdf_projected.area
+
+For compact study areas, :meth:`GeoDataFrame.estimate_utm_crs` can provide a
+convenient metric CRS. For larger or accuracy-sensitive analyses, select a
+CRS appropriate to the study area and intended measurement.
+
 
 Re-projecting
 ----------------


### PR DESCRIPTION
## Summary
This documentation update clarifies that measurement units (area, length, distance, buffer) depend on the active CRS. It demonstrates the practical workflow of defining known coordinates with `set_crs()` before transforming them with `to_crs()` for metric calculations.

Related to #942 — a maintainer confirmed in that thread that a documentation update along these lines would be welcome.

## Changes
- Added a short explanatory note in `projections.rst` on how coordinate units dictate measurement interpretation.
- Provided a self-contained, runnable example distinguishing metadata assignment (`set_crs`) from coordinate transformation (`to_crs`).
- Used `estimate_utm_crs()` as a convenient local metric example.
- Added a `CHANGELOG.md` entry under the "New features and improvements" section.

## Validation
- Executed the Python code block locally in a standard development environment to ensure it runs cleanly, emits the expected geographic-CRS warning for `.area`, and produces no tracebacks.
- Formatted the prose to match the surrounding reStructuredText conventions and line wrapping.
- *Note: I have not executed a full local Sphinx build. I will rely on the CI pipeline to verify the rST directives and documentation rendering.*
