### PR TITLE
DOC/TST: remove usage of CartoDB tiles

### DIFF
--- a/doc/source/docs/user_guide/interactive_mapping.ipynb
+++ b/doc/source/docs/user_guide/interactive_mapping.ipynb
@@ -78,7 +78,7 @@
                 "    column=\"BoroName\",  # make choropleth based on \"BoroName\" column\n",
                 "    tooltip=\"BoroName\",  # show \"BoroName\" value in tooltip (on hover)\n",
                 "    popup=True,  # show all values in popup (on click)\n",
-                "    tiles=\"CartoDB positron\",  # use \"CartoDB positron\" tiles\n",
+                "    tiles=\"OpenStreetMap HOT\",  # use humanitarian OpenStreetMap tiles\n",
                 "    cmap=\"Set1\",  # use \"Set1\" matplotlib colormap\n",
                 "    style_kwds=dict(color=\"black\"),  # use black outline\n",
                 ")"
@@ -121,18 +121,26 @@
                 "    name=\"groceries\",  # name of the layer in the map\n",
                 ")\n",
                 "\n",
-                "folium.TileLayer(\"CartoDB positron\", show=False).add_to(\n",
+                "folium.TileLayer(\"OpenStreetMap HOT\", show=False).add_to(\n",
                 "    m\n",
                 ")  # use folium to add alternative tiles\n",
                 "folium.LayerControl().add_to(m)  # use folium to add layer control\n",
                 "\n",
                 "m  # show map"
             ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "4d09db10",
+            "metadata": {},
+            "outputs": [],
+            "source": []
         }
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "Python 3 (ipykernel)",
+            "display_name": "default",
             "language": "python",
             "name": "python3"
         },
@@ -146,12 +154,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.11.0"
-        },
-        "vscode": {
-            "interpreter": {
-                "hash": "b1fe2ae8565152c84d3dbd08488d3746f754c9bdf2de9b61cf939da5306d3793"
-            }
+            "version": "3.14.6"
         }
     },
     "nbformat": 4,

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor=\"k\")\n",
     "cx.add_basemap(ax, source=cx.providers.OpenRailwayMap, zoom=10)\n",
-    "cx.add_basemap(ax, source=cx.providers.OpenStreetMap.HOT, zoom=10)"
+    "cx.add_basemap(ax, source=cx.providers.OpenStreetMap.HOT, zoom=12)"
    ]
   }
  ],

--- a/doc/source/gallery/plotting_basemap_background.ipynb
+++ b/doc/source/gallery/plotting_basemap_background.ipynb
@@ -10,7 +10,7 @@
     "This example shows how you can add a background basemap to plots created\n",
     "with the geopandas ``.plot()`` method beyond capabilities of the `tiles` keyword. This makes use of the\n",
     "[contextily](https://github.com/geopandas/contextily) package to retrieve\n",
-    "web map tiles from several sources (OpenStreetMap, CartoDB). Also have a\n",
+    "web map tiles from several sources (OpenStreetMap, NASA). Also have a\n",
     "look at contextily's \n",
     "[introduction guide](https://contextily.readthedocs.io/en/latest/intro_guide.html#Using-transparent-layers)\n",
     "for possible new features not covered here.\n"
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor=\"k\")\n",
-    "cx.add_basemap(ax, zoom=12)"
+    "cx.add_basemap(ax, zoom=10)"
    ]
   },
   {
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor=\"k\")\n",
-    "cx.add_basemap(ax, source=cx.providers.CartoDB.Positron)\n",
+    "cx.add_basemap(ax, source=cx.providers.OpenTopoMap)\n",
     "ax.set_axis_off()"
    ]
   },
@@ -220,8 +220,8 @@
    "outputs": [],
    "source": [
     "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor=\"k\")\n",
-    "cx.add_basemap(ax, source=cx.providers.CartoDB.PositronNoLabels)\n",
-    "cx.add_basemap(ax, source=cx.providers.CartoDB.PositronOnlyLabels)"
+    "cx.add_basemap(ax, source=cx.providers.OpenRailwayMap)\n",
+    "cx.add_basemap(ax, source=cx.providers.OpenStreetMap.HOT)"
    ]
   },
   {
@@ -239,14 +239,14 @@
    "outputs": [],
    "source": [
     "ax = df_wm.plot(figsize=(10, 10), alpha=0.5, edgecolor=\"k\")\n",
-    "cx.add_basemap(ax, source=cx.providers.CartoDB.PositronNoLabels, zoom=12)\n",
-    "cx.add_basemap(ax, source=cx.providers.CartoDB.PositronOnlyLabels, zoom=10)"
+    "cx.add_basemap(ax, source=cx.providers.OpenRailwayMap, zoom=10)\n",
+    "cx.add_basemap(ax, source=cx.providers.OpenStreetMap.HOT, zoom=10)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "default",
    "language": "python",
    "name": "python3"
   },
@@ -260,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/gallery/plotting_with_folium.ipynb
+++ b/doc/source/gallery/plotting_with_folium.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
    "metadata": {},
    "source": [
     "## Create Folium map\n",
-    "Folium has a number of built-in tilesets from OpenStreetMap, Mapbox, and CartoDB. For example:"
+    "Folium has a number of built-in tilesets. For example:"
    ]
   },
   {
@@ -103,8 +103,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# CartoDB Positron\n",
-    "map = folium.Map(location=[13.406, 80.110], tiles=\"CartoDB Positron\", zoom_start=9)\n",
+    "# OpenTopoMap\n",
+    "map = folium.Map(location=[13.406, 80.110], tiles=\"OpenTopoMap\", zoom_start=9)\n",
     "map"
    ]
   },
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +204,7 @@
     "\n",
     "from folium import plugins\n",
     "\n",
