### PR TITLE
ENH: support reading GeoParquet 2.0 files with bbox filter

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -884,16 +884,71 @@ def _read_parquet(
 
     kwargs["use_pandas_metadata"] = True
 
-    table = parquet.read_table(
-        path, columns=columns, filesystem=filesystem, filters=filters, **kwargs
-    )
+    # table = parquet.read_table(
+    #     path, columns=columns, filesystem=filesystem, filters=filters, **kwargs
+    # )
+
+    pqdataset = parquet.ParquetDataset(path, filesystem=filesystem)
+    dsdataset = pqdataset._dataset
+
+    if bbox is not None and bbox_filter is None:
+        # if bbox is specified, but the dataset does not have a bbox column,
+        # we need to filter the row groups manually.
+        # breakpoint()
+        ds = import_optional_dependency(
+            "pyarrow.dataset", extra="pyarrow is required for Parquet support."
+        )
+
+        geometry = geo_metadata["primary_column"]
+        filtered_fragments = []
+
+        for fragment in pqdataset.fragments:
+            geometry_idx = fragment.metadata.schema.names.index(geometry)
+            row_group_ids = [
+                rg.id
+                for rg in fragment.row_groups
+                if _bbox_intersects(
+                    rg.metadata.column(geometry_idx).geo_statistics, bbox
+                )
+            ]
+            fragment_filtered = fragment.subset(row_group_ids=row_group_ids)
+
+            filtered_fragments.append(fragment_filtered)
+
+        dsdataset = ds.FileSystemDataset(
+            filtered_fragments,
+            dsdataset.schema,
+            dsdataset.format,
+            filesystem=dsdataset.filesystem,
+            root_partition=dsdataset.partition_expression,
+        )
+
+    if filters is not None and isinstance(filters, list):
+        filters = parquet.filters_to_expression(filters)
+    table = dsdataset.to_table(columns=columns, filter=filters)
 
     if metadata and b"PANDAS_ATTRS" in metadata:
         df_attrs = metadata[b"PANDAS_ATTRS"]
     else:
         df_attrs = None
 
-    return _arrow_to_geopandas(table, geo_metadata, to_pandas_kwargs, df_attrs)
+    result = _arrow_to_geopandas(table, geo_metadata, to_pandas_kwargs, df_attrs)
+
+    if bbox is not None and bbox_filter is None:
+        # post-filtering step: manual filtering above only filtered up to the row group
+        # level -> further filter at the row level to give consistent behaviour
+        bbox_bounds = result.bounds
+        result_bbox = shapely.box(
+            bbox_bounds["minx"],
+            bbox_bounds["miny"],
+            bbox_bounds["maxx"],
+            bbox_bounds["maxy"],
+        )
+        result = result[
+            shapely.intersects(result_bbox, shapely.box(*bbox))
+        ].reset_index(drop=True)
+
+    return result
 
 
 def _read_feather(path, columns=None, to_pandas_kwargs=None, **kwargs):
@@ -985,6 +1040,10 @@ def _get_parquet_bbox_filter(geo_metadata, bbox):
             & (pc.field((primary_column, "y")) <= bbox[3])
         )
 
+    elif geo_metadata["version"] == "2.0.0":
+        # this case gets handled later manually
+        return None
+
     else:
         raise ValueError(
             "Specifying 'bbox' not supported for this Parquet file (it should either "
@@ -1030,3 +1089,19 @@ def _splice_bbox_and_filters(kwarg_filters, bbox_filter):
 
     filters_expression = parquet.filters_to_expression(kwarg_filters)
     return bbox_filter & filters_expression
+
+
+def _bbox_intersects(geo_stats, bbox):
+    stats_xmin, stats_ymin, stats_xmax, stats_ymax = (
+        geo_stats.xmin,
+        geo_stats.ymin,
+        geo_stats.xmax,
+        geo_stats.ymax,
+    )
+    xmin, ymin, xmax, ymax = bbox
+    return (
+        (stats_xmin <= xmax)
+        and (stats_xmax >= xmin)
+        and (stats_ymin <= ymax)
+        and (stats_ymax >= ymin)
+    )

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1168,25 +1168,31 @@ def test_to_parquet_bbox_values(tmpdir, geometry, expected_bbox):
     assert result["bbox"][0] == expected_bbox
 
 
-def test_read_parquet_bbox_single_point(tmpdir):
+@pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
+def test_read_parquet_bbox_single_point(tmpdir, write_kargs):
     # confirm that on a single point, bbox will pick it up.
     df = GeoDataFrame(data=[[1, 2]], columns=["a", "b"], geometry=[Point(1, 1)])
     filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename, write_covering_bbox=True)
+    df.to_parquet(filename, **write_kargs)
     pq_df = read_parquet(filename, bbox=(1, 1, 1, 1))
     assert len(pq_df) == 1
     assert pq_df.geometry[0] == Point(1, 1)
 
 
+@pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
 @pytest.mark.parametrize("geometry_name", ["geometry", "custum_geom_col"])
-def test_read_parquet_bbox(tmpdir, naturalearth_lowres, geometry_name):
+def test_read_parquet_bbox(tmpdir, naturalearth_lowres, geometry_name, write_kargs):
     # check bbox is being used to filter results.
     df = read_file(naturalearth_lowres)
     if geometry_name != "geometry":
         df = df.rename_geometry(geometry_name)
 
     filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename, write_covering_bbox=True)
