### PR TITLE
REF: refactor read_parquet implementation to use the pyarrow Parquet dataset functionality

### DIFF
--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -716,22 +716,39 @@ def _validate_and_decode_metadata(metadata):
     return decoded_geo_metadata
 
 
-def _read_parquet_schema_and_metadata(path, filesystem):
-    """Open the Parquet file/dataset a first time to get the schema and metadata.
+def _open_parquet_dataset(path, filesystem, kwargs, bbox):
+    """Open the Parquet file/dataset and get the schema and metadata.
 
-    TODO: we should look into how we can reuse opened dataset for reading the
-    actual data, to avoid discovering the dataset twice (problem right now is
-    that the ParquetDataset interface doesn't allow passing the filters on read)
-
+    This has a fallback ParquetFile in case pyarrow.dataset is not available,
+    mimicking the logic of pyarrow.parquet.read_table().
     """
     import pyarrow
     from pyarrow import parquet
 
     try:
         try:
-            schema = parquet.ParquetDataset(path, filesystem=filesystem).schema
-        except Exception:
-            schema = parquet.read_schema(path, filesystem=filesystem)
+            dataset = parquet.ParquetDataset(path, filesystem=filesystem, **kwargs)
+            schema = dataset.schema
+        except ImportError:
+            # the above can fail if pyarrow.dataset submodule is not available
+            if kwargs.get("filters") is not None:
+                raise ValueError(
+                    "the 'filters' keyword is not supported when the "
+                    "pyarrow.dataset module is not available"
+                )
+            if bbox is not None:
+                raise ValueError(
+                    "the 'bbox' keyword is not supported when the "
+                    "pyarrow.dataset module is not available"
+                )
+
+            if filesystem is not None:
+                pa_filesystem = _ensure_arrow_fs(filesystem)
+                source = pa_filesystem.open_input_file(path)
+            else:
+                source = path
+            dataset = parquet.ParquetFile(source, **kwargs)
+            schema = dataset.schema_arrow
     except OSError as exc:
         if "Thrift LogicalType that is not recognized" in str(exc):
             raise OSError(
@@ -741,18 +758,51 @@ def _read_parquet_schema_and_metadata(path, filesystem):
             ) from exc
         raise
 
-    metadata = schema.metadata
+    metadata = schema.metadata or {}
 
     # read metadata separately to get the raw Parquet FileMetaData metadata
     # (pyarrow doesn't properly exposes those in schema.metadata for files
     # created by GDAL - https://issues.apache.org/jira/browse/ARROW-16688)
-    if metadata is None or b"geo" not in metadata:
+    if b"geo" not in metadata:
         try:
             metadata = parquet.read_metadata(path, filesystem=filesystem).metadata
         except Exception:
             pass
 
-    return schema, metadata
+    return dataset, schema, metadata
+
+
+def _add_index_columns_from_pandas_metadata(columns, metadata):
+    """
+    When a user specifies a subset of columns to read, we by default still
+    include the index columns in the read as well to be able to restore the
+    index.
+
+    Adapted from pyarrow.parquet.core.ParquetDataset.read()
+    """
+    if metadata and b"pandas" in metadata:
+        pandas_metadata = _decode_metadata(metadata[b"pandas"])
+
+        # RangeIndex can be represented as dict instead of column name
+        index_columns = [
+            col for col in pandas_metadata["index_columns"] if not isinstance(col, dict)
+        ]
+        columns = list(columns) + list(set(index_columns) - set(columns))
+    return columns
+
+
+def _restore_pandas_metadata(table, metadata):
+    """
+    If use_pandas_metadata, restore the pandas metadata (which gets
+    lost if doing a specific `columns` selection in to_table).
+
+    Adapted from pyarrow.parquet.core.ParquetDataset.read()
+    """
+    if b"pandas" in metadata:
+        new_metadata = table.schema.metadata or {}
+        new_metadata.update({b"pandas": metadata[b"pandas"]})
+        table = table.replace_schema_metadata(new_metadata)
+    return table
 
 
 def _read_parquet(
@@ -854,7 +904,12 @@ def _read_parquet(
         path, filesystem=filesystem, storage_options=storage_options
     )
     path = _expand_user(path)
-    schema, metadata = _read_parquet_schema_and_metadata(path, filesystem)
+
+    # those keywords are used at read() time
+    use_pandas_metadata = kwargs.pop("use_pandas_metadata", True)
+    use_threads = kwargs.pop("use_threads", True)
+
+    dataset, schema, metadata = _open_parquet_dataset(path, filesystem, kwargs, bbox)
 
     geo_metadata = _validate_and_decode_metadata(metadata)
     if len(geo_metadata["columns"]) == 0:
@@ -874,19 +929,28 @@ def _read_parquet(
     # columns are read in if it exists.
     if not columns and if_bbox_column_exists:
         columns = _get_non_bbox_columns(schema, geo_metadata)
+    elif columns is not None and use_pandas_metadata:
+        columns = _add_index_columns_from_pandas_metadata(columns, metadata)
+
+    filters = kwargs.pop("filters", None)
+    if filters is not None and isinstance(filters, list):
+        filters = parquet.filters_to_expression(filters)
 
     # if both bbox and filters kwargs are used, must splice together.
-    if "filters" in kwargs:
-        filters_kwarg = kwargs.pop("filters")
-        filters = _splice_bbox_and_filters(filters_kwarg, bbox_filter)
+    if filters is not None:
+        filters = _splice_bbox_and_filters(filters, bbox_filter)
     else:
         filters = bbox_filter
 
-    kwargs["use_pandas_metadata"] = True
+    if isinstance(dataset, parquet.ParquetFile):
+        table = dataset.read(columns=columns, use_threads=use_threads)
+    else:
+        table = dataset._dataset.to_table(
+            columns=columns, filter=filters, use_threads=use_threads
+        )
 
-    table = parquet.read_table(
-        path, columns=columns, filesystem=filesystem, filters=filters, **kwargs
-    )
+    if use_pandas_metadata:
+        table = _restore_pandas_metadata(table, metadata)
 
     if metadata and b"PANDAS_ATTRS" in metadata:
         df_attrs = metadata[b"PANDAS_ATTRS"]

--- a/geopandas/io/arrow.py
+++ b/geopandas/io/arrow.py
@@ -933,14 +933,16 @@ def _read_parquet(
         columns = _add_index_columns_from_pandas_metadata(columns, metadata)
 
     filters = kwargs.pop("filters", None)
-    if filters is not None and isinstance(filters, list):
+    if filters is not None:
+        # support both old-style [(..)] filters and pyarrow expressions
         filters = parquet.filters_to_expression(filters)
 
     # if both bbox and filters kwargs are used, must splice together.
-    if filters is not None:
-        filters = _splice_bbox_and_filters(filters, bbox_filter)
-    else:
-        filters = bbox_filter
+    if bbox_filter is not None:
+        if filters is not None:
+            filters = bbox_filter & filters
+        else:
+            filters = bbox_filter
 
     if isinstance(dataset, parquet.ParquetFile):
         table = dataset.read(columns=columns, use_threads=use_threads)
@@ -1083,14 +1085,3 @@ def _get_non_bbox_columns(schema, geo_metadata):
     if bbox_column_name in columns:
         columns.remove(bbox_column_name)
     return columns
-
-
-def _splice_bbox_and_filters(kwarg_filters, bbox_filter):
-    parquet = import_optional_dependency(
-        "pyarrow.parquet", extra="pyarrow is required for Parquet support."
-    )
-    if bbox_filter is None:
-        return kwarg_filters
-
-    filters_expression = parquet.filters_to_expression(kwarg_filters)
-    return bbox_filter & filters_expression

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -9,6 +9,7 @@ from itertools import product
 from packaging.version import Version
 
 import numpy as np
+import pandas as pd
 from pandas import ArrowDtype, DataFrame, Index, Series
 from pandas import read_parquet as pd_read_parquet
 
@@ -1152,6 +1153,37 @@ def test_parquet_dataset_availability_filters(
 
     with pytest.raises(ValueError, match="not supported"):
         geopandas.read_parquet(filename, filters=[("gdp_md_est", ">", 20000)])
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.Index(["a", "b", "c"], name="named_index"),
+        pd.RangeIndex(1, 4, name="named_index"),
+    ],
+)
+def test_read_parquet_pandas_metadata(tmp_path, index):
+    gdf = GeoDataFrame(
+        {"col": pd.array([1, 2, 3], dtype="Int64")},
+        index=index,
+        geometry=geopandas.points_from_xy([1, 2, 3], [1, 2, 3]),
+        crs="EPSG:4326",
+    )
+    gdf.to_parquet(tmp_path / "test.parquet")
+
+    result = geopandas.read_parquet(tmp_path / "test.parquet")
+    # index and dtypes should be preserved
+    assert result.index.name == "named_index"
+    assert result["col"].dtype == "Int64"
+    assert_geodataframe_equal(result, gdf)
+
+    # also when reading a subset of columns, the index gets preserved
+    result = geopandas.read_parquet(
+        tmp_path / "test.parquet", columns=["col", "geometry"]
+    )
+    assert result.index.name == "named_index"
+    assert result["col"].dtype == "Int64"
+    assert_geodataframe_equal(result, gdf)
 
 
 @pytest.mark.parametrize(

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1136,7 +1136,7 @@ def test_parquet_dataset_availability_partitioned(
     df[:100].to_parquet(basedir / "data1.parquet")
     df[100:].to_parquet(basedir / "data2.parquet")
 
-    with pytest.raises(Exception, match="is a directory"):
+    with pytest.raises(Exception, match=r"is a directory|Failed to open local file"):
         geopandas.read_parquet(str(basedir))
 
 

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -3,6 +3,7 @@ import json
 import os
 import pathlib
 import re
+import sys
 from io import BytesIO
 from itertools import product
 from packaging.version import Version
@@ -1079,6 +1080,78 @@ def test_parquet_read_partitioned_dataset_fsspec(tmpdir, naturalearth_lowres):
 
     result = read_parquet("memory://partitioned_dataset")
     assert_geodataframe_equal(result, df)
+
+
+@pytest.fixture
+def pyarrow_dataset_unavailable():
+    import pyarrow.dataset as ds
+
+    sys.modules["pyarrow.dataset"] = None
+    yield
+    sys.modules["pyarrow.dataset"] = ds
+
+
+def test_parquet_dataset_availability(
+    tmp_path, naturalearth_lowres, pyarrow_dataset_unavailable
+):
+    # basic roundtrip test (subset of test_roundtrip) to ensure basic files
+    # can be read if pyarrow.dataset is not available
+    df = read_file(naturalearth_lowres)
+    orig = df.copy()
+
+    filename = str(tmp_path / "test.parquet")
+
+    # Write to single file
+    df.to_parquet(filename)
+    assert os.path.exists(filename)
+    assert_geodataframe_equal(df, orig)
+
+    # Read from single file
+    pq_df = geopandas.read_parquet(filename)
+    assert_geodataframe_equal(pq_df, df)
+
+    pq_df = geopandas.read_parquet(filename, columns=["name", "geometry"])
+    assert_geodataframe_equal(pq_df, df[["name", "geometry"]])
+
+    # and with file-like object
+    buf = BytesIO()
+    df.to_parquet(buf)
+    buf.seek(0)
+    assert_geodataframe_equal(df, orig)
+
+    pq_df = geopandas.read_parquet(BytesIO(buf.getvalue()))
+    assert_geodataframe_equal(pq_df, df)
+
+
+def test_parquet_dataset_availability_partitioned(
+    tmpdir, naturalearth_lowres, pyarrow_dataset_unavailable
+):
+    # reading a directory is not supported in this case
+
+    # manually create partitioned dataset
+    df = read_file(naturalearth_lowres)
+    basedir = tmpdir / "partitioned_dataset"
+    basedir.mkdir()
+    df[:100].to_parquet(basedir / "data1.parquet")
+    df[100:].to_parquet(basedir / "data2.parquet")
+
+    with pytest.raises(Exception, match="is a directory"):
+        geopandas.read_parquet(str(basedir))
+
+
+def test_parquet_dataset_availability_filters(
+    tmpdir, naturalearth_lowres, pyarrow_dataset_unavailable
+):
+    # reading with filters is not supported in this case
+    df = read_file(naturalearth_lowres)
+    filename = os.path.join(str(tmpdir), "test.pq")
+    df.to_parquet(filename, write_covering_bbox=True)
+
+    with pytest.raises(ValueError, match="not supported"):
+        geopandas.read_parquet(filename, bbox=(0, 0, 1, 1))
+
+    with pytest.raises(ValueError, match="not supported"):
+        geopandas.read_parquet(filename, filters=[("gdp_md_est", ">", 20000)])
 
 
 @pytest.mark.parametrize(

--- a/geopandas/io/tests/test_arrow.py
+++ b/geopandas/io/tests/test_arrow.py
@@ -1164,7 +1164,10 @@ def test_parquet_dataset_availability_filters(
 )
 def test_read_parquet_pandas_metadata(tmp_path, index):
     gdf = GeoDataFrame(
-        {"col": pd.array([1, 2, 3], dtype="Int64")},
+        {
+            "col1": pd.array([1, 2, 3], dtype="Int64"),
+            "col2": pd.period_range("2012-01-01", periods=3, freq="D"),
+        },
         index=index,
         geometry=geopandas.points_from_xy([1, 2, 3], [1, 2, 3]),
         crs="EPSG:4326",
@@ -1174,16 +1177,16 @@ def test_read_parquet_pandas_metadata(tmp_path, index):
     result = geopandas.read_parquet(tmp_path / "test.parquet")
     # index and dtypes should be preserved
     assert result.index.name == "named_index"
-    assert result["col"].dtype == "Int64"
+    assert result["col1"].dtype == "Int64"
     assert_geodataframe_equal(result, gdf)
 
     # also when reading a subset of columns, the index gets preserved
     result = geopandas.read_parquet(
-        tmp_path / "test.parquet", columns=["col", "geometry"]
+        tmp_path / "test.parquet", columns=["col1", "geometry"]
     )
     assert result.index.name == "named_index"
-    assert result["col"].dtype == "Int64"
-    assert_geodataframe_equal(result, gdf)
+    assert result["col1"].dtype == "Int64"
+    assert_geodataframe_equal(result, gdf[["col1", "geometry"]])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR refactors our `read_parquet` implementation to use the `pyarrow.parquet` dataset functionality, instead of the `pyarrow.parquet.read_table()` convenience function.

This is triggered as a precursor to https://github.com/geopandas/geopandas/pull/3847, where I want to use the dataset API to filter based on the Geo stats of the parquet file (GeoParquet 2.0). 
But there are other benefits in general for doing this refactor:

- it resolves a TODO comment about opening the data twice (and thus discovering twice, which can be expensive for cloud and/or partitioned datasets)
- it can enable other new features (in addition to the GeoParquet 2.0 filtered read), such as supporting a keyword for limiting the number of rows to read (not yet done in this PR)

We did get some behaviours implicitly through our use of `pq.read_table`:

- a fallback when `pyarrow.dataset` is not available (which `pq.read_table` does automatically, and we had some (untested) code for it in `_read_parquet_schema_and_metadata` by falling back to `pq.read_schema` manually)
- honoring of `use_pandas_metadata` when it comes to reading a subset of columns (to still preserve the index, i.e. to add the index columns to the `columns` to read). This was enabled by setting `kwargs["use_pandas_metadata"] = True` before calling `pa.read_table`

Both were untested (all tests pass locally when commenting out the relevant line), and so in the first two commits I added some tests for better coverage before doing a refactor. 
To be honest, both are also quite uncommon and/or potentially ambiguous (should the index be preserved when selecting columns?), but for now I am preserving existing behaviour here.