-    "map = folium.Map(location=[15, 30], tiles=\"Cartodb dark_matter\", zoom_start=2)\n",
+    "map = folium.Map(location=[15, 30], tiles=\"OpenTopoMap\", zoom_start=2)\n",
     "\n",
     "heat_data = [[point.xy[1][0], point.xy[0][0]] for point in geo_df.geometry]\n",
     "\n",
@@ -213,11 +213,18 @@
     "\n",
     "map"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "default",
    "language": "python",
    "name": "python3"
   },
@@ -231,7 +238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/doc/source/gallery/polygon_plotting_with_folium.ipynb
+++ b/doc/source/gallery/polygon_plotting_with_folium.ipynb
@@ -120,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = folium.Map(location=[40.70, -73.94], zoom_start=10, tiles=\"CartoDB positron\")\n",
+    "m = folium.Map(location=[40.70, -73.94], zoom_start=10)\n",
     "m"
    ]
   },
@@ -210,11 +210,18 @@
     "\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "default",
    "language": "python",
    "name": "python3"
   },
@@ -228,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/geopandas/explore.py
+++ b/geopandas/explore.py
@@ -93,11 +93,8 @@ def _explore(
         Map tileset to use. Can choose from the list supported by folium, query a
         :class:`xyzservices.TileProvider` by a name from ``xyzservices.providers``,
         pass :class:`xyzservices.TileProvider` object or pass custom XYZ URL.
-        The current list of built-in providers (when ``xyzservices`` is not available):
-
-        ``["OpenStreetMap", "CartoDB positron", “CartoDB dark_matter"]``
-
-        You can pass a custom tileset to Folium by passing a Leaflet-style URL
+        When ``xyzservices`` is not available, it defaults to OpenStreetMap Mapnik
+        tiles. You can pass a custom tileset to Folium by passing a Leaflet-style URL
         to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
         Be sure to check their terms and conditions and to provide attribution with
         the ``attr`` keyword.
@@ -941,11 +938,8 @@ def _explore_geoseries(
         Map tileset to use. Can choose from the list supported by folium, query a
         :class:`xyzservices.TileProvider` by a name from ``xyzservices.providers``,
         pass :class:`xyzservices.TileProvider` object or pass custom XYZ URL.
-        The current list of built-in providers (when ``xyzservices`` is not available):
-
-        ``["OpenStreetMap", "CartoDB positron", “CartoDB dark_matter"]``
-
-        You can pass a custom tileset to Folium by passing a Leaflet-style URL
+        When ``xyzservices`` is not available, it defaults to OpenStreetMap Mapnik
+        tiles. You can pass a custom tileset to Folium by passing a Leaflet-style URL
         to the tiles parameter: ``http://{s}.yourtiles.com/{z}/{x}/{y}.png``.
         Be sure to check their terms and conditions and to provide attribution with
         the ``attr`` keyword.

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -803,7 +803,7 @@ class TestExplore:
     def test_xyzservices_query_name(self):
         pytest.importorskip("xyzservices")
 
-        m = self.nybb.explore(tiles="OPenStreetMap DE")
+        m = self.nybb.explore(tiles="OpenStreetMap DE")
         out_str = self._fetch_map_string(m)
 
         assert '"https://tile.openstreetmap.de/{z}/{x}/{y}.png"' in out_str

--- a/geopandas/tests/test_explore.py
+++ b/geopandas/tests/test_explore.py
@@ -789,43 +789,35 @@ class TestExplore:
     def test_xyzservices_providers(self):
         xyzservices = pytest.importorskip("xyzservices")
 
-        m = self.nybb.explore(tiles=xyzservices.providers.CartoDB.PositronNoLabels)
+        m = self.nybb.explore(tiles=xyzservices.providers.OpenStreetMap.DE)
         out_str = self._fetch_map_string(m)
 
-        assert (
-            '"https://a.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"'
-            in out_str
-        )
+        assert '"https://tile.openstreetmap.de/{z}/{x}/{y}.png"' in out_str
         assert (
             'attribution":"\\u0026copy;\\u003cahref=\\"https://www.openstreetmap.org'
             in out_str
         )
-        assert '"maxZoom":20' in out_str
+        assert '"maxZoom":18' in out_str
 
     @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_query_name(self):
         pytest.importorskip("xyzservices")
 
-        m = self.nybb.explore(tiles="CartoDB Positron No Labels")
+        m = self.nybb.explore(tiles="OPenStreetMap DE")
         out_str = self._fetch_map_string(m)
 
-        assert (
-            '"https://a.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"'
-            in out_str
-        )
+        assert '"https://tile.openstreetmap.de/{z}/{x}/{y}.png"' in out_str
         assert (
             'attribution":"\\u0026copy;\\u003cahref=\\"https://www.openstreetmap.org'
             in out_str
         )
-        assert '"maxZoom":20' in out_str
+        assert '"maxZoom":18' in out_str
 
     @pytest.mark.skipif(not HAS_PYPROJ, reason="requires pyproj")
     def test_xyzservices_providers_min_zoom_override(self):
         xyzservices = pytest.importorskip("xyzservices")
 
-        m = self.nybb.explore(
-            tiles=xyzservices.providers.CartoDB.PositronNoLabels, min_zoom=3
-        )
+        m = self.nybb.explore(tiles=xyzservices.providers.OpenStreetMap.DE, min_zoom=3)
         out_str = self._fetch_map_string(m)
 
         assert '"minZoom":3' in out_str
@@ -834,9 +826,7 @@ class TestExplore:
     def test_xyzservices_providers_max_zoom_override(self):
         xyzservices = pytest.importorskip("xyzservices")
 
-        m = self.nybb.explore(
-            tiles=xyzservices.providers.CartoDB.PositronNoLabels, max_zoom=12
-        )
+        m = self.nybb.explore(tiles=xyzservices.providers.OpenStreetMap.DE, max_zoom=12)
         out_str = self._fetch_map_string(m)
 
         assert '"maxZoom":12' in out_str
@@ -846,7 +836,7 @@ class TestExplore:
         xyzservices = pytest.importorskip("xyzservices")
 
         m = self.nybb.explore(
-            tiles=xyzservices.providers.CartoDB.PositronNoLabels,
+            tiles=xyzservices.providers.OpenStreetMap.DE,
             min_zoom=3,
             max_zoom=12,
         )

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -2914,22 +2914,20 @@ class TestTilesPlotting:
         )
 
     def test_tiles_custom_xyzservices(self):
-        ax = self.nybb.plot(tiles="NASAGIBS.BlueMarble")
+        ax = self.nybb.plot(tiles="OpenTopoMap")
         im = next(iter(ax.images))
-        assert im.get_array().shape == (256, 259, 4)
+        assert im.get_array().shape == (1023, 1030, 4)
 
         attr = next(iter(ax.texts)).get_text()
         assert (
-            attr
-            == "Imagery provided by services from the Global Imagery Browse Services "
-            "(GIBS), operated by the NASA/GSFC/Earth Science Data and Information "
-            "System (ESDIS) with funding provided by NASA/HQ."
+            attr == "Map data: (C) OpenStreetMap contributors, SRTM | Map style: (C) "
+            "OpenTopoMap (CC-BY-SA)"
         )
 
     def test_tiles_custom_attribution(self):
-        ax = self.nybb.plot(tiles="NASAGIBS.BlueMarble", attr="Custom attribution")
+        ax = self.nybb.plot(tiles="OpenTopoMap", attr="Custom attribution")
         im = next(iter(ax.images))
-        assert im.get_array().shape == (256, 259, 4)
+        assert im.get_array().shape == (1023, 1030, 4)
 
         attr = next(iter(ax.texts)).get_text()
         assert attr == "Custom attribution"

--- a/geopandas/tests/test_plotting.py
+++ b/geopandas/tests/test_plotting.py
@@ -2914,17 +2914,22 @@ class TestTilesPlotting:
         )
 
     def test_tiles_custom_xyzservices(self):
-        ax = self.nybb.plot(tiles="CartoDBPositron")
+        ax = self.nybb.plot(tiles="NASAGIBS.BlueMarble")
         im = next(iter(ax.images))
-        assert im.get_array().shape == (1023, 1030, 4)
+        assert im.get_array().shape == (256, 259, 4)
 
         attr = next(iter(ax.texts)).get_text()
-        assert attr == "(C) OpenStreetMap contributors (C) CARTO"
+        assert (
+            attr
+            == "Imagery provided by services from the Global Imagery Browse Services "
+            "(GIBS), operated by the NASA/GSFC/Earth Science Data and Information "
+            "System (ESDIS) with funding provided by NASA/HQ."
+        )
 
     def test_tiles_custom_attribution(self):
-        ax = self.nybb.plot(tiles="CartoDBPositron", attr="Custom attribution")
+        ax = self.nybb.plot(tiles="NASAGIBS.BlueMarble", attr="Custom attribution")
         im = next(iter(ax.images))
-        assert im.get_array().shape == (1023, 1030, 4)
+        assert im.get_array().shape == (256, 259, 4)
 
         attr = next(iter(ax.texts)).get_text()
         assert attr == "Custom attribution"


### PR DESCRIPTION
Carto started requiring an API key for their tiles, which renders their use in our docs and tests quite impractical. All removed here in favour of various open tiles.