+    df.to_parquet(filename, **write_kargs)
 
     pq_df = read_parquet(filename, bbox=(0, 0, 10, 10))
 
@@ -1203,8 +1209,13 @@ def test_read_parquet_bbox(tmpdir, naturalearth_lowres, geometry_name):
     ]
 
 
+@pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
 @pytest.mark.parametrize("geometry_name", ["geometry", "custum_geom_col"])
-def test_read_parquet_bbox_partitioned(tmpdir, naturalearth_lowres, geometry_name):
+def test_read_parquet_bbox_partitioned(
+    tmpdir, naturalearth_lowres, geometry_name, write_kargs
+):
     # check bbox is being used to filter results on partitioned data.
     df = read_file(naturalearth_lowres)
     if geometry_name != "geometry":
@@ -1213,8 +1224,8 @@ def test_read_parquet_bbox_partitioned(tmpdir, naturalearth_lowres, geometry_nam
     # manually create partitioned dataset
     basedir = tmpdir / "partitioned_dataset"
     basedir.mkdir()
-    df[:100].to_parquet(basedir / "data1.parquet", write_covering_bbox=True)
-    df[100:].to_parquet(basedir / "data2.parquet", write_covering_bbox=True)
+    df[:100].to_parquet(basedir / "data1.parquet", **write_kargs)
+    df[100:].to_parquet(basedir / "data2.parquet", **write_kargs)
 
     pq_df = read_parquet(basedir, bbox=(0, 0, 10, 10))
 
@@ -1232,6 +1243,9 @@ def test_read_parquet_bbox_partitioned(tmpdir, naturalearth_lowres, geometry_nam
 
 
 @pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
+@pytest.mark.parametrize(
     "geometry, bbox",
     [
         (LineString([(1, 1), (3, 3)]), (1.5, 1.5, 3.5, 3.5)),
@@ -1244,10 +1258,12 @@ def test_read_parquet_bbox_partitioned(tmpdir, naturalearth_lowres, geometry_nam
         (Polygon([(0, 0), (4, 0), (4, 4), (0, 4)]), (1, 1, 5, 3)),
     ],
 )
-def test_read_parquet_bbox_partial_overlap_of_geometry(tmpdir, geometry, bbox):
+def test_read_parquet_bbox_partial_overlap_of_geometry(
+    tmpdir, geometry, bbox, write_kargs
+):
     df = GeoDataFrame(data=[[1, 2]], columns=["a", "b"], geometry=[geometry])
     filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename, write_covering_bbox=True)
+    df.to_parquet(filename, **write_kargs)
 
     pq_df = read_parquet(filename, bbox=bbox)
     assert len(pq_df) == 1
@@ -1307,16 +1323,21 @@ def test_read_parquet_bbox_column_default_behaviour(tmpdir, naturalearth_lowres)
 
 
 @pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
+@pytest.mark.parametrize(
     "filters",
     [
         [("gdp_md_est", ">", 20000)],
         pc.field("gdp_md_est") > 20000,
     ],
 )
-def test_read_parquet_filters_and_bbox(tmpdir, naturalearth_lowres, filters):
+def test_read_parquet_filters_and_bbox(
+    tmpdir, naturalearth_lowres, filters, write_kargs
+):
     df = read_file(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename, write_covering_bbox=True)
+    df.to_parquet(filename, **write_kargs)
 
     result = read_parquet(filename, filters=filters, bbox=(0, 0, 20, 20))
     assert result["name"].values.tolist() == [
@@ -1331,16 +1352,21 @@ def test_read_parquet_filters_and_bbox(tmpdir, naturalearth_lowres, filters):
 
 
 @pytest.mark.parametrize(
+    "write_kargs", [{"write_covering_bbox": True}, {"schema_version": "2.0.0"}]
+)
+@pytest.mark.parametrize(
     "filters",
     [
         ([("gdp_md_est", ">", 15000), ("gdp_md_est", "<", 16000)]),
         ((pc.field("gdp_md_est") > 15000) & (pc.field("gdp_md_est") < 16000)),
     ],
 )
-def test_read_parquet_filters_without_bbox(tmpdir, naturalearth_lowres, filters):
+def test_read_parquet_filters_without_bbox(
+    tmpdir, naturalearth_lowres, filters, write_kargs
+):
     df = read_file(naturalearth_lowres)
     filename = os.path.join(str(tmpdir), "test.pq")
-    df.to_parquet(filename, write_covering_bbox=True)
+    df.to_parquet(filename, **write_kargs)
 
     result = read_parquet(filename, filters=filters)
     assert result["name"].values.tolist() == ["Burkina Faso", "Mozambique", "Albania"]


### PR DESCRIPTION
Follow-up on https://github.com/geopandas/geopandas/pull/3825, last important part of https://github.com/geopandas/geopandas/issues/3632 to claim full GeoParquet 2.0 support.

This requires using the `pyarrow.dataset` interface, which I might first do separately in a (to open) pre-cursor -> https://github.com/geopandas/geopandas/pull/3849

